### PR TITLE
add a default blue user

### DIFF
--- a/CDS/config/wlp/cds/users.xml
+++ b/CDS/config/wlp/cds/users.xml
@@ -3,6 +3,7 @@
    <basicRegistry>
       <user name="admin" password="adm1n"/>
       <user name="presAdmin" password="padm1n"/>
+      <user name="blue" password="blu3"/>
       <user name="balloon" password="balloonPr1nter"/>
       <user name="public" password="publ1c"/>
       <user name="presentation" password="presentat1on"/>


### PR DESCRIPTION
This user is required to use resolver in client mode.

fixes #41