### PR TITLE
Do not reset first after encoding one value.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
@@ -216,7 +216,6 @@ public class JSONEncoder {
 		else
 			first = false;
 		pw.write(value + "");
-		first = true;
 	}
 
 	public void close() {


### PR DESCRIPTION
I checked where this method gets called and it is only in `org.icpc.tools.client.core.BasicClient::writeClients`. I'm not sure why this was here, but the code didn't write a `,` before each element when this was there, making all the client ID's become concatenated.