### PR TITLE
Do not use sun.net.www.protocol.https.HttpsURLConnectionImpl directly, since it is not available in Java 13

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -50,8 +50,7 @@ import org.icpc.tools.contest.model.internal.FileReference;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.Organization;
 import org.icpc.tools.contest.model.internal.Team;
-
-import sun.net.www.protocol.https.HttpsURLConnectionImpl;
+import javax.net.ssl.HttpsURLConnection;
 
 public class RESTContestSource extends DiskContestSource {
 	protected static final NumberFormat nf = NumberFormat.getNumberInstance(Locale.US);
@@ -744,8 +743,8 @@ public class RESTContestSource extends DiskContestSource {
 		try {
 			Object target = c;
 			try {
-				if (c instanceof HttpsURLConnectionImpl) {
-					final Field delegate = HttpsURLConnectionImpl.class.getDeclaredField("delegate");
+				if (c instanceof HttpsURLConnection) {
+					final Field delegate = c.getClass().getDeclaredField("delegate");
 					delegate.setAccessible(true);
 					target = delegate.get(c);
 				}


### PR DESCRIPTION
Java 13 does not allow access to `sun.net.www.protocol.https.HttpsURLConnectionImpl` directly, so I modified the code to check for the base class and then use the actual class name to get the `delegate` field from. Tested locally and I could still pause/unpause with a HTTPS DOMjudge.

If a non-Oracle JDK would be used, I expect the `catch` that ignores the error to be triggered, making it so that we do set the request method on the 'normal' class.