### PR TITLE
Default (error) problem colour

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/ICPCColors.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ICPCColors.java
@@ -55,4 +55,17 @@ public class ICPCColors {
 		}
 		return colors;
 	}
+
+	/**
+	 * Return a contrasting color to the given color.
+	 *
+	 * @param color
+	 * @return a contrasting color
+	 */
+	public static Color getContrastColor(Color color) {
+		if (color == null)
+			return Color.WHITE;
+		long y = (299 * color.getRed() + 587 * color.getGreen() + 114 * color.getBlue()) / 1000;
+		return y >= 128 ? Color.BLACK : Color.WHITE;
+	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 import java.util.List;
 import java.util.Map;
 
+import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.feed.Decimal;
@@ -61,23 +62,34 @@ public class Problem extends ContestObject implements IProblem {
 		if (colorVal != null)
 			return colorVal;
 
-		if (rgb == null || (rgb.length() != 3 && rgb.length() != 6 && rgb.length() != 7))
-			return null;
-
-		if (rgb.length() == 3) {
-			int r = Integer.parseInt(rgb.substring(0, 1) + rgb.substring(0, 1), 16);
-			int g = Integer.parseInt(rgb.substring(1, 2) + rgb.substring(1, 2), 16);
-			int b = Integer.parseInt(rgb.substring(2, 3) + rgb.substring(2, 3), 16);
-			colorVal = new Color(r, g, b);
-		} else {
-			if (rgb.length() == 7)
-				rgb = rgb.substring(1);
-			int r = Integer.parseInt(rgb.substring(0, 2), 16);
-			int g = Integer.parseInt(rgb.substring(2, 4), 16);
-			int b = Integer.parseInt(rgb.substring(4, 6), 16);
-			colorVal = new Color(r, g, b);
+		if (rgb == null || !(rgb.length() == 3 || rgb.length() == 4 || rgb.length() == 6 || rgb.length() == 7)) {
+			colorVal = Color.BLACK;
+			return colorVal;
 		}
-		return colorVal;
+
+		try {
+			String rgbv = rgb;
+			if (rgbv.length() == 3 || rgbv.length() == 4) {
+				if (rgbv.length() == 4)
+					rgbv = rgbv.substring(1);
+				int r = Integer.parseInt(rgbv.substring(0, 1) + rgbv.substring(0, 1), 16);
+				int g = Integer.parseInt(rgbv.substring(1, 2) + rgbv.substring(1, 2), 16);
+				int b = Integer.parseInt(rgbv.substring(2, 3) + rgbv.substring(2, 3), 16);
+				colorVal = new Color(r, g, b);
+				return colorVal;
+			}
+			if (rgbv.length() == 7)
+				rgbv = rgbv.substring(1);
+			int r = Integer.parseInt(rgbv.substring(0, 2), 16);
+			int g = Integer.parseInt(rgbv.substring(2, 4), 16);
+			int b = Integer.parseInt(rgbv.substring(4, 6), 16);
+			colorVal = new Color(r, g, b);
+			return colorVal;
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Invalid color value for problem " + id + " (" + rgb + ")");
+			colorVal = Color.BLACK;
+			return colorVal;
+		}
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/JudgementChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/JudgementChart.java
@@ -10,7 +10,6 @@ import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.presentation.contest.internal.ContestData;
-import org.icpc.tools.presentation.contest.internal.ICPCColors;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.Utility;
 import org.icpc.tools.presentation.core.chart.AbstractChartPresentation;
@@ -64,23 +63,11 @@ public class JudgementChart extends AbstractChartPresentation {
 			return;
 
 		String[] labels = new String[numProblems];
-		int u = 0;
-
 		Color[] colorAttempt = new Color[numProblems];
 		Color[] colorSolved = new Color[numProblems];
 		for (int j = 0; j < numProblems; j++) {
 			labels[j] = problems[j].getLabel();
 			colorAttempt[j] = problems[j].getColorVal();
-			if (colorAttempt[j] == null) {
-				if (u == 0)
-					colorAttempt[j] = ICPCColors.BLUE;
-				else if (u == 1)
-					colorAttempt[j] = ICPCColors.YELLOW;
-				else
-					colorAttempt[j] = ICPCColors.RED;
-				u++;
-				u %= 3;
-			}
 			colorSolved[j] = Utility.alphaDarker(colorAttempt[j], 200, 0.8f);
 		}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemSummaryChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemSummaryChart.java
@@ -8,7 +8,6 @@ import org.icpc.tools.contest.model.IResult;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.Status;
 import org.icpc.tools.presentation.contest.internal.ContestData;
-import org.icpc.tools.presentation.contest.internal.ICPCColors;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.Utility;
 import org.icpc.tools.presentation.core.chart.AbstractChartPresentation;
@@ -36,23 +35,11 @@ public class ProblemSummaryChart extends AbstractChartPresentation {
 			return;
 
 		String[] labels = new String[numProblems];
-		int u = 0;
-
 		Color[] colorAttempt = new Color[numProblems];
 		Color[] colorSolved = new Color[numProblems];
 		for (int j = 0; j < numProblems; j++) {
 			labels[j] = problems[j].getLabel();
 			colorAttempt[j] = problems[j].getColorVal();
-			if (colorAttempt[j] == null) {
-				if (u == 0)
-					colorAttempt[j] = ICPCColors.BLUE;
-				else if (u == 1)
-					colorAttempt[j] = ICPCColors.YELLOW;
-				else
-					colorAttempt[j] = ICPCColors.RED;
-				u++;
-				u %= 3;
-			}
 			colorSolved[j] = Utility.alphaDarker(colorAttempt[j], 200, 0.8f);
 		}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/Balloon.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/Balloon.java
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage;
 import javax.imageio.ImageIO;
 
 import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.ICPCColors;
 
 public class Balloon {
 	private static BufferedImage balloonImage;
@@ -42,8 +43,7 @@ public class Balloon {
 			balloonColor = 255 << 24 | c.getRed() << 16 | c.getGreen() << 8 | c.getBlue();
 			Color cc = c.brighter();
 			highlightColor = 255 << 24 | cc.getRed() << 16 | cc.getGreen() << 8 | cc.getBlue();
-			if (c.getRed() + c.getGreen() + c.getBlue() < 100)
-				outlineColor = 255 << 24 | 255 << 16 | 255 << 8 | 255;
+			outlineColor = ICPCColors.getContrastColor(c).getRGB();
 		}
 		BufferedImage img = new BufferedImage(balloonImage.getWidth(), balloonImage.getHeight(),
 				BufferedImage.TYPE_4BYTE_ABGR);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemColorsPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemColorsPresentation.java
@@ -67,10 +67,7 @@ public class ProblemColorsPresentation extends AbstractICPCPresentation {
 			Graphics2D g = (Graphics2D) bi.getGraphics();
 			g.drawImage(img, 0, 0, w, h, 0, 0, img.getWidth(), img.getHeight(), null);
 			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-			if (c != null && c.getRed() + c.getGreen() + c.getBlue() > 500)
-				g.setColor(Color.BLACK);
-			else
-				g.setColor(Color.WHITE);
+			g.setColor(org.icpc.tools.contest.model.ICPCColors.getContrastColor(c));
 			g.setFont(font);
 			String s = p.getLabel();
 			FontMetrics fm = g.getFontMetrics();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummaryPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummaryPresentation.java
@@ -186,15 +186,9 @@ public class ProblemSummaryPresentation extends AbstractICPCPresentation {
 				pColor = pColors.get(problemId);
 				poColor = poColors.get(problemId);
 				if (pColor == null) {
-					if (probColor == null)
-						pColor = new Color(0, 0, 0, 164);
-					else
-						pColor = new Color(probColor.getRed(), probColor.getGreen(), probColor.getBlue(), 164);
+					pColor = new Color(probColor.getRed(), probColor.getGreen(), probColor.getBlue(), 164);
 					pColors.put(problemId, pColor);
-					if (probColor == null)
-						poColor = Color.BLACK;
-					else
-						poColor = Utility.darker(probColor, 0.25f);
+					poColor = org.icpc.tools.contest.model.ICPCColors.getContrastColor(probColor);
 					poColors.put(problemId, poColor);
 				}
 			}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamJudgePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamJudgePresentation.java
@@ -280,11 +280,8 @@ public class TeamJudgePresentation extends AbstractICPCPresentation {
 		String probId = sr.submission.getProblemId();
 		IProblem problem = contest.getProblemById(probId);
 		Color c = problem.getColorVal();
-		if (c != null) {
-			c = new Color(c.getRed(), c.getGreen(), c.getBlue(), 127);
-			g.setColor(c);
-			g.fillRect(0, 0, width / COLUMNS, height / ROWS);
-		}
+		g.setColor(new Color(c.getRed(), c.getGreen(), c.getBlue(), 127));
+		g.fillRect(0, 0, width / COLUMNS, height / ROWS);
 
 		String teamId = sr.submission.getTeamId();
 		ITeam team = contest.getTeamById(teamId);


### PR DESCRIPTION
Fix for issue #141. When there is no colour given or it is unparsable, choose black. Use a util to determine better contrast colour and remove unnecessary null colour checks.