### PR TITLE
Add error when institution does not have a shortname

### DIFF
--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -333,7 +333,10 @@ public class JsonToTSVConverter {
 			fw.write("\t");
 			fw.write(inst.name);
 			fw.write("\t");
-			fw.write(inst.shortName);
+			if (!inst.shortName.isEmpty())
+				fw.write(inst.shortName);
+			else
+				System.err.println("Institution without shortname: " + inst.name);
 			fw.write("\t");
 			if (inst.group != null)
 				fw.write(inst.group.id);


### PR DESCRIPTION
NWERC has some institutions without short name and this allows us to see that (well looking in the CSV would also work but this is easier)