### PR TITLE
Remove support for XML feed everywhere but CDS

### DIFF
--- a/BalloonUtility/docs/BalloonUtil.txt
+++ b/BalloonUtility/docs/BalloonUtil.txt
@@ -51,52 +51,30 @@ image::BUStartupScreen.png[Balloon Utility Startup Screen,align="center"]
 screen will be unpopulated as shown above.)
 
 In order to use the BU once it is started, it must 
-be connected to the _event feed_ output of a 
-_Contest Control System (CCS)_.
-The Balloon Utility will work with any event feed which is 
-compliant with the _CLI CCS Specification_ defined at 
-https://clics.ecs.baylor.edu/.  
-CCS's known to produce compliant event feeds include 
-http://pc2.ecs.csus.edu/pc2[PC-Squared] and 
+be connected to the output of a _Contest Control System (CCS)_.
+The Balloon Utility will work with any CCS or the CDS which is 
+compliant with the _CLI Contest API Specification_ defined at 
+https://clics.ecs.baylor.edu/.
+Tools known to produce compliant event feeds include
+https://icpc.baylor.edu/icpctools[Contest Data Server], 
+https://www.domjudge.org[DOMjudge],
+http://pc2.ecs.csus.edu/pc2[PC-Squared], and 
 https://www.kattis.com/[Kattis]; 
 other Contest Control Systems may also produce compatible event feeds and 
 hence work with the Balloon Utility.
 
-The BU is capable of operating with contest data obtained from one of three
-different sources: a Contest API source (e.g. CCS or CDS), an _event feed file_, or
-a _socket connection_ directly to an active CCS.
+The BU is capable of operating with contest data obtained from one of two
+different sources: a Contest API source (e.g. CCS or CDS) or an _event feed file_.
 
 Pressing the "Connect" button (above) will produce the following dialog, used to 
 select the event feed input source for the BU.
 
 image::BUSourceSelectionDialog.png[BUSourceSelection,align=center]
 
+Connecting the BU directly to a running (compatible) CCS or CDS is done using the REST
+selection in the Connect dialog and entering a valid Contest API URL, user, and password.
 The BU can be connected
-to an event feed file using the bottom selection in the Connect dialog.
-An event feed file is created off-line (that is, by steps external to 
-the Balloon Utility) by connecting to port 4713 on a machine
-running a compatible CCS and saving the resulting output to a file (see 
-https://clics.ecs.baylor.edu/index.php/Event_Feed for details on the structure of an event feed).  
-
-Connecting the BU directly to a running (compatible) CCS is done by entering 
-the Host IP address and port number in the middle entry of the Connect dialog.
-Note that the default event feed port for ICPC-compatible CCS's is 4713. 
-
-Alternatively, the BU can obtain its event feed data from a Contest Data Server (CDS). 
-A CDS provides URL access points for obtaining event feed and other contest data; 
-connecting the BU to a CDS causes it to pull the necessary information dynamically
-from the CDS.  
-(Note: the CDS must have been configured to connect to a compatible CCS in order
-for it to supply event feed data to the BU.)
-
-The main reason for using a CDS instead of a simple event feed file or live 
-event feed connection to provide
-BU input is that a CDS can also provide other information to the BU.  
-For example, if the CDS has been configured with
-problem names and balloon colors, the BU knows how to pull these
-from the CDS as well and will use them in the output display.  The sample image
-presented at the start of this document shows the use of such data; 
-these came from connecting the BU to a CDS.
+to an event feed file using the Disk selection in the Connect dialog.
 
 
 === Operating the Balloon Utility
@@ -176,5 +154,3 @@ for teams which are not at their site.
 
 Note that the definition of the groups in a contest comes from data in the event feed read by the BU; 
 groups cannot be directly defined within the Balloon Utility itself.
-
-

--- a/CDS/config/tomcat/conf/config/cdsConfig.xml
+++ b/CDS/config/tomcat/conf/config/cdsConfig.xml
@@ -6,9 +6,9 @@
     <ccs url="https://my-ccs" user="" password=""/>
     -->
 
-    <!-- Or configure your older CCS via the XML event feed and optional start time and submission file interfaces -->
+    <!-- Or configure your older CCS via the XML event feed and optional start time interface -->
     <!--
-    <ccs eventFeed="my-ccs:4713" startTime="https://..." submissionFiles="https://..." user="" password=""/>
+    <ccs eventFeed="my-ccs:4713" startTime="https://..." user="" password=""/>
     -->
 
     <!-- Uncomment to enable test (contest playback) mode. Countdown in seconds *or* specific start time, and contest speed multiplier -->

--- a/CDS/config/wlp/cds/config/cdsConfig.xml
+++ b/CDS/config/wlp/cds/config/cdsConfig.xml
@@ -6,9 +6,9 @@
     <ccs url="https://my-ccs" user="" password=""/>
     -->
 
-    <!-- Or configure your older CCS via the XML event feed and optional start time and submission file interfaces -->
+    <!-- Or configure your older CCS via the XML event feed and optional start time interface -->
     <!--
-    <ccs eventFeed="my-ccs:4713" startTime="https://..." submissionFiles="https://..." user="" password=""/>
+    <ccs eventFeed="my-ccs:4713" startTime="https://..." user="" password=""/>
     -->
 
     <!-- Uncomment to enable test (contest playback) mode. Countdown in seconds *or* specific start time, and contest speed multiplier -->

--- a/CDS/docs/ContestDataServer.txt
+++ b/CDS/docs/ContestDataServer.txt
@@ -202,10 +202,7 @@ that this is just meant to allow some configuration to happen in private, not a 
 <ccs
     url=""
     user=""
-    password=""
-    eventFeed=""
-    startTime=""
-    submissionFiles=""/>
+    password=""/>
 ....
 
 The optional <ccs> element is used to configure the CDS's access to the Contest Control System.  
@@ -213,29 +210,38 @@ The attributes associated with this element are as follows:
 
 ** url: the URL to a REST-based CCS
 
-** user: the user account name to be used to log in to the CCS
+** user: the user account name to log into the CCS
 
-** password:  the password for the CCS user account
+** password: the password for the CCS user account
 
-** eventFeed: (deprecated) the IP address and port at which the CDS should contact the CCS to obtain its event feed
+If the <ccs> element is present then the CDS will use the CCS as the master source of all contest data. The local
+<contest> folder is used as an initial source, cache, and can provide additional data (e.g. logos if the CCS does
+not provide those) but the event feed and all other contest data will come from or be overridden by the CCS.
 
-** startTime: (deprecated) the URL at which the CDS should contact the CCS to obtain the scheduled start time of the contest.
+====== <ccs> Child Element (deprecated)
+
+....
+<ccs
+    eventFeed=""
+    startTime=""
+    user=""
+    password=""/>
+....
+
+Only one <ccs> element may be used. This alternate and deprecated <ccs> element is provided to connect to older
+CCSs that do not support the CLI Contest API. It provides support for the final XML Event Feed specification
+(https://clics.ecs.baylor.edu/index.php?title=Event_Feed_2016) and Contest Start Interface
+(https://clics.ecs.baylor.edu/index.php?title=Contest_Start_Interface).
+The attributes associated with this element are as follows:
+
+** eventFeed: (host:port) the IP address and port at which the CDS should contact the CCS to obtain its event feed
+
+** startTime: the optional URL at which the CDS should contact the CCS to obtain the scheduled start time of the contest.
 The return start time is expected to be in mSec since the start of the Unix epoch (i.e., since midnight January 1st, 1970)
 
-** submissionFiles: (deprecated) the URL at which the CDS should contact the CCS to obtain the files corresponding to a specific team
-submission.  The URL must be of the form https://<host>/<path>?id={0} (for example, 
-"https://203.0.113.5/api/v0/submission_files.php?id={0}"); 
-the CDS will substitute the submission ID number (also called the "runID") in place of "{0}" 
-prior to invoking the request on the CCS.
+** user: the optional user account name to log into the CCS Start Interface
 
-Note that if the <ccs> element is present then it has the effect of overriding the source of the event feed as specified in the 
-<contest> element.  That is, if the <ccs> element is present then the CDS will obtain its event feed from the CCS
-rather than from the CDP whose location is specified in the <contest> element.  However, this does not affect any
-other data specified by the <contest> element; the CDS continues to obtain images, backups, etc. from the CDP location
-specified in the <contest> element even if the <ccs> element is present.
-
-See the https://clics.ecs.baylor.edu/index.php/CDS[CLI CDS wiki] for further details about the <ccs> element attributes.
-
+** password: the optional password for the CCS Start Interface user account
 
 ====== <video> Child Element
 

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -238,7 +238,6 @@ public class ConfiguredContest {
 		private String password;
 		private String eventFeed;
 		private String startTime;
-		private String submissionFiles;
 
 		protected CCS(Element e) {
 			url = CDSConfig.getString(e, "url");
@@ -246,7 +245,6 @@ public class ConfiguredContest {
 			password = CDSConfig.getString(e, "password");
 			eventFeed = CDSConfig.getString(e, "eventFeed");
 			startTime = CDSConfig.getString(e, "startTime");
-			submissionFiles = CDSConfig.getString(e, "submissionFiles");
 		}
 
 		public String getURL() {
@@ -269,10 +267,6 @@ public class ConfiguredContest {
 			return startTime;
 		}
 
-		public String getSubmissionFiles() {
-			return submissionFiles;
-		}
-
 		@Override
 		public String toString() {
 			if (getURL() != null)
@@ -282,8 +276,6 @@ public class ConfiguredContest {
 			sb.append(getUser() + "@" + getEventFeed());
 			if (startTime != null)
 				sb.append(", start " + startTime);
-			if (submissionFiles != null)
-				sb.append(", submissionFiles " + submissionFiles);
 			return sb.toString();
 		}
 	}
@@ -499,7 +491,7 @@ public class ConfiguredContest {
 					contestSource = new RESTContestSource(ccs.getURL(), ccs.getUser(), ccs.getPassword(), folder);
 				else
 					contestSource = new CCSContestSource(ccs.getEventFeed(), ccs.getUser(), ccs.getPassword(),
-							ccs.getSubmissionFiles(), ccs.getStartTime(), folder);
+							ccs.getStartTime(), folder);
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Could not configure contest source", e);
 				contestSource = new DiskContestSource(folder);

--- a/CoachView/docs/CoachView.txt
+++ b/CoachView/docs/CoachView.txt
@@ -30,7 +30,7 @@ The general form for executing the Coach View is
   
 where
 ........  
-  <contestSource> is either an HTTP or HTTPS URL to connect to a Contest API DS
+  <contestSource> is either an HTTP or HTTPS URL to connect to a Contest API
                   source, followed by user and password
 
   [options] can be "--display <num>", where <num> is which desktop display to use

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -67,13 +67,6 @@ public abstract class ContestSource {
 			// could not parse as a url, ignore
 		}
 
-		if (source.equals("ccs")) {
-			try {
-				return new CCSContestSource(arg1, Integer.parseInt(arg2));
-			} catch (Exception e) {
-				// ignore, try file instead
-			}
-		}
 		File f = new File(source);
 		if (f.exists()) {
 			if (f.isDirectory())

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
@@ -34,10 +34,7 @@ public class Admin {
 
 		ContestSource source = null;
 		try {
-			if (args.length == 3)
-				source = ContestSource.parseSource(args[0], args[1], args[2]);
-			else
-				source = ContestSource.parseSource(args[0]);
+			source = ContestSource.parseSource(args[0], args[1], args[2]);
 		} catch (IOException e) {
 			Trace.trace(Trace.ERROR, "Could not parse source: " + e.getMessage());
 			return;

--- a/PresContest/docs/PresentationClient.txt
+++ b/PresContest/docs/PresentationClient.txt
@@ -41,33 +41,26 @@ image::PresentationCollage.png["Presentation Samples",align="center",scaledwidth
 When a Presentation Client is started it must be told, in addition to what presentations to display,
 where to obtain its input data (images, contest events, etc.).
 This is referred to as specifying a _contest data source_.  
-Presentation Clients can obtain their input data from three different types of contest data sources: 
-a https://clics.ecs.baylor.edu/index.php/Main_Page#Contest_Data_Package[_contest data package (CDP)_],
-a https://clics.ecs.baylor.edu/index.php/Contest_Control_System[_contest control system (CCS)_], 
-or a https://clics.ecs.baylor.edu/index.php/CDS[_contest data server (CDS)_].
-(A _Contest Data Server_ is another ICPC Tool; see the 
-http://icpc.baylor.edu/icpctools[ICPC Tools website] for details.)
+Presentation Clients can obtain their input data from two different types of contest data sources:
+a compliant https://clics.ecs.baylor.edu/index.php?title=Contest_API[_Contest API_], or a
+a https://clics.ecs.baylor.edu/index.php/Main_Page#Contest_Data_Package[_contest data package (CDP)_].
 
-When connecting to a live Contest Control System, the Presentation Client works by reading 
-the _event feed_ output of the CCS
-The ICPC Presentation System will work with any CCS that produces an event feed which is 
-compliant with the https://clics.ecs.baylor.edu/[_CLI CCS Specification_].  
-Systems known to produce compliant event feeds include 
-http://pc2.ecs.csus.edu[PC-Squared] and 
+When connecting to a live Contest Control System via the Contest API, the Presentation Client works
+by reading the _event feed_ output of the CCS.
+The ICPC Presentation System will work with any CCS or the CDS that produces an event feed which is 
+compliant with the _CLI Contest API Specification_ defined at 
+https://clics.ecs.baylor.edu/. 
+Tools known to produce compliant event feeds include the
+https://icpc.baylor.edu/icpctools[Contest Data Server],
+https://www.domjudge.org[DOMjudge],
+http://pc2.ecs.csus.edu/pc2[PC-Squared], and 
 https://www.kattis.com/[Kattis]; 
 other Contest Control Systems may also produce compatible event feeds and 
 hence work with the Presentation System.
 
 A second way to provide the Presentation Client with input data is by creating a _contest data package_ (CDP). 
 A CDP is an arbitrarily-named folder with specific contest-configuration contents;
-see the above reference for details on CDP structure.     
-
-Alternatively, a Presentation Client can obtain its input from a Contest Data Server. 
-A CDS provides URL access points for obtaining event feed and other contest data; 
-starting a Presentation Client with the URL of a CDS causes it to connect to the CDS 
-and pull down the necessary information dynamically.  
-(Note: the CDS must have been configured to connect to a compatible CCS in order
-for it to supply event feed data to the Presentation Client.)
+see the above reference for details on CDP structure.
 
 == Using the Presentation Client
 
@@ -115,18 +108,12 @@ The second parameter to the script specifies a contest data source.
 If the second parameter is the name of a folder,
 the Presentation Client interprets it as the root of a _contest data package (CDP)_,
 as described above, and it uses the specified CDP to obtain its contest data.
-  
-If the second parameter is the keyword "ccs"
-the Presentation Client expects the next two parameters to
-specify a host and port, and it attempts to open a connection to an event feed 
-from a Contest Control System at that host and port.
 
 If the second parameter is a URL, the Presentation Client interprets it as
-the URL of a contest data server; it opens a connection to the specified
-CDS and reads its input data from the CDS.  When the second parameter specifies 
-an HTTPS URL, the Presentation Client expects the next two parameters to
-specify a user name and password.  This user name and password is used to login to 
-a CDS at the specified URL.
+the URL of a Contest API server; it opens a connection to the specified
+server and reads its input data.  The Presentation Client expects the next two parameters to
+specify a user name and password. This user name and password are used to login to 
+the Contest API.
  
 To terminate a running presentation, press Ctrl-Q.
 
@@ -311,7 +298,7 @@ The first source that correctly resolves into a number is used. All of the examp
 
 == Additional Notes
 
-The Presentation System is written in Java and will run on any platform supporting Java Version 7 or greater.  
+The Presentation System is written in Java and will run on any platform supporting Java Version 8 or greater.  
 However, it makes heavy use of screen-level graphics and is therefore heavily dependent on the 
 graphics drivers on the platform.  
 In our experience, Linux graphics drivers tend to be substantially less robust than others; 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -40,7 +40,7 @@ public class ClientLauncher {
 	}
 
 	public static void showHelp() {
-		System.out.println("Usage: client.bat/sh id cdsURL [user] [password]");
+		System.out.println("Usage: client.bat/sh id cdsURL user password");
 		System.out.println();
 		System.out.println("   cdsURL");
 		System.out.println("      an HTTP(S) URL to a CDS");

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -58,20 +58,18 @@ public class StandaloneLauncher {
 	}
 
 	public static void showHelp(List<PresentationInfo> presentations) {
-		System.out.println("Usage: standalone.bat/sh presentations contestSource [user/host] [password/port] [options]");
+		System.out.println("Usage: standalone.bat/sh presentations contestSource [user] [password] [options]");
 		System.out.println();
 		System.out.println("   presentations");
 		System.out.println("      one or more presentation names or ids, separated by |");
-		System.out.println("   contestSource [user/host] [password/port]");
+		System.out.println("   contestSource [user] [password]");
 		System.out.println("      \"http://\" to connect to a CDS, or");
 		System.out.println("      \"https:// [user] [password] to connect to a secure CDS, or");
-		System.out.println("      \"ccs [host] [port]\" to connect to CCS, or");
 		System.out.println("      \"[folder]\" to load from a contest data package archive folder");
 		System.out.println("   options");
 		System.out.println("      \"--display X\" display on screen X");
 		System.out.println();
 		System.out.println("Examples: standalone logo|photos https://cds tim pwd");
-		System.out.println("          standalone timeline ccs ccsServer 4713");
 		System.out.println("          standalone 1|3|16 c:\\myContestCDPfolder");
 		System.out.println();
 

--- a/Resolver/docs/Resolver.txt
+++ b/Resolver/docs/Resolver.txt
@@ -89,43 +89,34 @@ the viewer clients see only the main Resolver output.
 
 === Input Data Sources
 
-The Resolver works by reading the _event feed_ output of a _Contest Control System (CCS)_.
-The ICPC Resolver will work with any CCS that produces an event feed which is 
-compliant with the _CLI CCS Specification_ defined at 
-https://clics.ecs.baylor.edu/.  
-Systems known to produce compliant event feeds include 
-http://pc2.ecs.csus.edu[PC-Squared] and 
+The Resolver works with any CCS or the CDS that produces an event feed which is 
+compliant with the _CLI Contest API Specification_ defined at 
+https://clics.ecs.baylor.edu/. 
+Tools known to produce compliant event feeds include the
+https://icpc.baylor.edu/icpctools[Contest Data Server],
+https://www.domjudge.org[DOMjudge],
+http://pc2.ecs.csus.edu/pc2[PC-Squared], and 
 https://www.kattis.com/[Kattis]; 
 other Contest Control Systems may also produce compatible event feeds and 
 hence work with the Resolver.
 
 The Resolver is capable of operating with event feed data obtained from one of
-three different sources: an _event feed file_, a _contest data package_ (folder),
-or a _Contest API source_
-(The _Contest Data Server_ is another ICPC Tool that is a Contest API; see the 
-https://icpc.baylor.edu/icpctools/[ICPCTools website] for details.)
+three different sources: an _event feed file_, a _contest data package_ (CDP folder),
+or a _Contest API source_.
 
-An event feed file is created by connecting to port 4713 on a machine
-running a compatible CCS and saving the resulting output to a file (see 
-https://clics.ecs.baylor.edu/index.php/Event_Feed for details on the structure of an event feed).  
-Once the event feed data has been saved in a file, the Resolver can be started 
-with the event feed file as an argument.
-
-A second way to provide the Resolver with input data is by creating a _contest data package_ (CDP). 
 A CDP is an arbitrarily-named folder with specific contest-configuration contents.  
 If the Resolver is started with its first argument being the path (relative or absolute)
 to a folder whose contents are organized following the 
 https://clics.ecs.baylor.edu/index.php/CDP[CLI Contest Data Package specification] it will read its
 event feed data from that folder
-Note: the Resolver expects the find the event feed information stored in
-a file named _contest.xml_ located in the CDP root folder when it reads from a CDP.
+Note: when reading from a CDP the Resolver expects the find the event feed information stored in
+a file named _events.json_ located in the CDP root folder.
 
 Alternatively, the Resolver can obtain its event feed data from a Contest API server, for example
 the Contest Data Server (CDS). 
 The Contest API provides URL access points for obtaining event feed and other contest data; 
 starting the Resolver with the URL of a Contest API causes it to connect to the Contest API
-and pull down the necessary information dynamically.  
-
+and pull down the necessary information dynamically.
 
 The main reason for using either a CDP or a CDS instead of a simple event feed file to provide
 Resolver input is that a CDP or CDS can also provide other information to the Resolver.  
@@ -357,7 +348,7 @@ at the same speed as the presenter and displaying only the Resolver data
 (no special info).
 
 [source]
-resolver.bat c:\eventFeed.xml --singleStep 
+resolver.bat c:\events.json --singleStep 
 
 The above command runs the Resolver in "stand-alone" mode, taking its input from the specified local
 file.  It runs in single-step mode for the entire resolving process (meaning the user must click to
@@ -477,7 +468,7 @@ awards
 or
 
 [source]
-awards eventFeed.xml options...
+awards events.json options...
 
 Omitting all arguments (as shown in the first example) causes the script to invoke the interactive Award Generator interface (see below).
 
@@ -489,9 +480,9 @@ generate a help (usage) message and quit.
 
 When using the command line award configuration method, 
 the augmented event feed file is automatically saved in a new file whose name is the same as the
-specified _eventFeed.xml_ file but with "-awards" added in front of the ".xml" extension.
-(That is, the AG strips off the last four characters of the specified file name, assumed to be ".xml",
-and replaces them with the characters "-awards.xml".)  
+specified _events.json_ file but with "-awards" added in front of the ".json" extension.
+(That is, the AG strips off the last five characters of the specified file name, assumed to be ".json",
+and replaces them with the characters "-awards.json".)  
 
 
 ====== Command Line Options
@@ -729,13 +720,13 @@ and then in the latter case the CDS must be restarted (see the separate document
 available from the https://icpc.baylor.edu/icpctools/[ICPCTools website] for further information).
 
 Recall that the Resolver expects that event feed files loaded from a local CDP are located in a file
-named _contest.xml_ in the CDP root folder (event feed files loaded by a CDS are also expected to be
-named _contest.xml_).   It is up to the user to insure these naming conventions are followed.
+named _events.json_ in the CDP root folder (event feed files loaded by a CDS are also expected to be
+named _events.json_).  It is up to the user to ensure these naming conventions are followed.
 
 
 === Additional Notes
 
-The Resolver and Award Generator tools are written in Java and will run on any platform supporting Java Version 7 or greater.  
+The Resolver and Award Generator tools are written in Java and will run on any platform supporting Java Version 8 or greater.  
 However, the Resolver makes heavy use of screen-level graphics and is therefore heavily dependent on the 
 graphics drivers on the platform.  
 In our experience, Linux graphics drivers are substantially less robust than others; 


### PR DESCRIPTION
Removed support for all command line tools and connection dialogs for connecting to a socket + XML feed. Removed support for the submission file interface from the CDS but *left in the support for connecting to the XML socket and start time interface*. Removed references to the XML feed in the docs, generally tried to clean them up as I went, made the CDS 'not special' and just another Contest API source, and added DOMjudge to the list of verified Contest API sources.