### PR TITLE
Fix overlap on scoreboard header

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -428,7 +428,7 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 
 		g.setColor(Color.white);
 		g.drawLine(0, headerHeight - 1, width, headerHeight - 1);
-		int y = headerHeight - 5;
+		int y = headerHeight - 3;
 
 		g.setFont(headerItalicsFont);
 		g.drawString("Rank", BORDER + (fm.stringWidth("199") - fm2.stringWidth("Rank")) / 2, y);


### PR DESCRIPTION
Found the difference between the main scoreboard and all the others: the column headers were 2 pixels higher than the others, which matters on lower res or odd aspect displays