### PR TITLE
Allow team rotation to be float

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
@@ -613,11 +613,11 @@ public class BalloonPrinter {
 			float yt = r.y + (int) ((team.getY() - bounds.y) * scale);
 
 			// team area
-			float teamAreaDepth = floor.teamAreaDepth;
-			float teamAreaWidth = floor.teamAreaWidth;
+			double teamAreaDepth = floor.teamAreaDepth;
+			double teamAreaWidth = floor.teamAreaWidth;
 			float dx = 1f;
 			transform.translate(xt, yt);
-			transform.rotate(-team.getRotation());
+			transform.rotate((float) -team.getRotation());
 			gc.setTransform(transform);
 
 			String id = team.getId();
@@ -631,8 +631,8 @@ public class BalloonPrinter {
 			gc.drawRectangle(tr1);
 
 			// chairs
-			float tableDepth = floor.tableDepth;
-			float tableWidth = floor.tableWidth;
+			double tableDepth = floor.tableDepth;
+			double tableWidth = floor.tableWidth;
 
 			// table
 			Rectangle tr = new Rectangle((int) (-tableDepth * scale / 2f), (int) (-tableWidth * scale / 2f),

--- a/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
@@ -33,10 +33,10 @@ import org.icpc.tools.contest.model.internal.Problem;
 import org.icpc.tools.contest.model.internal.Team;
 
 public class FloorMap {
-	public static final short N = 90;
-	public static final short E = 0;
-	public static final short S = 270;
-	public static final short W = 180;
+	public static final double N = 90;
+	public static final double E = 0;
+	public static final double S = 270;
+	public static final double W = 180;
 
 	private static final String NO_ID = "<-1>";
 
@@ -115,10 +115,10 @@ public class FloorMap {
 	private static final String COMMA = ",";
 	private static final String TAB = "\t";
 
-	public float tableWidth;
-	public float tableDepth;
-	public float teamAreaWidth;
-	public float teamAreaDepth;
+	public double tableWidth;
+	public double tableDepth;
+	public double teamAreaWidth;
+	public double teamAreaDepth;
 	private Rectangle2D.Double tBounds;
 	private Rectangle2D.Double otBounds;
 
@@ -186,7 +186,7 @@ public class FloorMap {
 	/**
 	 * Create a new floor map.
 	 */
-	public FloorMap(float taw, float tad, float tw, float td) {
+	public FloorMap(double taw, double tad, double tw, double td) {
 		teamAreaWidth = taw;
 		teamAreaDepth = tad;
 		tableWidth = tw;
@@ -207,13 +207,13 @@ public class FloorMap {
 			AffineTransform transform = AffineTransform.getTranslateInstance(t.getX(), t.getY());
 			transform.concatenate(AffineTransform.getRotateInstance(Math.toRadians(t.getRotation())));
 
-			Rectangle2D.Float r = new Rectangle2D.Float(-tableDepth / 2f, -tableWidth / 2f, tableDepth, tableWidth);
+			Rectangle2D.Double r = new Rectangle2D.Double(-tableDepth / 2f, -tableWidth / 2f, tableDepth, tableWidth);
 			Shape s = transform.createTransformedShape(r);
 			Rectangle2D r2 = s.getBounds2D();
-			x1 = (float) Math.min(x1, r2.getMinX());
-			y1 = (float) Math.min(y1, r2.getMinY());
-			x2 = (float) Math.max(x2, r2.getMaxX());
-			y2 = (float) Math.max(y2, r2.getMaxY());
+			x1 = Math.min(x1, r2.getMinX());
+			y1 = Math.min(y1, r2.getMinY());
+			x2 = Math.max(x2, r2.getMaxX());
+			y2 = Math.max(y2, r2.getMaxY());
 		}
 
 		if (!onlyTeams) {
@@ -239,7 +239,7 @@ public class FloorMap {
 
 		// add small gap
 		// TODO gap should be configurable
-		float gap = 2f;
+		double gap = 2f;
 		x1 -= gap;
 		y1 -= gap;
 		x2 += gap;
@@ -468,7 +468,7 @@ public class FloorMap {
 
 			double dx = (x - xc);
 			double dy = (y - yc);
-			float dist2 = (float) Math.sqrt(dx * dx + dy * dy);
+			double dist2 = Math.sqrt(dx * dx + dy * dy);
 			// System.out.println("point: " + xc + "," + yc + " - " + dist);
 
 			if (dist2 < dist) {
@@ -589,7 +589,7 @@ public class FloorMap {
 
 			// chairs
 			double c = tableWidth * scale / 8f;
-			float rnd = 0f;// c * 0.5f;
+			double rnd = 0f;// c * 0.5f;
 			for (int i = 0; i < 3; i++) {
 				// RoundRectangle2D.Float tr = new RoundRectangle2D.Float(-tableDepth * scale * 0.75f,
 				// -tableWidth * scale
@@ -627,7 +627,7 @@ public class FloorMap {
 		}
 
 		for (IProblem b : balloons) {
-			float dim = 1.5f;
+			double dim = 1.5f;
 			double d = dim * scale;
 			int x = r.x + (int) ((b.getX() - bounds.x) * scale);
 			int y = r.y + (int) ((b.getY() - bounds.y) * scale);
@@ -861,7 +861,7 @@ public class FloorMap {
 					id = "";
 				double x = Double.parseDouble(st.nextToken());
 				double y = Double.parseDouble(st.nextToken());
-				int rotation = Short.parseShort(st.nextToken());
+				double rotation = Double.parseDouble(st.nextToken());
 				createTeam(id, x, y, rotation);
 			} else if ("balloon".equals(type)) {
 				String id = st.nextToken();
@@ -874,10 +874,10 @@ public class FloorMap {
 				createPrinter(x, y);
 			} else if ("aisle".equals(type)) {
 				Aisle a = new Aisle();
-				a.x1 = Float.parseFloat(st.nextToken());
-				a.y1 = Float.parseFloat(st.nextToken());
-				a.x2 = Float.parseFloat(st.nextToken());
-				a.y2 = Float.parseFloat(st.nextToken());
+				a.x1 = Double.parseDouble(st.nextToken());
+				a.y1 = Double.parseDouble(st.nextToken());
+				a.x2 = Double.parseDouble(st.nextToken());
+				a.y2 = Double.parseDouble(st.nextToken());
 				aisles.add(a);
 			}
 
@@ -886,13 +886,13 @@ public class FloorMap {
 		computeAisleIntersections();
 	}
 
-	public ITeam createTeam(int num, double x, double y, int rotation) {
+	public ITeam createTeam(int num, double x, double y, double rotation) {
 		if (num < 0)
 			return createTeam("", x, y, rotation);
 		return createTeam(num + "", x, y, rotation);
 	}
 
-	public ITeam createTeam(String id, double x, double y, int rotation) {
+	public ITeam createTeam(String id, double x, double y, double rotation) {
 		Team t = new Team();
 		t.add("id", id);
 		t.add("x", x + "");
@@ -941,7 +941,7 @@ public class FloorMap {
 			Team t = (Team) tt;
 			t.add("x", -t.getX() + "");
 			t.add("y", -t.getY() + "");
-			int r = t.getRotation() + 180;
+			double r = t.getRotation() + 180;
 			t.add("rotation", (r % 360) + "");
 		}
 
@@ -968,13 +968,13 @@ public class FloorMap {
 	}
 
 	public void writeCSV(PrintStream out) {
-		out.print(teamAreaWidth);
+		out.print(rnd(teamAreaWidth));
 		out.print(COMMA);
-		out.print(teamAreaDepth);
+		out.print(rnd(teamAreaDepth));
 		out.print(COMMA);
-		out.print(tableWidth);
+		out.print(rnd(tableWidth));
 		out.print(COMMA);
-		out.println(tableDepth);
+		out.println(rnd(tableDepth));
 
 		for (ITeam t : teams) {
 			out.print("team");
@@ -988,7 +988,7 @@ public class FloorMap {
 			out.print(COMMA);
 			out.print(rnd(t.getY()));
 			out.print(COMMA);
-			out.println(t.getRotation());
+			out.println(rnd(t.getRotation()));
 		}
 
 		for (IProblem b : balloons) {
@@ -1043,7 +1043,7 @@ public class FloorMap {
 			out.print(TAB);
 			out.print(rnd(t.getY()));
 			out.print(TAB);
-			out.println(t.getRotation());
+			out.println(rnd(t.getRotation()));
 		}
 
 		for (IProblem b : balloons) {
@@ -1106,19 +1106,15 @@ public class FloorMap {
 		out.append("\"");
 	}
 
-	private static void write(PrintStream out, String name, float value) {
-		write(out, name, value + "");
-	}
-
 	public void write(PrintStream out) {
 		out.append("\"floorMap\": {\n  ");
-		write(out, "teamWidth", teamAreaWidth);
+		write(out, "teamWidth", rnd(teamAreaWidth));
 		out.append(",\n  ");
-		write(out, "teamDepth", teamAreaDepth);
+		write(out, "teamDepth", rnd(teamAreaDepth));
 		out.append(",\n  ");
-		write(out, "tableWidth", tableWidth);
+		write(out, "tableWidth", rnd(tableWidth));
 		out.append(",\n  ");
-		write(out, "tableDepth", tableDepth);
+		write(out, "tableDepth", rnd(tableDepth));
 		out.append(",\n");
 
 		for (ITeam t : teams) {
@@ -1132,7 +1128,7 @@ public class FloorMap {
 			out.append(", ");
 			write(out, "y", rnd(t.getY()));
 			out.append(", ");
-			write(out, "angle", t.getRotation() + "");
+			write(out, "angle", rnd(t.getRotation()));
 			out.append("},\n");
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
@@ -50,12 +50,12 @@ public interface ITeam extends IContestObject, IPosition {
 	String getICPCId();
 
 	/**
-	 * The integer rotation of the team's desk in degrees, increasing counter-clockwise from 0 to
-	 * 359. 0 is a desk facing E, 90 for table facing N, 180 for table facing W, etc.
+	 * The rotation of the team's desk in degrees, increasing counter-clockwise in the range [0,
+	 * 360). 0 is a desk facing E, 90 for table facing N, 180 for table facing W, etc.
 	 *
 	 * @return the rotation
 	 */
-	int getRotation();
+	double getRotation();
 
 	File getPhoto(int width, int height, boolean force);
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -37,7 +37,7 @@ public class Team extends ContestObject implements ITeam {
 	private String icpcId;
 	private double x = Double.MIN_VALUE;
 	private double y = Double.MIN_VALUE;
-	private int rotation = -1;
+	private double rotation = Double.MIN_VALUE;
 	private FileReferenceList photo;
 	private FileReferenceList video;
 	private FileReferenceList desktop;
@@ -93,7 +93,7 @@ public class Team extends ContestObject implements ITeam {
 	}
 
 	@Override
-	public int getRotation() {
+	public double getRotation() {
 		return rotation;
 	}
 
@@ -234,14 +234,14 @@ public class Team extends ContestObject implements ITeam {
 				return true;
 			}
 			case ROTATION: { // deprecated - use child location object
-				rotation = parseInt(value);
+				rotation = parseDouble(value);
 				return true;
 			}
 			case LOCATION: {
 				JsonObject obj = JSONParser.getOrReadObject(value);
 				x = obj.getDouble(X);
 				y = obj.getDouble(Y);
-				rotation = obj.getInt(ROTATION);
+				rotation = obj.getDouble(ROTATION);
 				return true;
 			}
 			case PHOTO: {
@@ -304,14 +304,14 @@ public class Team extends ContestObject implements ITeam {
 		props.put(BACKUP, backup);
 		props.put(DESKTOP, desktop);
 		props.put(WEBCAM, webcam);
-		if (x != Double.MIN_VALUE || y != Double.MIN_VALUE || rotation >= 0) {
+		if (x != Double.MIN_VALUE || y != Double.MIN_VALUE || rotation != Double.MIN_VALUE) {
 			List<String> attrs = new ArrayList<>(3);
 			if (x != Double.MIN_VALUE)
 				attrs.add("\"" + X + "\":" + round(x));
 			if (y != Double.MIN_VALUE)
 				attrs.add("\"" + Y + "\":" + round(y));
-			if (rotation >= 0)
-				attrs.add("\"" + ROTATION + "\":" + rotation);
+			if (rotation != Double.MIN_VALUE)
+				attrs.add("\"" + ROTATION + "\":" + round(rotation));
 			props.put(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
 	}
@@ -335,14 +335,14 @@ public class Team extends ContestObject implements ITeam {
 		je.encodeSubs(DESKTOP, desktop, false);
 		je.encodeSubs(WEBCAM, webcam, false);
 
-		if (x != Double.MIN_VALUE || y != Double.MIN_VALUE || rotation >= 0) {
+		if (x != Double.MIN_VALUE || y != Double.MIN_VALUE || rotation != Double.MIN_VALUE) {
 			List<String> attrs = new ArrayList<>(3);
 			if (x != Double.MIN_VALUE)
 				attrs.add("\"" + X + "\":" + round(x));
 			if (y != Double.MIN_VALUE)
 				attrs.add("\"" + Y + "\":" + round(y));
-			if (rotation >= 0)
-				attrs.add("\"" + ROTATION + "\":" + rotation);
+			if (rotation != Double.MIN_VALUE)
+				attrs.add("\"" + ROTATION + "\":" + round(rotation));
 			je.encodePrimitive(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
 	}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2013.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2013.java
@@ -2,10 +2,10 @@ package org.icpc.tools.contest.util.floor;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
 import org.icpc.tools.contest.model.IPrinter;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.FloorMap.Path;
 
 public class FloorGenerator2013 extends FloorGenerator {
 	private static final float tw = 1.8f; // table width
@@ -16,7 +16,8 @@ public class FloorGenerator2013 extends FloorGenerator {
 	private static FloorMap floor = new FloorMap(taw, tad, tw, td);
 	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2014.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2014.java
@@ -2,10 +2,10 @@ package org.icpc.tools.contest.util.floor;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
 import org.icpc.tools.contest.model.IPrinter;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.FloorMap.Path;
 
 public class FloorGenerator2014 extends FloorGenerator {
 	private static final float tw = 1.8f; // table width
@@ -18,13 +18,14 @@ public class FloorGenerator2014 extends FloorGenerator {
 	private static final int[] left = new int[] { 1, 7, 3, 8, 2, 9 };
 	private static final int[] right = new int[] { 4, 10, 5, 11, 6, 12 };
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}
 	}
 
-	protected static void createAdjacentTeam(int id, int newId, float dx, float dy) {
+	protected static void createAdjacentTeam(int id, int newId, double dx, double dy) {
 		ITeam t = floor.getTeam(id);
 		floor.createTeam(newId, t.getX() + dx, t.getY() + dy, t.getRotation());
 	}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2015.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2015.java
@@ -2,8 +2,8 @@ package org.icpc.tools.contest.util.floor;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
-import org.icpc.tools.contest.model.IPrinter;
 import org.icpc.tools.contest.model.FloorMap.Path;
+import org.icpc.tools.contest.model.IPrinter;
 
 public class FloorGenerator2015 extends FloorGenerator {
 	// table width (in meters). ICPC standard is 1.8
@@ -22,7 +22,8 @@ public class FloorGenerator2015 extends FloorGenerator {
 
 	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2016.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2016.java
@@ -2,9 +2,9 @@ package org.icpc.tools.contest.util.floor;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
 import org.icpc.tools.contest.model.IPrinter;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.FloorMap.Path;
 
 public class FloorGenerator2016 extends FloorGenerator {
 	// table width (in meters). ICPC standard is 1.8
@@ -23,7 +23,8 @@ public class FloorGenerator2016 extends FloorGenerator {
 
 	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2017.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2017.java
@@ -2,9 +2,9 @@ package org.icpc.tools.contest.util.floor;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
 import org.icpc.tools.contest.model.IPrinter;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.FloorMap.Path;
 
 public class FloorGenerator2017 extends FloorGenerator {
 	// table width (in meters). ICPC standard is 1.8
@@ -23,14 +23,15 @@ public class FloorGenerator2017 extends FloorGenerator {
 
 	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}
 	}
 
-	protected static void createTeamRowRev(int num, int startingId, float x, float y, float dx, float dy,
-			short rotation) {
+	protected static void createTeamRowRev(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId - i, x + dx * i, y + dy * i, rotation);
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2018.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2018.java
@@ -2,9 +2,9 @@ package org.icpc.tools.contest.util.floor;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
 import org.icpc.tools.contest.model.IPrinter;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.FloorMap.Path;
 
 public class FloorGenerator2018 extends FloorGenerator {
 	// table width (in meters). ICPC standard is 1.8
@@ -23,14 +23,15 @@ public class FloorGenerator2018 extends FloorGenerator {
 
 	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}
 	}
 
-	protected static void createTeamRowRev(int num, int startingId, float x, float y, float dx, float dy,
-			short rotation) {
+	protected static void createTeamRowRev(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId - i, x + dx * i, y + dy * i, rotation);
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2019.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2019.java
@@ -29,14 +29,15 @@ public class FloorGenerator2019 extends FloorGenerator {
 
 	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-	protected static void createTeamRow(int num, int startingId, float x, float y, float dx, float dy, short rotation) {
+	protected static void createTeamRow(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId + i, x + dx * i, y + dy * i, rotation);
 		}
 	}
 
-	protected static void createTeamRowRev(int num, int startingId, float x, float y, float dx, float dy,
-			short rotation) {
+	protected static void createTeamRowRev(int num, int startingId, double x, double y, double dx, double dy,
+			double rotation) {
 		for (int i = 0; i < num; i++) {
 			floor.createTeam(startingId - i, x + dx * i, y + dy * i, rotation);
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC.java
@@ -1,0 +1,149 @@
+package org.icpc.tools.contest.util.floor;
+
+import java.awt.geom.Point2D;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
+import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.internal.Printer;
+
+public class FloorGeneratorNAC extends FloorGenerator {
+	// table width (in meters). ICPC standard is 1.8
+	private static final float tw = 1.8f;
+
+	// table depth (in meters). ICPC standard is 0.8
+	private static final float td = 0.8f;
+
+	// team area width (in meters). ICPC standard is 3.0
+	private static final float taw = 2.2f;
+
+	// team area depth (in meters). ICPC standard is 2.2
+	private static final float tad = 2.0f;
+
+	private static FloorMap floor = new FloorMap(taw, tad, tw, td);
+
+	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+	protected static void createTeamPod(int num, int startingId, float x, float y) {
+		for (int i = 0; i < num; i++) {
+			short rotation = (short) ((45 * i + 135) % 360);
+			double tx = x + 3.2 * Math.sin(Math.toRadians(rotation));
+			double ty = y + 3.2 * Math.cos(Math.toRadians(rotation));
+			floor.createTeam(startingId + i, tx, ty, (rotation + 90) % 360);
+		}
+	}
+
+	protected static void createTeamPodAisles(float x, float y, List<Point2D.Double> list, int num) {
+		double AISLE = 6.5;
+		for (int i = 0; i < num; i++) {
+			short r1 = (short) ((45 * (i + 3) + 135 + 22) % 360);
+			double x1 = x + AISLE * Math.sin(Math.toRadians(r1));
+			double y1 = y + AISLE * Math.cos(Math.toRadians(r1));
+			list.add(new Point2D.Double(x1, y1));
+		}
+	}
+
+	protected static void createTeamPodAisles(float x, float y, List<Point2D.Double> list) {
+		createTeamPodAisles(x, y, list, 8);
+	}
+
+	protected static void createAisle(List<Point2D.Double> list, int i, int j) {
+		Point2D.Double p1 = list.get(i);
+		Point2D.Double p2 = list.get(j);
+		floor.createAisle(p1.x, p1.y, p2.x, p2.y);
+	}
+
+	public static void main(String[] args) {
+		Trace.init("ICPC Floor Map Generator", "floorMap", args);
+
+		try {
+			/*float dyRow = aisleWidth;
+			float rowX = td + elecGap;*/
+
+			float x = 0;
+			float y = 0;
+
+			/*double rightAisle = x + taw / 2 + centerAisleWidth / 2;
+			double leftAisle = x - 19.5 * taw - centerAisleWidth * 3 / 2;*/
+
+			float GAP = 17;
+			createTeamPod(7, 1, x, y);
+			createTeamPod(7, 8, x + GAP, y);
+
+			createTeamPod(7, 15, x + GAP / 2, y + GAP / 2);
+
+			createTeamPod(7, 22, x, y + GAP);
+			createTeamPod(7, 29, x + GAP, y + GAP);
+
+			createTeamPod(7, 36, x + GAP / 2, y + GAP * 3 / 2);
+
+			createTeamPod(7, 43, x, y + GAP * 2);
+			createTeamPod(7, 50, x + GAP, y + GAP * 2);
+
+			createTeamPod(7, 57, x + GAP / 2, y + GAP * 5 / 2);
+
+			List<Point2D.Double> ai = new ArrayList<>();
+			createTeamPodAisles(x, y, ai);
+			createTeamPodAisles(x + GAP, y, ai);
+			createTeamPodAisles(x, y + GAP, ai);
+			createTeamPodAisles(x + GAP, y + GAP, ai);
+			createTeamPodAisles(x, y + GAP * 2, ai);
+			createTeamPodAisles(x + GAP, y + GAP * 2, ai);
+			createTeamPodAisles(x + GAP / 2, y + GAP * 5 / 2, ai, 4);
+
+			int size = ai.size();
+			for (int i = 0; i < size - 1; i++) {
+				for (int j = i + 1; j < size; j++) {
+					Point2D.Double p1 = ai.get(i);
+					Point2D.Double p2 = ai.get(j);
+					double dx = p1.x - p2.x;
+					double dy = p1.y - p2.y;
+					if (Math.sqrt(dx * dx + dy * dy) < 7.5)
+						floor.createAisle(p1.x, p1.y, p2.x, p2.y);
+				}
+			}
+			createAisle(ai, 5, 14);
+
+			createAisle(ai, 0, 23);
+			createAisle(ai, 11, 28);
+
+			createAisle(ai, 16, 39);
+			createAisle(ai, 27, 44);
+
+			// createAisle(ai, 32, 48);
+			// createAisle(ai, 42, 51);
+
+			// floor.createAisle(rightAisle, y, leftAisle, y);
+
+			double bx = 0;
+			for (int i = 0; i < 10; i++)
+				floor.createBalloon(balloon.charAt(i) + "", bx + i * 2, -8);
+
+			Printer p = floor.createPrinter(25, 5);
+
+			floor.resetOrigin();
+
+			floor.writeTSV(System.out);
+
+			Trace.trace(Trace.USER, "------------------");
+
+			long time = System.currentTimeMillis();
+			ITeam t1 = floor.getTeam(10);
+			ITeam t2 = floor.getTeam(47);
+			ITeam t3 = floor.getTeam(57);
+			Path path1 = floor.getPath(t1, t2);
+			Path path2 = floor.getPath(t3, p);
+
+			Trace.trace(Trace.USER, "Time: " + (System.currentTimeMillis() - time));
+
+			show(floor, 57, true, path1, path2);
+			// show(floor, 57, true, null, null);
+			// show(floor, 57, true);
+		} catch (Exception e) {
+			Trace.trace(Trace.ERROR, "Error generating floor map", e);
+		}
+	}
+}


### PR DESCRIPTION
The CDS only allowed the team's desk rotation to be integers, but we made the spec support floating point values. Updating the contest model to support double, and getting rid of float/short in FloorMap utility and downstream effect on FloorGenerators and BalloonPrinter. Using this opportunity to check in the NAC floor map gen too.