### PR TITLE
Don't finalize before assigning awards

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -627,7 +627,6 @@ public class Resolver {
 
 				if (!hasAwards) {
 					Trace.trace(Trace.USER, "Generating awards");
-					cc.finalizeResults();
 					AwardUtil.createDefaultAwards(cc);
 				}
 
@@ -645,7 +644,6 @@ public class Resolver {
 			IAward[] contestAwards = finalContest.getAwards();
 			if (contestAwards == null || contestAwards.length == 0) {
 				Trace.trace(Trace.USER, "Generating awards");
-				finalContest.finalizeResults();
 				AwardUtil.createDefaultAwards(finalContest);
 			}
 


### PR DESCRIPTION
If you 'finalize' (assign ranks and hide solution times for non-medal teams) then any group awards for these teams end up being assigned to multiple teams because they look tied. The next step after this is applying the official results (Hs, alphabetic ordering within rank) so this step is unnecessary anyway.