### PR TITLE
Merge FTS based on the current contest

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -281,7 +281,7 @@ public class ResolverUI {
 			}
 		};
 		awardPresentation.setSize(window.getSize());
-		awardPresentation.cacheAwards(contest, steps);
+		awardPresentation.cacheAwards(steps);
 		awardPresentation.addMouseListener(nullMouse);
 		awardPresentation.setShowInfo(showInfo);
 


### PR DESCRIPTION
Normally if a team solves A, B, and D first the citation in the resolver gets merged into a single 'First to solve A, B, D' line to save space and be more readable. During the PacNW we noticed that this wasn't happening in some cases. This is because the team award presentation was reliant on a single global contest instead of using the current one when it hits each award.