### PR TITLE
CDS version fix

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -153,8 +153,6 @@ public class CDSConfig {
 			if (instance != null)
 				return instance;
 
-			Trace.trace(Trace.USER, "CDS version: " + Trace.getVersion());
-
 			InputStream in = null;
 			Exception ce = null;
 			try {

--- a/CDS/src/org/icpc/tools/cds/service/ExecutorListener.java
+++ b/CDS/src/org/icpc/tools/cds/service/ExecutorListener.java
@@ -24,7 +24,7 @@ public class ExecutorListener implements ServletContextListener {
 
 	@Override
 	public void contextInitialized(ServletContextEvent servletContextEvent) {
-		Trace.initSysout("CDS");
+		Trace.initSysout("CDS", servletContextEvent.getServletContext().getResourceAsStream("META-INF/MANIFEST.MF"));
 		executor = new ScheduledThreadPoolExecutor(400, new ThreadFactory() {
 			@Override
 			public Thread newThread(Runnable r) {


### PR DESCRIPTION
JEE war files are not jars, so the default location where Ant puts the manifest file cannot be picked up by classpath. I tried modifying the build or moving the file but that wasn't working, so I changed the ServletContextListener to load the manifest by resource location instead, and cached the value for future use. CDS logs should now show the correct version, and I removed a duplicate trace statement from CDSConfig.