### PR TITLE
Fix click order in resolver

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -665,6 +665,12 @@ public class Resolver {
 			outputStats(steps, time);
 		}
 
+		ResolutionUtil.numberThePauses(steps);
+
+		Trace.trace(Trace.INFO, "Resolution steps:");
+		for (ResolutionStep step : steps)
+			Trace.trace(Trace.INFO, "  " + step);
+
 		ui = new ResolverUI(steps, show_info, displayStr, isPresenter || client == null, screen, new ClickListener() {
 			@Override
 			public void clicked(int num) {

--- a/Resolver/src/org/icpc/tools/resolver/ResolverLogic.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverLogic.java
@@ -293,13 +293,8 @@ public class ResolverLogic {
 
 		// fourth click and beyond: start resolving!
 		resolveEverything(bill);
-		ResolutionUtil.numberThePauses(steps);
 
 		Trace.trace(Trace.USER, "Done resolving");
-
-		Trace.trace(Trace.INFO, "Resolution steps:");
-		for (ResolutionStep step : steps)
-			Trace.trace(Trace.INFO, "  " + step);
 
 		return steps;
 	}


### PR DESCRIPTION
When resolving 2 contests the resolver restarts the click order instead of continuing on in order from one to the other.