### PR TITLE
Add temporary "--problems ABC,DEF" to resolver

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1618,6 +1618,43 @@ public class Contest implements IContest {
 			removeFromHistory(obj);
 	}
 
+	public void removeProblems(List<String> problemIds) {
+		List<IContestObject> remove = new ArrayList<>();
+
+		for (IProblem p : problems) {
+			if (problemIds.contains(p.getId())) {
+				remove.add(p);
+			}
+		}
+
+		for (ISubmission s : getSubmissions()) {
+			String problemId = s.getProblemId();
+			if (problemIds.contains(problemId))
+				removeSubmission(remove, s);
+		}
+
+		for (IClarification clar : getClarifications()) {
+			String problemId = clar.getProblemId();
+			if (problemId != null && problemIds.contains(problemId))
+				remove.add(clar);
+		}
+
+		for (IAward award : getAwards()) {
+			if (award.getAwardType() == IAward.FIRST_TO_SOLVE) {
+				for (String pId : problemIds) {
+					if (award.getId().endsWith("-" + pId)) {
+						remove.add(award);
+						break;
+					}
+				}
+			}
+		}
+
+		Trace.trace(Trace.INFO, "Removing " + problemIds.size() + " problems and " + remove.size() + " total objects");
+		for (IContestObject obj : remove)
+			removeFromHistory(obj);
+	}
+
 	public int removeSubmissionsOutsideOfContestTime() {
 		List<IContestObject> remove = new ArrayList<>();
 

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -14,6 +14,7 @@ import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IContestObject.ContestType;
 import org.icpc.tools.contest.model.IGroup;
+import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.Scoreboard;
 import org.icpc.tools.contest.model.TimeFilter;
@@ -68,6 +69,7 @@ public class Resolver {
 	private boolean test;
 	private Style style;
 	private String[] groups;
+	private String[] problems;
 
 	// client/server variables
 	private PresentationClient client;
@@ -448,6 +450,8 @@ public class Resolver {
 				style = TeamUtil.getStyleByString(argList.remove(0));
 			} else if ("--groups".equalsIgnoreCase(option)) {
 				groups = argList.remove(0).split(",");
+			} else if ("--problems".equalsIgnoreCase(option)) {
+				problems = argList.remove(0).split(",");
 			} else if ("--rowDisplayOffset".equalsIgnoreCase(option)) {
 				// causes rows to be moved up the screen so they are not blocked by people on
 				// stage
@@ -594,18 +598,29 @@ public class Resolver {
 		List<ResolutionStep> steps = null;
 		if (groups != null) {
 			steps = new ArrayList<ResolutionUtil.ResolutionStep>();
-			for (String groupId : groups) {
-				Trace.trace(Trace.INFO, "Resolving for group " + groupId);
+			for (int i = 0; i < groups.length; i++) {
+				// for (String groupId : groups) {
+				Trace.trace(Trace.INFO, "Resolving for group " + groups[i]);
 				Contest cc = finalContest.clone(true);
 				// set the current group to be visible and all others hidden
 				for (IGroup g : cc.getGroups()) {
-					if (groupId.trim().equals(g.getId())) {
+					if (groups[i].trim().equals(g.getId())) {
 						cc.setGroupIsHidden(g, false);
 					} else if (!g.isHidden())
 						cc.setGroupIsHidden(g, true);
 				}
 
 				cc.removeHiddenTeams();
+
+				if (problems != null) {
+					String pIds = problems[i].trim();
+					List<String> problemIds = new ArrayList<String>();
+					for (IProblem p : cc.getProblems()) {
+						if (!pIds.contains(p.getLabel()))
+							problemIds.add(p.getId());
+					}
+					cc.removeProblems(problemIds);
+				}
 
 				IAward[] contestAwards = cc.getAwards();
 				if (contestAwards == null || contestAwards.length == 0) {


### PR DESCRIPTION
Add option to filter by problems for the PacNW contest. This argument can only be used when you use the --groups option, and it filters to problems in the given list, i.e. group 1 would only show problems A,B, and C, and group 2 would only show problems D, E, and F.