### PR TITLE
Add little margin around balloon map to fit names

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
@@ -265,8 +265,8 @@ public class BalloonMapPresentation extends AbstractICPCPresentation {
 
 				double lon = org.getLongitude();
 				if (lon != Double.MIN_VALUE) {
-					minLon = Math.min(minLon, lon);
-					maxLon = Math.max(maxLon, lon);
+					minLon = Math.min(minLon, lon - 3);
+					maxLon = Math.max(maxLon, lon + 3);
 				}
 			}
 		}


### PR DESCRIPTION
So my balloon map didn't fit the team name of the leftmost team.
I thought that just adding a bit of margin left and right would be an easy fix but if you think differently, let me know.