### PR TITLE
Remove teams (and members in teams) without a number

### DIFF
--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -140,6 +140,9 @@ public class JsonToTSVConverter {
 			readContest(folder, index);
 			readStaff(folder);
 
+			teamList.removeIf(t -> t.number == null);
+			memberList.removeIf(m -> m.team.number == null);
+
 			groupList.sort((g1, g2) -> compare(g1.id, g2.id));
 			teamList.sort((t1, t2) -> compare(t1.number, t2.number));
 			institutionList.sort((i1, i2) -> compare(i1.id, i2.id));


### PR DESCRIPTION
So when using this epic tool, I noticed it crashes if a team does not have a humber. This happens if a team is pending or rejected in the CMS but the registration is not closed yet.

So we just filter these out.