### PR TITLE
Add a minimal set of Bazel BUILD files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 **/.DS_Store
 **/*.pdf
 .vscode
+bazel-*

--- a/BalloonUtility/src/BUILD
+++ b/BalloonUtility/src/BUILD
@@ -1,0 +1,15 @@
+java_binary(
+    name = "balloonutil",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//ContestModel/src:contestModel",
+        "//PresCore/src:presentCore",
+        "//SWTLauncher/lib:swt",
+        "//SWTLauncher/src:swtLauncher",
+    ],
+    main_class = "org.icpc.tools.balloon.BalloonUtility",
+    resources = glob([
+        "images/**/*",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/CDS/BUILD
+++ b/CDS/BUILD
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_java_war//java_war:defs.bzl", "java_war")
+
+java_war(
+    name = "cds",
+    java_srcs = glob(["src/**/*.java"]),
+    web_app_dir = "WebContent",
+    deps = [
+        ":javaee",
+        "//ContestModel/src:contestModel",
+        "//PresContest/src:presentations",
+        "//PresCore/lib:tyrus-standalone",
+    ],
+)
+
+java_import(
+    name = "javaee",
+    jars = [
+        "com.ibm.ws.javaee.jsp.2.2_1.0.0.jar",
+        "com.ibm.ws.javaee.servlet.3.0_1.0.1.jar",
+        "com.ibm.ws.javaee.websocket.1.1_1.0.12.jar",
+    ],
+)

--- a/CoachView/lib/BUILD
+++ b/CoachView/lib/BUILD
@@ -1,0 +1,25 @@
+java_import(
+    name = "jna",
+    jars = [
+        "jna-5.2.0.jar",
+        "jna-platform-5.2.0.jar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "slf4",
+    jars = [
+        "slf4j-api-1.7.25.jar",
+        "slf4j-nop-1.7.25.jar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "vlc",
+    jars = [
+        "vlcj-3.12.1.jar",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/CoachView/src/BUILD
+++ b/CoachView/src/BUILD
@@ -1,0 +1,17 @@
+java_binary(
+    name = "coachview",
+    srcs = glob(["**/*.java"]),
+    deps = [
+	"//CoachView/lib:jna",
+	"//CoachView/lib:slf4",
+	"//CoachView/lib:vlc",
+        "//ContestModel/src:contestModel",
+        "//PresCore/src:presentCore",
+    ],
+    main_class = "org.icpc.tools.coachview.CoachView",
+    resources = glob([
+        "font/**/*",
+        "images/**/*",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/ContestModel/lib/BUILD
+++ b/ContestModel/lib/BUILD
@@ -1,0 +1,5 @@
+java_import(
+    name = "snakeyaml",
+    jars = ["snakeyaml-1.18.jar"],
+    visibility = ["//visibility:public"],
+)

--- a/ContestModel/src/BUILD
+++ b/ContestModel/src/BUILD
@@ -1,0 +1,7 @@
+java_library(
+    name = "contestModel",
+    srcs = glob(["**/*.java"]),
+    deps = ["//ContestModel/lib:snakeyaml"],
+    visibility = ["//visibility:public"],
+    resources = ["org/icpc/tools/contest/model/util/messages.properties"],
+)

--- a/PresAdmin/src/BUILD
+++ b/PresAdmin/src/BUILD
@@ -1,0 +1,14 @@
+java_library(
+    name = "presentationAdmin",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//ContestModel/src:contestModel",
+        "//PresCore/src:presentCore",
+        "//SWTLauncher/lib:swt",
+        "//SWTLauncher/src:swtLauncher",
+    ],
+    resources = glob([
+        "images/**/*",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/PresContest/lib/BUILD
+++ b/PresContest/lib/BUILD
@@ -1,0 +1,25 @@
+java_import(
+    name = "jna",
+    jars = [
+        "jna-5.2.0.jar",
+        "jna-platform-5.2.0.jar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "slf4",
+    jars = [
+        "slf4j-api-1.7.25.jar",
+        "slf4j-nop-1.7.25.jar",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_import(
+    name = "vlc",
+    jars = [
+        "vlcj-3.12.1.jar",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/PresContest/src/BUILD
+++ b/PresContest/src/BUILD
@@ -1,0 +1,16 @@
+java_library(
+    name = "presentations",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//ContestModel/src:contestModel",
+        "//PresCore/src:presentCore",
+        "//PresContest/lib:jna",
+        "//PresContest/lib:vlc",
+    ],
+    resources = glob([
+        "data/**/*",
+        "font/**/*",
+        "images/**/*",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/PresCore/lib/BUILD
+++ b/PresCore/lib/BUILD
@@ -1,0 +1,5 @@
+java_import(
+    name = "tyrus-standalone",
+    jars = ["tyrus-standalone-client-1.15.jar"],
+    visibility = ["//visibility:public"],
+)

--- a/PresCore/src/BUILD
+++ b/PresCore/src/BUILD
@@ -1,0 +1,10 @@
+java_library(
+    name = "presentCore",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//ContestModel/src:contestModel",
+        "//PresCore/lib:tyrus-standalone",
+    ],
+    resources = glob(["*.png"]),
+    visibility = ["//visibility:public"],
+)

--- a/ProblemSet/lib/BUILD
+++ b/ProblemSet/lib/BUILD
@@ -1,0 +1,5 @@
+java_import(
+    name = "snakeyaml",
+    jars = ["snakeyaml-1.18.jar"],
+    visibility = ["//visibility:public"],
+)

--- a/ProblemSet/src/BUILD
+++ b/ProblemSet/src/BUILD
@@ -1,0 +1,10 @@
+java_library(
+    name = "problemset",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//ProblemSet/lib:snakeyaml",
+        "//SWTLauncher/lib:swt",
+        "//SWTLauncher/src:swtLauncher",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/Resolver/src/BUILD
+++ b/Resolver/src/BUILD
@@ -1,0 +1,14 @@
+java_binary(
+    name = "resolver",
+    main_class = "org.icpc.tools.resolver.Resolver",
+    srcs = glob(["**/*.java"]),
+    deps = [
+        "//ContestModel/src:contestModel",
+        "//PresContest/src:presentations",
+        "//PresCore/src:presentCore",
+        "//SWTLauncher/lib:swt",
+        "//SWTLauncher/src:swtLauncher",
+    ],
+    resources = ["org/icpc/tools/resolver/messages.properties"] +
+                glob(["images/*.png"]),
+)

--- a/SWTLauncher/lib/BUILD
+++ b/SWTLauncher/lib/BUILD
@@ -1,0 +1,10 @@
+java_import(
+    name = "swt",
+    jars =
+        select({
+            "@bazel_tools//src/conditions:darwin": [":swt-cocoa-macosx-x86_64.jar"],
+            "@bazel_tools//src/conditions:windows": [":swt-win32-win32-x86_64.jar"],
+            "//conditions:default": [":swt-gtk-linux-x86_64.jar"],
+        }),
+    visibility = ["//visibility:public"],
+)

--- a/SWTLauncher/src/BUILD
+++ b/SWTLauncher/src/BUILD
@@ -1,0 +1,6 @@
+java_library(
+    name = "swtLauncher",
+    srcs = glob(["**/*.java"]),
+    deps = ["//SWTLauncher/lib:swt"],
+    visibility = ["//visibility:public"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,10 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+RULES_JAVA_WAR_TAG = "0.1.0"
+
+http_archive(
+    name = "io_bazel_rules_java_war",
+    strip_prefix = "rules_java_war-%s" % RULES_JAVA_WAR_TAG,
+    url = "https://github.com/bmuschko/rules_java_war/archive/%s.tar.gz" % RULES_JAVA_WAR_TAG,
+    sha256 = "38011f979713c4aefd43ab56675ce4c6c14bc949b128c3a303f1f57ebe4bfeac",
+)


### PR DESCRIPTION
Targets are relatively coarse-grained for easy maintenance.
To fully benefit from increased build performance we will need to split
the libs up further.