### PR TITLE
Show splash screen between each contest resolve

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/ResolutionUtil.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolutionUtil.java
@@ -28,7 +28,7 @@ public class ResolutionUtil {
 
 	public static class PresentationStep implements ResolutionStep {
 		enum Presentations {
-			SCOREBOARD, JUDGE, TEAM_AWARD, TEAM_LIST
+			SPLASH, SCOREBOARD, JUDGE, TEAM_AWARD, TEAM_LIST
 		}
 
 		public Presentations p;

--- a/Resolver/src/org/icpc/tools/resolver/ResolverLogic.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverLogic.java
@@ -269,8 +269,9 @@ public class ResolverLogic {
 		cleanOutlierSubmissions();
 
 		// set the initial state
-		steps.add(new PauseStep());
 		steps.add(new ContestStateStep(contest));
+		steps.add(new PresentationStep(PresentationStep.Presentations.SPLASH));
+		steps.add(new PauseStep());
 		steps.add(new TeamSelectionStep());
 		steps.add(new SubmissionSelectionStep(null));
 		steps.add(new ToJudgeStep(null));

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -20,6 +20,7 @@ import javax.imageio.ImageIO;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.internal.Contest;
+import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
 import org.icpc.tools.presentation.contest.internal.presentations.StaticLogoPresentation;
@@ -90,6 +91,7 @@ public class ResolverUI {
 	private List<ResolutionStep> steps = new ArrayList<>();
 
 	private PresentationWindow window;
+	private AbstractICPCPresentation splashPresentation;
 	private ScoreboardPresentation scoreboardPresentation;
 	private TeamAwardPresentation awardPresentation;
 	private TeamLogoPresentation teamLogoPresentation;
@@ -220,7 +222,6 @@ public class ResolverUI {
 			}
 		};
 
-		Presentation splashPresentation = null;
 		if (screen == Screen.TEAM || screen == Screen.SIDE) {
 			logoPresentation = new StaticLogoPresentation();
 			logoPresentation.addMouseListener(nullMouse);
@@ -234,11 +235,10 @@ public class ResolverUI {
 				teamListSidePresentation.addMouseListener(nullMouse);
 			}
 		} else {
-			splashPresentation = new SplashPresentation(contest);
+			splashPresentation = new SplashPresentation();
+			splashPresentation.setContest(contest);
 			splashPresentation.addMouseListener(nullMouse);
 		}
-
-		window.setPresentation(splashPresentation);
 
 		scoreboardPresentation = new ScoreboardPresentation() {
 			@Override
@@ -302,6 +302,8 @@ public class ResolverUI {
 		final float dpi = 96;
 		float size = (window.getHeight() / 14f) * 36f / dpi;
 		messageFont = ICPCFont.getMasterFont().deriveFont(Font.PLAIN, size);
+
+		processAction(Action.FORWARD);
 	}
 
 	private String getStatusInfo() {
@@ -491,6 +493,7 @@ public class ResolverUI {
 	private int processStep(long[] startTime, ResolutionStep step) {
 		if (step instanceof ContestStateStep) {
 			ContestStateStep state = (ContestStateStep) step;
+			splashPresentation.setContest(state.contest);
 			scoreboardPresentation.setContest(state.contest);
 			judgePresentation.setContest(state.contest);
 			awardPresentation.setContest(state.contest);
@@ -535,7 +538,9 @@ public class ResolverUI {
 			scoreboardPresentation.setScrollToRow(scroll.row);
 		} else if (step instanceof PresentationStep) {
 			PresentationStep pstep = (PresentationStep) step;
-			if (pstep.p == PresentationStep.Presentations.SCOREBOARD)
+			if (pstep.p == PresentationStep.Presentations.SPLASH)
+				setPresentation(splashPresentation);
+			else if (pstep.p == PresentationStep.Presentations.SCOREBOARD)
 				setPresentation(scoreboardPresentation);
 			else if (pstep.p == PresentationStep.Presentations.JUDGE)
 				setPresentation(judgePresentation);

--- a/Resolver/src/org/icpc/tools/resolver/SplashPresentation.java
+++ b/Resolver/src/org/icpc/tools/resolver/SplashPresentation.java
@@ -34,10 +34,6 @@ public class SplashPresentation extends AbstractICPCPresentation {
 
 	private BufferedImage image;
 
-	public SplashPresentation(IContest c) {
-		setContest(c);
-	}
-
 	@Override
 	public void init() {
 		float dpi = 96;


### PR DESCRIPTION
Makes the splash presentation more consistent with the other presentations so that you can put the splash 'between' resolving two or more contests. (really just at ther beginning of each contest instead of at the beginning of the resolver)