### PR TITLE
Make sure directory page is valid HTML5 and remove doctype line when parsing

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/layout/baseMenu.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/baseMenu.jsp
@@ -2,7 +2,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
     <a class="navbar-brand" href="/<%= webroot %>">
         <img src="${pageContext.request.contextPath}/cdsIcon.png" alt="CDS" height="30"
-             class="d-inline-block align-top">
+             class="d-inline-block align-top" />
         Contest Data Server
     </a>
 </nav>

--- a/CDS/WebContent/WEB-INF/jsps/layout/contestMenu.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/contestMenu.jsp
@@ -10,7 +10,7 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
     <a class="navbar-brand" href="<%= webroot %>">
         <img src="${pageContext.request.contextPath}/cdsIcon.png" alt="CDS" height="30"
-             class="d-inline-block align-top">
+             class="d-inline-block align-top" />
         <%= contest.getFormalName() %>
     </a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#nav" aria-controls="nav"

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -1,9 +1,9 @@
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
 
-    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/bootstrap.min.css">
-    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/cds.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/cds.css"/>
     <link rel="icon" type="image/png" href="${pageContext.request.contextPath}/favicon.png"/>
     <title>
         <%= request.getAttribute("title") %>

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/LinkParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/LinkParser.java
@@ -27,14 +27,24 @@ public class LinkParser {
 
 		try {
 			sp.parse(in, new DefaultHandler() {
+				boolean inTd = false;
 				@Override
 				public void startElement(String uri, String localName, String qName, Attributes attributes)
 						throws SAXException {
-					if ("a".endsWith(qName)) {
+					if (inTd && "a".endsWith(qName)) {
 						String href = attributes.getValue("href");
 						if (href != null && href.length() > 0) {
 							listener.linkFound(href);
 						}
+					} else if ("td".endsWith(qName)) {
+						inTd = true;
+					}
+				}
+
+				@Override
+				public void endElement(String uri, String localName, String qName) throws SAXException {
+					if ("td".endsWith(qName)) {
+						inTd = false;
 					}
 				}
 			});

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -4,6 +4,7 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -21,6 +22,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -472,12 +474,27 @@ public class RESTContestSource extends DiskContestSource {
 
 			final List<String> list = new ArrayList<>();
 
+			// We need to remove the doctype from the file, if it has any
+			InputStream fs = new FileInputStream(file);
+			BufferedReader reader = new BufferedReader(new InputStreamReader(fs));
+			StringBuilder sb = new StringBuilder();
+			String line;
+
+			do {
+				line = reader.readLine();
+				if (line != null && !line.startsWith("<!doctype")) {
+					sb.append(line).append("\n");
+				}
+			} while(line != null);
+
+			String contents = sb.toString();
+
 			LinkParser.parse(new ILinkListener() {
 				@Override
 				public void linkFound(String s) {
 					list.add(s);
 				}
-			}, new FileInputStream(file));
+			}, new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)));
 
 			return list.toArray(new String[list.size()]);
 		} catch (Exception e) {


### PR DESCRIPTION
So I changed three things:

* I keep track of whether we are in a `<td>` to not have other links (header and footer) in the link parser
* I made the head and menu XML-compatible
* I remove the `<!doctype html>` line from the input, since that is not valid XML. I hope my way of doing it is clean enough 🙈 