### PR TITLE
Remove solution awards

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IAward.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAward.java
@@ -34,11 +34,10 @@ public interface IAward extends IContestObject {
 	AwardType GROUP = new AwardType("Group Winner", "group-winner-.*");
 	AwardType ORGANIZATION = new AwardType("Organization Winner", "organization-winner-.*");
 	AwardType GROUP_HIGHLIGHT = new AwardType("Group Highlight", "group-highlight-.*");
-	AwardType SOLUTION = new AwardType("Solution", "solution-.*");
 	AwardType OTHER = new AwardType("Other", ".*");
 
-	AwardType[] KNOWN_TYPES = new AwardType[] { WINNER, RANK, MEDAL, FIRST_TO_SOLVE, GROUP,
-			ORGANIZATION, GROUP_HIGHLIGHT, SOLUTION, OTHER };
+	AwardType[] KNOWN_TYPES = new AwardType[] { WINNER, RANK, MEDAL, FIRST_TO_SOLVE, GROUP, ORGANIZATION,
+			GROUP_HIGHLIGHT, OTHER };
 
 	/**
 	 * Returns the ids of the teams that this award is for.

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -131,8 +131,7 @@ public class AwardUtil {
 			}
 		}
 
-		contest.add(
-				new Award(IAward.GROUP_HIGHLIGHT, groupId2, teamIds.toArray(new String[0]), citation, show));
+		contest.add(new Award(IAward.GROUP_HIGHLIGHT, groupId2, teamIds.toArray(new String[0]), citation, show));
 	}
 
 	public static void createFirstPlaceAward(Contest contest, String citation) {
@@ -259,24 +258,6 @@ public class AwardUtil {
 		return num;
 	}
 
-	protected static void createSolutionAwards(Contest contest) {
-		ITeam[] teams = contest.getOrderedTeams();
-		if (teams.length == 0)
-			return;
-
-		int lastBronze = getLastBronze(contest);
-
-		for (int i = 0; i < lastBronze; i++) {
-			ITeam team = teams[i];
-			IStanding s = contest.getStanding(team);
-			if (s.getNumSolved() == 1)
-				contest.add(new Award(IAward.SOLUTION, i + 1, team.getId(), Messages.getString("awardSolvedOne"), false));
-			else if (s.getNumSolved() > 1)
-				contest.add(new Award(IAward.SOLUTION, i + 1, team.getId(),
-						Messages.getString("awardSolvedMultiple").replace("{0}", s.getNumSolved() + ""), false));
-		}
-	}
-
 	public static void createDefaultAwards(Contest contest) {
 		createWorldFinalsAwards(contest);
 	}
@@ -293,8 +274,6 @@ public class AwardUtil {
 		int silver = Math.min(4, Math.max(numTeams - 4, 0));
 		int bronze = Math.min(4 + b, Math.max(numTeams - 8, 0));
 		createMedalAwards(contest, gold, silver, bronze);
-
-		createSolutionAwards(contest);
 
 		createFirstToSolveAwards(contest, false, true);
 

--- a/Resolver/src/org/icpc/tools/resolver/awards/WorldFinalsAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/WorldFinalsAwardDialog.java
@@ -29,7 +29,7 @@ public class WorldFinalsAwardDialog extends AbstractAwardDialog {
 
 	@Override
 	protected AwardType[] getAwardTypes() {
-		return new AwardType[] { IAward.WINNER, IAward.FIRST_TO_SOLVE, IAward.GROUP, IAward.MEDAL, IAward.SOLUTION };
+		return new AwardType[] { IAward.WINNER, IAward.FIRST_TO_SOLVE, IAward.GROUP, IAward.MEDAL };
 	}
 
 	@Override


### PR DESCRIPTION
The solution awards were 'non standard', didn't really mean anything, and always showed up as a difference when compared to DOMjudge. I've removed the award type and stopped generating them in both the CDS & award util. To avoid change in behaviour I did change the resolver so that if there are solution awards it'll show them, and if there aren't it'll show the number of problems solved for all teams that received a medal (which is all the solution award was anyway).