### PR TITLE
GitHub builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,10 @@ test:
 
 push release to GitHub:
   stage: deploy
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+      when: always
+    - when: never
   before_script:
     - apt install -y httpie jq
     - eval $(ssh-agent -s)
@@ -86,6 +90,10 @@ push release to GitHub:
 
 deploy to CSUS:
   stage: deploy
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+      when: always
+    - when: never
   script:
     - apt-get install -y curl
     - export BUILDNUMBER=`echo dist/wlp.CDS-*.zip | sed 's#^dist/wlp.CDS-\([0-9\.]*\).zip*#\1#'`


### PR DESCRIPTION
This PR will push builds to https://github.com/icpctools/builds

The 2.2.245 build there is from this job: https://gitlab.com/icpctools/icpctools/-/jobs/383879421

Note that currently it is using my personal access token (set up in GitLab). We should switch this to a separate user. The SSH private key is a deploy key I added for the builds repo, so that one should be good to go.

Later I will use the GitHub API to get releases to display on the website.