### PR TITLE
Automatic reloading of cdsConfig.xml

### DIFF
--- a/CDS/docs/ContestDataServer.txt
+++ b/CDS/docs/ContestDataServer.txt
@@ -145,8 +145,9 @@ This configuration is done via an XML file named _cdsConfig.xml_,
 located in the _usr/servers/cds_ folder. 
 The _cdsConfig.xml_ file contains a root element *<cds>* which in turn contains a separate "service-defining" XML element for each 
 service which the CDS knows how to provide.  All nested elements and attributes are optional except
-for the _contest location_ attribute, and unknown elements or attributes are ignored. 
-This allows you to easily rename or comment-out an element to add or remove a service.
+for the _contest location_ attribute, and unknown elements or attributes are ignored - 
+this allows you to easily rename or comment-out an element to add or remove a service.
+If you save changes to _cdsConfig.xml_ while the CDS is running the changes will be automatically applied after a few seconds.
 
 A simple example of a _cdsConfig.xml_ file is shown below.  
 

--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -6,18 +6,21 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 
+import org.icpc.tools.cds.service.ExecutorListener;
 import org.icpc.tools.cds.video.VideoAggregator;
 import org.icpc.tools.cds.video.VideoAggregator.ConnectionMode;
 import org.icpc.tools.contest.Trace;
 import org.w3c.dom.Attr;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -25,7 +28,6 @@ import org.xml.sax.InputSource;
 public class CDSConfig {
 	private static final Object INIT_LOCK = new Object();
 	private static CDSConfig instance;
-	private static File folder;
 
 	public static class UserVideo {
 		private Element video;
@@ -75,42 +77,149 @@ public class CDSConfig {
 	}
 
 	private ConfiguredContest[] contests;
-	private UserVideo[] video;
+	private long[] contestHashes;
 	private Domain[] domains;
+	private File file;
+	private long lastModified;
 
-	private CDSConfig(Element e) {
-		Element[] contests3 = getChildren(e, "contest");
-		if (contests3 != null) {
-			contests = new ConfiguredContest[contests3.length];
-			for (int i = 0; i < contests3.length; i++)
-				contests[i] = new ConfiguredContest(contests3[i]);
-		} else
+	private CDSConfig(File file) {
+		this.file = file;
+
+		lastModified = file.lastModified();
+		Element e = readElement(file);
+		loadContests(e);
+		loadOtherConfig(e);
+
+		ExecutorListener.getExecutor().scheduleAtFixedRate(new Runnable() {
+			@Override
+			public void run() {
+				if (lastModified == file.lastModified())
+					return;
+
+				Trace.trace(Trace.USER, "----- CDS config change detected -----");
+				lastModified = file.lastModified();
+
+				Element el = readElement(file);
+				loadContests(el);
+				loadOtherConfig(el);
+			}
+		}, 15, 5, TimeUnit.SECONDS);
+	}
+
+	private static void appendString(StringBuffer sb, Element el) {
+		NamedNodeMap nnm = el.getAttributes();
+		boolean first = true;
+		for (int i = 0; i < nnm.getLength(); i++) {
+			if (!first)
+				sb.append(",");
+			else
+				first = false;
+			Node n = nnm.item(i);
+			sb.append(n.getNodeName() + "=" + n.getNodeValue());
+		}
+
+		Element[] children = getChildren(el, null);
+		if (children != null) {
+			for (int i = 0; i < children.length; i++) {
+				if (!first)
+					sb.append(",");
+				else
+					first = false;
+				sb.append(children[i].getNodeName());
+				sb.append("[");
+				appendString(sb, children[i]);
+				sb.append("]");
+			}
+		}
+	}
+
+	private static long getHash(Element e) {
+		StringBuffer sb = new StringBuffer();
+		appendString(sb, e);
+
+		long hash = 0;
+		for (int i = 0; i < sb.length(); i++)
+			hash = hash * 31 + sb.charAt(i);
+
+		return hash;
+	}
+
+	private ConfiguredContest getContestByHash(long hash) {
+		if (contestHashes == null)
+			return null;
+
+		for (int i = 0; i < contestHashes.length; i++)
+			if (contestHashes[i] == hash)
+				return contests[i];
+
+		return null;
+	}
+
+	private void loadContests(Element e) {
+		Element[] children = getChildren(e, "contest");
+
+		ConfiguredContest[] oldContests = contests;
+		long[] oldHashes = contestHashes;
+		if (children != null) {
+			ConfiguredContest[] temp = new ConfiguredContest[children.length];
+			long[] tempHash = new long[children.length];
+			for (int i = 0; i < children.length; i++) {
+				tempHash[i] = getHash(children[i]);
+
+				ConfiguredContest cc = getContestByHash(tempHash[i]);
+				if (cc == null)
+					cc = new ConfiguredContest(children[i]);
+				temp[i] = cc;
+			}
+
+			contests = temp;
+			contestHashes = tempHash;
+		} else {
 			contests = new ConfiguredContest[0];
+			contestHashes = new long[0];
+		}
 
-		listConfiguration();
+		// clean up any removed or changed projects
+		if (oldContests != null) {
+			for (int i = 0; i < oldContests.length; i++) {
+				boolean stillInUse = false;
+				for (int j = 0; j < contestHashes.length; j++) {
+					if (oldHashes[i] == contestHashes[j]) {
+						stillInUse = true;
+						break;
+					}
+				}
+				if (!stillInUse)
+					oldContests[i].close();
+			}
+		}
+
+		Trace.trace(Trace.USER, "Configured contests:");
+		for (ConfiguredContest cc : contests)
+			Trace.trace(Trace.USER, "   " + cc);
 
 		// initialize
 		for (int i = 0; i < contests.length; i++)
 			contests[i].init();
+	}
 
+	private void loadOtherConfig(Element e) {
 		Element[] children = getChildren(e, "video");
 		if (children != null) {
-			video = new UserVideo[children.length];
 			for (int i = 0; i < children.length; i++) {
-				video[i] = new UserVideo(children[i]);
-				String name = video[i].getName();
-				String url = video[i].getURL();
-				ConnectionMode mode = VideoAggregator.getConnectionMode(video[i].getMode());
-				VideoAggregator.getInstance().addReservation(name, url, mode, i);
+				UserVideo video = new UserVideo(children[i]);
+				ConnectionMode mode = VideoAggregator.getConnectionMode(video.getMode());
+				VideoAggregator.getInstance().addReservation(video.getName(), video.getURL(), mode, i);
 			}
 		}
 
 		children = getChildren(e, "domain");
 		if (children != null) {
-			domains = new Domain[children.length];
+			Domain[] temp = new Domain[children.length];
 			for (int i = 0; i < children.length; i++) {
-				domains[i] = new Domain(children[i]);
+				temp[i] = new Domain(children[i]);
 			}
+			domains = temp;
 		}
 	}
 
@@ -118,31 +227,43 @@ public class CDSConfig {
 		return domains;
 	}
 
-	protected void listConfiguration() {
-		Trace.trace(Trace.USER, "Configured contests:");
-		for (ConfiguredContest cc : contests)
-			Trace.trace(Trace.USER, "   " + cc);
-	}
-
-	private static CDSConfig createReadRoot(InputStream in) {
+	private static Element readElement(File file) {
 		Document document = null;
-		try {
+		try (InputStream in = new BufferedInputStream(new FileInputStream(file))) {
 			DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 			DocumentBuilder parser = factory.newDocumentBuilder();
 			document = parser.parse(new InputSource(in));
 			Node node = document.getFirstChild();
 			if (node instanceof Element)
-				return new CDSConfig((Element) node);
+				return (Element) node;
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Error reading CDS config", e);
-		} finally {
-			try {
-				in.close();
-			} catch (Exception e) {
-				// ignore
-			}
 		}
-		return new CDSConfig(null);
+		return null;
+	}
+
+	private static CDSConfig createInstance() {
+		Exception ce = null;
+		try {
+			Context context = new InitialContext();
+			String folderStr = (String) context.lookup("java:/comp/env/icpc.cds.config");
+			File file = new File(folderStr, "cdsConfig.xml");
+			Trace.trace(Trace.USER, "Loading CDS configuration from: " + file.getAbsolutePath());
+			return new CDSConfig(file);
+		} catch (Exception e) {
+			ce = e;
+		}
+
+		try {
+			Context context = new InitialContext();
+			String folderStr = (String) context.lookup("icpc.cds.config");
+			File file = new File(folderStr, "cdsConfig.xml");
+			Trace.trace(Trace.USER, "Loading CDS configuration from: " + file.getAbsolutePath());
+			return new CDSConfig(file);
+		} catch (Exception e) {
+			System.err.println("Could not load CDS configuration: " + ce.getMessage() + " / " + e.getMessage());
+		}
+		return null;
 	}
 
 	public static CDSConfig getInstance() {
@@ -153,52 +274,14 @@ public class CDSConfig {
 			if (instance != null)
 				return instance;
 
-			InputStream in = null;
-			Exception ce = null;
-			try {
-				Context context = new InitialContext();
-				String folderStr = (String) context.lookup("java:/comp/env/icpc.cds.config");
-				folder = new File(folderStr);
-				Trace.trace(Trace.USER, "Loading CDS configuration from: " + folder.getAbsolutePath());
-				in = new BufferedInputStream(new FileInputStream(new File(folder, "cdsConfig.xml")));
-				instance = CDSConfig.createReadRoot(in);
-			} catch (Exception e) {
-				ce = e;
-			} finally {
-				try {
-					if (in != null)
-						in.close();
-				} catch (Exception e) {
-					// ignore
-				}
-			}
-
-			if (in == null) {
-				try {
-					Context context = new InitialContext();
-					String folderStr = (String) context.lookup("icpc.cds.config");
-					folder = new File(folderStr);
-					Trace.trace(Trace.USER, "Loading CDS configuration from: " + folder.getAbsolutePath());
-					in = new BufferedInputStream(new FileInputStream(new File(folder, "cdsConfig.xml")));
-					instance = CDSConfig.createReadRoot(in);
-				} catch (Exception e) {
-					System.err.println("Could not load CDS configuration: " + ce.getMessage() + " / " + e.getMessage());
-				} finally {
-					try {
-						if (in != null)
-							in.close();
-					} catch (Exception e) {
-						// ignore
-					}
-				}
-			}
+			instance = createInstance();
 		}
 
 		return instance;
 	}
 
 	public static File getFolder() {
-		return folder;
+		return getInstance().file.getParentFile();
 	}
 
 	public static ConfiguredContest[] getContests() {
@@ -243,7 +326,7 @@ public class CDSConfig {
 		for (int i = 0; i < size; i++) {
 			Node n = nodes.item(i);
 			if (n instanceof Element) {
-				if (n.getNodeName().equals(childName))
+				if (childName == null || n.getNodeName().equals(childName))
 					list.add((Element) n);
 			}
 		}

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -153,6 +153,26 @@ public class ConfiguredContest {
 		}
 
 		@Override
+		public int hashCode() {
+			return countdown + (int) startTime * 31 + (int) (multiplier * 31.0 * 31.0);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (!(obj instanceof Test))
+				return false;
+
+			Test t = (Test) obj;
+			if (t.countdown != countdown)
+				return false;
+			if (t.startTime != startTime)
+				return false;
+			if (t.multiplier != multiplier)
+				return false;
+			return true;
+		}
+
+		@Override
 		public String toString() {
 			if (startTime > 0)
 				return "Playback at " + ContestUtil.formatStartTime(startTime) + " at " + getMultiplier() + "x speed";
@@ -332,6 +352,14 @@ public class ConfiguredContest {
 				else
 					VideoMapper.WEBCAM.mapAllTeams(this, urlPattern, mode);
 			}
+		}
+	}
+
+	public void close() {
+		try {
+			getContestSource().close();
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Could not close contest", e);
 		}
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/CCSContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/CCSContestSource.java
@@ -25,6 +25,7 @@ public class CCSContestSource extends DiskContestSource {
 	private int port;
 	private String startTime;
 	private String submissionFiles;
+	private XMLFeedParser parser;
 
 	/**
 	 * Create a CCS contest source with a temporary cache.
@@ -143,7 +144,7 @@ public class CCSContestSource extends DiskContestSource {
 			in = new BufferedInputStream(connectToSocket());
 			if (super.isCache())
 				notifyListeners(ConnectionState.CONNECTED);
-			XMLFeedParser parser = new XMLFeedParser();
+			parser = new XMLFeedParser();
 			parser.parse(contest, in);
 		} catch (Exception e) {
 			throw e;
@@ -155,6 +156,13 @@ public class CCSContestSource extends DiskContestSource {
 				// ignore
 			}
 		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		if (parser != null)
+			parser.close();
 	}
 
 	/**

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -245,6 +245,10 @@ public abstract class ContestSource {
 		// do nothing
 	}
 
+	public void close() throws Exception {
+		// do nothing
+	}
+
 	/**
 	 * Wait for the contest to be reading from a live source, or done/failed from any other source.
 	 *

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -164,9 +164,11 @@ public class RESTContestSource extends DiskContestSource {
 
 		instance = this;
 
-		// TODO should be in temp folder? only when we know it gets cleaned up or there's an easy way
-		// to delete
-		feedCacheFile = new File("events-" + getRemoteContestId() + ".log");
+		// store temporary events cache in log folder
+		File logFolder = new File("logs");
+		if (!logFolder.exists())
+			logFolder.mkdir();
+		feedCacheFile = new File(logFolder, "events-" + getRemoteContestId() + ".log");
 		if (feedCacheFile.exists()) {
 			// delete if older than 6h
 			if (feedCacheFile.lastModified() < System.currentTimeMillis() - 6 * 60 * 60 * 1000) {
@@ -722,6 +724,13 @@ public class RESTContestSource extends DiskContestSource {
 				// ignore
 			}
 		}
+	}
+
+	@Override
+	public void close() throws Exception {
+		super.close();
+		if (parser != null)
+			parser.close();
 	}
 
 	@Override


### PR DESCRIPTION
Watches cdsConfig.xml and automatically reloads as necessary every 4s (because 5s felt too long...). Uses a hash of each contest's xml snippet (<contest> element) to tell if anything has changed. If not (even if moved or reordered in the file), the contest is not touched. If the contest is changed or removed it gets cleaned up and any new or modified contests get started.