### PR TITLE
Reset event feed

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -88,7 +88,7 @@
       </div>
       <div class="row">
       <div class="col-9">
-                <div class="card">
+        <div class="card">
            <div class="card-header">
              <h3 class="card-title">Contest Readiness</h3>
            </div>
@@ -166,6 +166,25 @@
                 </table>
             </div>
             </div>
+            
+        <div class="card">
+           <div class="card-header">
+             <h3 class="card-title">Event Feed Reset</h3>
+           </div>
+        <div class="card-body">
+          <p>If the contest data has changed in an incompatible way that makes past events invalid (e.g. if .tsv config files
+          are manually changed after a contest has started), the event feed id can be reset to notify clients that they should
+          throw out any cached information and reconnect.</p>
+          <span id="reset-status">&nbsp;</span>
+          <form>
+            <div class="form-group">
+            <button id="reset" class="btn btn-primary form-control" onclick="sendIdResetCommand()">
+                Reset
+            </button>
+            </div>
+            </form>
+        </div>
+        </div>
         </div>
 
         <div class="col-3">
@@ -362,7 +381,7 @@
         xmlhttp.open("GET", "<%= webroot %>/admin/status", true);
         xmlhttp.send();
     }
-    
+
     function sendFinalizeCommand(id, command) {
         document.getElementById(id).disabled = true;
 
@@ -387,6 +406,35 @@
             document.getElementById(id).disabled = false;
         };
         xmlhttp.open("PUT", "<%= webroot %>/admin/finalize/" + command, true);
+        xmlhttp.send();
+    }
+
+    function sendIdResetCommand() {
+    	var id = "reset";
+        document.getElementById(id).disabled = true;
+
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function () {
+            document.getElementById("reset-status").innerHTML = "Resetting...";
+            if (xmlhttp.readyState == 4) {
+                var resp = xmlhttp.responseText;
+                if (xmlhttp.status == 200) {
+                    if (resp == null || resp.trim().length == 0)
+                        targetTime = null;
+                    else
+                        targetTime = parseInt(resp) / 1000.0;
+                    document.getElementById("reset-status").innerHTML = "Event feed successfully reset";
+                } else
+                    document.getElementById("reset-status").innerHTML = resp;
+                document.getElementById(id).disabled = false;
+            }
+        };
+        xmlhttp.timeout = 10000;
+        xmlhttp.ontimeout = function () {
+            document.getElementById("status").innerHTML = "Request timed out";
+            document.getElementById(id).disabled = false;
+        };
+        xmlhttp.open("PUT", "<%= webroot %>/admin/reset-feed/", true);
         xmlhttp.send();
     }
 

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -121,7 +121,10 @@ public class ContestWebService extends HttpServlet {
 					return;
 				}
 
-				if (segments.length == 4) {
+				if (segments.length == 3) {
+					if (segments[2].equals("reset-feed"))
+						ContestFeedService.reset(response, cc);
+				} else if (segments.length == 4) {
 					String command = segments[3];
 					if (segments[2].equals("time"))
 						StartTimeService.doPut(response, command, cc);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -168,10 +168,10 @@ public class RESTContestSource extends DiskContestSource {
 		File logFolder = new File("logs");
 		if (!logFolder.exists())
 			logFolder.mkdir();
-		feedCacheFile = new File(logFolder, "events-" + getRemoteContestId() + ".log");
+		feedCacheFile = new File(logFolder, "events-" + getRemoteContestId() + "-" + getUser() + ".log");
 		if (feedCacheFile.exists()) {
-			// delete if older than 6h
-			if (feedCacheFile.lastModified() < System.currentTimeMillis() - 6 * 60 * 60 * 1000) {
+			// delete if older than 8h
+			if (feedCacheFile.lastModified() < System.currentTimeMillis() - 8 * 60 * 60 * 1000) {
 				feedCacheFile.delete();
 			}
 		}


### PR DESCRIPTION
Add admin button to reset event feed (changes the prefix via the hacky hash file support that's already there) and make the local contest cache base on user id to avoid crossing roles