### PR TITLE
Delete client cache before reopening, avoid reconnection NPE

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
@@ -107,6 +107,8 @@ public class JSONParser {
 	}
 
 	public JSONParser(String s) {
+		if (s == null)
+			throw new IllegalArgumentException("Invalid JSON: null");
 		this.s = s;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedLogParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedLogParser.java
@@ -34,6 +34,9 @@ public class NDJSONFeedLogParser {
 				s = br.readLine();
 			}
 			try {
+				if (lastJson == null)
+					return;
+
 				JSONParser rdr = new JSONParser(lastJson);
 				JsonObject obj = rdr.readObject();
 				lastId = obj.getString("id");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -691,10 +691,12 @@ public class RESTContestSource extends DiskContestSource {
 					// ignore
 				}
 
-				feedCacheOut = new FileOutputStream(feedCacheFile, true);
+				if (feedCacheFile.exists()) {
+					if (!feedCacheFile.delete())
+						Trace.trace(Trace.WARNING, "Could not delete cache file");
+				}
 
-				if (feedCacheFile.exists())
-					feedCacheFile.delete();
+				feedCacheOut = new FileOutputStream(feedCacheFile, true);
 
 				if (contestSizeBeforeFeed != contest.getNumObjects()) {
 					try {


### PR DESCRIPTION
Issue 87. At PacNW, some clients would detect that the feed had changed, disconnect, and then reconnect using the same cache and enter a loop. I cannot reproduce, but one possibility is that on Windows the FileOutputStream behaviour is different and the cache is not thrown out because the file has already been reopened. Closing this loophole and adding another log message in case this wasn't the problem.