### PR TITLE
Fix for display_name, NAC floor generator

### DIFF
--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -226,10 +226,7 @@ public class JsonToTSVConverter {
 				System.err.println("Team with no group: " + team.id + " - " + team.name);
 			fw.write("\t");
 			if (inst != null) {
-				if (FINALS_NAMING)
-					fw.write(inst.name);
-				else
-					fw.write(team.name);
+				fw.write(team.name);
 				fw.write("\t");
 				fw.write(inst.name);
 				fw.write("\t");
@@ -264,11 +261,7 @@ public class JsonToTSVConverter {
 			fw.write("\t");
 
 			if (inst != null) {
-				if (FINALS_NAMING)
-					fw.write(inst.name);
-				else
-					fw.write(team.name);
-
+				fw.write(team.name);
 				fw.write("\t");
 				fw.write(inst.name);
 				fw.write("\t");
@@ -600,13 +593,13 @@ public class JsonToTSVConverter {
 		for (JsonObject result : arr.getValuesAs(JsonObject.class)) {
 			// String name = team.getString("name");
 			// String cId = result.getInt("externalContestId") + "";
-
+		
 			// String rank = result.getInt("rank") + "";
 			// String problemssolved = result.getInt("problemssolved") + "";
 			// String totaltime = result.getInt("totaltime") + "";
 			// String lastproblemtime = result.getInt("lastproblemtime") + "";
 			// CMSTeam t = getTeam(tId);
-
+		
 			// System.out.println(id + " " + cId + " " + rank + " " + contestIdList.contains(cId));
 		}*/
 	}
@@ -740,7 +733,7 @@ public class JsonToTSVConverter {
 				for (JsonObject member : teamMembers.getValuesAs(JsonObject.class)) {
 					String firstName = member.getString("firstName");
 					String lastName = member.getString("lastName");
-
+				
 					CMSMember m = getMember(firstName, lastName);
 					m.role = member.getString("teamRole");
 					m.team = t;

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC.java
@@ -9,6 +9,7 @@ import org.icpc.tools.contest.model.FloorMap;
 import org.icpc.tools.contest.model.FloorMap.Path;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.internal.Printer;
+import org.icpc.tools.contest.model.internal.Team;
 
 public class FloorGeneratorNAC extends FloorGenerator {
 	// table width (in meters). ICPC standard is 1.8
@@ -123,6 +124,12 @@ public class FloorGeneratorNAC extends FloorGenerator {
 				floor.createBalloon(balloon.charAt(i) + "", bx + i * 2, -8);
 
 			Printer p = floor.createPrinter(25, 5);
+
+			// fix teams
+			((Team) floor.getTeam(54)).add("id", "<-1>");
+			((Team) floor.getTeam(61)).add("id", "<-1>");
+			((Team) floor.getTeam(62)).add("id", "<-1>");
+			((Team) floor.getTeam(63)).add("id", "<-1>");
 
 			floor.rotate(-90);
 


### PR DESCRIPTION
Remove 'finals hack' from teams.tsv and teams2.tsv, these files should always contain the real team name. Fix to NAC floor generator to match missing team and extra desks