### PR TITLE
Contest and Org getActualFormalName

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -32,8 +32,13 @@
                             </td>
                         </tr>
                         <tr>
+                            <td><b>Display Name:</b></td>
+                            <td><%= team.getDisplayName() == null ? "" : team.getDisplayName() %>
+                            </td>
+                        </tr>
+                        <tr>
                             <td><b>Name:</b></td>
-                            <td><%= team.getActualDisplayName() %>
+                            <td><%= team.getName() %>
                             </td>
                         </tr>
                         <tr>
@@ -49,7 +54,7 @@
                         </tr>
                         <tr>
                             <td><b>Org formal name:</b></td>
-                            <td><%= organization.getFormalName() %>
+                            <td><%= organization.getFormalName() == null ? "" : organization.getFormalName() %>
                             </td>
                         </tr>
                         <tr>
@@ -59,7 +64,7 @@
                         </tr>
                         <tr>
                             <td><b>Country:</b></td>
-                            <td><%= organization.getCountry() %>
+                            <td><%= organization.getCountry() == null ? "" : organization.getCountry() %>
                             </td>
                         </tr>
                         <% } %>

--- a/CDS/WebContent/WEB-INF/jsps/time.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/time.jsp
@@ -18,7 +18,7 @@
 <body onload="connectTime('<%= cc.getId() %>')">
 
 <div id="navigation-header">
-  <div id="navigation-cds"><%= contest.getFormalName() %> - Time</div>
+  <div id="navigation-cds"><%= contest.getActualFormalName() %> - Time</div>
 </div>
 
 <div id="main">

--- a/CDS/WebContent/WEB-INF/jsps/video.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/video.jsp
@@ -39,7 +39,7 @@
                             IOrganization org = contest.getOrganizationById(t.getOrganizationId());
                             String orgName = "";
                             if (org != null)
-                                orgName = org.getFormalName(); %>
+                                orgName = org.getActualFormalName(); %>
                             <tr>
                                 <td><%= tId %>
                                 </td>

--- a/CDS/WebContent/WEB-INF/jsps/welcome.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/welcome.jsp
@@ -38,7 +38,7 @@
            String apiRootH = "/api/contests/" + cch.getId(); %>
         <div class="card-header <%= headerClass %> <%= textClass %>">
           <a href="<%= webRootH %>">
-            <h2 class="card-title <%= textClass %>"><%= contestH.getFormalName() %></h2>
+            <h2 class="card-title <%= textClass %>"><%= contestH.getActualFormalName() %></h2>
           </a>
           <div class="card-tools"><a href="<%= apiRootH %>" class="<%= textClass %>">/<%= cch.getId() %></a></div>
         </div>

--- a/CDS/src/org/icpc/tools/cds/service/SearchService.java
+++ b/CDS/src/org/icpc/tools/cds/service/SearchService.java
@@ -106,9 +106,9 @@ public class SearchService extends HttpServlet {
 				for (IOrganization org : orgs) {
 					if (org.getName().toLowerCase().contains(search)) {
 						write(en, org, org.getName());
-					} else if (org.getFormalName().toLowerCase().contains(search)) {
+					} else if (org.getFormalName() != null && org.getFormalName().toLowerCase().contains(search)) {
 						write(en, org, org.getFormalName());
-					} else if (org.getCountry().toLowerCase().contains(search)) {
+					} else if (org.getCountry() != null && org.getCountry().toLowerCase().contains(search)) {
 						write(en, org, org.getCountry());
 					}
 				}

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -361,9 +361,11 @@ public class CoachView extends Panel {
 			if (logoImg != null)
 				g.drawImage(logoImg, d.width - logoImg.getWidth() - BORDER, BORDER, null);
 
-			y = drawLine(g, y, "Organization", org.getFormalName());
+			y = drawLine(g, y, "Organization", org.getActualFormalName());
 			y = drawLine(g, y, null, "(" + org.getName() + ")");
-			String country = localeMap.get(org.getCountry()).getDisplayCountry();
+			String country = null;
+			if (org.getCountry() != null)
+				country = localeMap.get(org.getCountry()).getDisplayCountry();
 			if (country != null)
 				y = drawLine(g, y, "Country", country);
 			y = drawLine(g, y, "URL", org.getURL());

--- a/ContestModel/src/org/icpc/tools/contest/model/IContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContest.java
@@ -44,6 +44,13 @@ public interface IContest {
 	String getFormalName();
 
 	/**
+	 * Returns the formal name of the contest, or fall back to the name.
+	 *
+	 * @return the formal name
+	 */
+	String getActualFormalName();
+
+	/**
 	 * A positive # indicates a contest start time in seconds from the Unix epoch (Jan 1, 1970). A
 	 * negative # indicates that the contest start is paused and gives the negative time of the
 	 * pause, in seconds (e.g. -65 means it is paused 1m 5s before the start of the contest). Null

--- a/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
@@ -29,6 +29,13 @@ public interface IOrganization extends IContestObject {
 	String getFormalName();
 
 	/**
+	 * The formal name of the organization, falls back to name.
+	 *
+	 * @return the name
+	 */
+	String getActualFormalName();
+
+	/**
 	 * The nationality of the organization.
 	 *
 	 * @return the nationality

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedParser.java
@@ -205,7 +205,7 @@ public class XMLFeedParser implements Closeable {
 				add(info, ID, "id-" + Math.random());
 
 			if (info.getName() == null)
-				add(info, "name", info.getFormalName());
+				add(info, "name", info.getActualFormalName());
 
 			contest.add(info);
 		} else if (TEAM.equals(name)) {
@@ -225,18 +225,18 @@ public class XMLFeedParser implements Closeable {
 			}
 
 			if (org.getName() == null)
-				add(org, "name", org.getFormalName());
+				add(org, "name", org.getActualFormalName());
 
 			boolean exists = false;
 			for (IOrganization org2 : contest.getOrganizations()) {
-				if (org2.getFormalName().equals(org.getFormalName())) {
+				if (org2.getActualFormalName().equals(org.getActualFormalName())) {
 					exists = true;
 					instId = org2.getId();
 				}
 			}
 
 			if (org.getName() == null || org.getName().isEmpty())
-				add(org, "name", org.getFormalName());
+				add(org, "name", org.getActualFormalName());
 			if (!exists)
 				contest.add(org);
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedWriter.java
@@ -87,7 +87,7 @@ public class XMLFeedWriter {
 			Info info = (Info) obj;
 			writeStart(XMLFeedParser.INFO);
 			write("contest-id", info.getId());
-			write("title", info.getFormalName());
+			write("title", info.getActualFormalName());
 			write("short-title", info.getName());
 			write("length", formatDuration(info.getDuration()));
 			write("scoreboard-freeze-length", formatDuration(info.getFreezeDuration()));
@@ -119,8 +119,9 @@ public class XMLFeedWriter {
 			write("id", team.getId());
 			if (org != null) {
 				write("name", team.getName());
-				write("nationality", org.getCountry());
-				write("university", org.getFormalName());
+				if (org.getCountry() != null)
+					write("nationality", org.getCountry());
+				write("university", org.getActualFormalName());
 				write("university-short-name", org.getName());
 			}
 			if (groups != null && groups.length > 0 && groups[0] != null)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -418,9 +418,9 @@ public class Contest implements IContest {
 	}
 
 	/**
-	 * Returns the name of the contest.
+	 * Returns the id of the contest.
 	 *
-	 * @return the name
+	 * @return the id
 	 */
 	@Override
 	public String getId() {
@@ -445,6 +445,16 @@ public class Contest implements IContest {
 	@Override
 	public String getFormalName() {
 		return info.getFormalName();
+	}
+
+	/**
+	 * Returns the formal name of the contest, or fall back to the name.
+	 *
+	 * @return the formal name
+	 */
+	@Override
+	public String getActualFormalName() {
+		return info.getActualFormalName();
 	}
 
 	@Override
@@ -719,11 +729,11 @@ public class Contest implements IContest {
 		// default sort: by last name with coaches to bottom
 		Arrays.sort(tempMembers, (o1, o2) -> {
 			if (o1.getRole() != null && o2.getRole() != null && !o1.getRole().equals(o2.getRole()))
-			  return -o1.getRole().compareTo(o2.getRole());
+				return -o1.getRole().compareTo(o2.getRole());
 			if (o1.getLastName() != null && o2.getLastName() != null)
-			  return collator.compare(o1.getLastName(), o2.getLastName());
+				return collator.compare(o1.getLastName(), o2.getLastName());
 			return 0;
-	 });
+		});
 		return tempMembers;
 	}
 
@@ -1586,7 +1596,7 @@ public class Contest implements IContest {
 			removeFromHistory(obj);
 	}
 
-	 public int removeSubmissionsOutsideOfContestTime() {
+	public int removeSubmissionsOutsideOfContestTime() {
 		List<IContestObject> remove = new ArrayList<>();
 
 		for (ISubmission s : getSubmissions()) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -51,6 +51,10 @@ public class Info extends ContestObject implements IInfo {
 	}
 
 	public String getFormalName() {
+		return formalName;
+	}
+
+	public String getActualFormalName() {
 		if (formalName == null)
 			return name;
 		return formalName;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -51,6 +51,11 @@ public class Organization extends ContestObject implements IOrganization {
 
 	@Override
 	public String getFormalName() {
+		return formalName;
+	}
+
+	@Override
+	public String getActualFormalName() {
 		if (formalName == null)
 			return name;
 		return formalName;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
@@ -153,7 +153,8 @@ public class Ranking {
 				for (int j = i + 1; j < next; j++) {
 					IOrganization org1 = contest.getOrganizationById(teams[order[i]].getOrganizationId());
 					IOrganization org2 = contest.getOrganizationById(teams[order[j]].getOrganizationId());
-					if (org1 != null && org2 != null && collator.compare(org1.getFormalName(), org2.getFormalName()) > 0) {
+					if (org1 != null && org2 != null
+							&& collator.compare(org1.getActualFormalName(), org2.getActualFormalName()) > 0) {
 						swapOrder(order, i, j);
 					}
 				}

--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -107,14 +107,14 @@ public class ImagesGenerator {
 				File from = new File(args[0], "images" + File.separator + "logo" + File.separator + t.getId() + ".png");
 				File to = new File(args[0],
 						"images" + File.separator + "logo" + File.separator + t.getOrganizationId() + ".png");
-
+		
 				if (from.exists())
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
-
+		
 				from = new File(args[0], "images" + File.separator + "tile" + File.separator + t.getId() + ".png");
 				to = new File(args[0],
 						"images" + File.separator + "tile" + File.separator + t.getOrganizationId() + ".png");
-
+		
 				if (from.exists())
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
 			}
@@ -315,7 +315,7 @@ public class ImagesGenerator {
 				IOrganization org = contest.getOrganizationById(team.getOrganizationId());
 				if (org != null) {
 					if (contest.getNumTeams() == contest.getNumOrganizations())
-						name = org.getFormalName();
+						name = org.getActualFormalName();
 
 					File orgFolder = new File(contestRoot, "organizations" + File.separator + org.getId());
 					File imgFile = new File(orgFolder, DEFAULT_NAME);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/TeamUtil.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/TeamUtil.java
@@ -53,7 +53,7 @@ public class TeamUtil {
 		else if (style2 == Style.ORGANIZATION_NAME)
 			s = org.getName();
 		else if (style2 == Style.ORGANIZATION_FORMAL_NAME)
-			s = org.getFormalName();
+			s = org.getActualFormalName();
 		return s;
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -152,7 +152,7 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 					minLon = Math.min(minLon, lon);
 					maxLon = Math.max(maxLon, lon);
 				}
-				String label = t.getId() + " - " + org.getFormalName();
+				String label = t.getId() + " - " + org.getActualFormalName();
 				Position p = new Position(lon, lat, 1, label);
 				createOrgLogo(p, org);
 				pos.add(p);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileListScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileListScoreboardPresentation.java
@@ -31,7 +31,7 @@ public class TileListScoreboardPresentation extends ScrollingTileScoreboardPrese
 				if (style == Style.ORGANIZATION_NAME)
 					names[i] = org.getName();
 				else if (style == Style.ORGANIZATION_FORMAL_NAME)
-					names[i] = org.getFormalName();
+					names[i] = org.getActualFormalName();
 			}
 		}
 

--- a/Resolver/src/org/icpc/tools/resolver/ResolverLogic.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverLogic.java
@@ -225,7 +225,7 @@ public class ResolverLogic {
 								if (org == null)
 									Trace.trace(Trace.INFO, "Team list award for: " + teamId);
 								else
-									Trace.trace(Trace.INFO, "Team list award for: " + teamId + " " + org.getFormalName());
+									Trace.trace(Trace.INFO, "Team list award for: " + teamId + " " + org.getActualFormalName());
 
 								// are we going to show this on a separate page?
 								boolean show = false;
@@ -526,8 +526,8 @@ public class ResolverLogic {
 									if (org == null)
 										Trace.trace(Trace.INFO, "Catch up award at row: " + r + " " + missedTeamId);
 									else
-										Trace.trace(Trace.INFO,
-												"Catch up award at row: " + r + " " + missedTeamId + " " + org.getFormalName());
+										Trace.trace(Trace.INFO, "Catch up award at row: " + r + " " + missedTeamId + " "
+												+ org.getActualFormalName());
 
 									// are we going to show this on a separate page?
 									boolean show = false;
@@ -559,7 +559,7 @@ public class ResolverLogic {
 						IOrganization org = contest.getOrganizationById(team.getOrganizationId());
 						if (org != null)
 							Trace.trace(Trace.INFO,
-									"Award at row: " + currentRow + " " + team.getId() + " " + org.getFormalName());
+									"Award at row: " + currentRow + " " + team.getId() + " " + org.getActualFormalName());
 						else
 							Trace.trace(Trace.INFO, "Award at row: " + currentRow + " " + team.getId());
 


### PR DESCRIPTION
When we implemented ITeam.getDisplayName() we added getActualDisplayName() so that the API was returning the correct/real value, but for an optional parameter clients could use one method with a fallback. The same issue existed for Contest and Organization formal names, so I fixed it here. Don't love the name, but can't think of anything better. Also fixed a few places where null checks were missing for getCountry().