### PR TITLE
Support for team tool usage data

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -36,6 +36,13 @@ import org.icpc.tools.contest.model.internal.Team;
 import org.icpc.tools.contest.model.internal.TeamMember;
 
 public class PlaybackContest extends Contest {
+	private static final String LOGO = "logo";
+	private static final String PHOTO = "photo";
+	private static final String VIDEO = "video";
+	private static final String BANNER = "banner";
+	private static final String FILES = "files";
+	private static final String REACTION = "reaction";
+
 	protected ConfiguredContest cc;
 	protected String contestId;
 	protected boolean recordReactions;
@@ -131,19 +138,19 @@ public class PlaybackContest extends Contest {
 			return;
 
 		if (obj instanceof Info) {
-			downloadMissingFiles(src, obj, "logo", (o) -> ((Info) o).getLogo());
-			downloadMissingFiles(src, obj, "banner", (o) -> ((Info) o).getBanner());
+			downloadMissingFiles(src, obj, LOGO, (o) -> ((Info) o).getLogo());
+			downloadMissingFiles(src, obj, BANNER, (o) -> ((Info) o).getBanner());
 		} else if (obj instanceof Team) {
-			downloadMissingFiles(src, obj, "photo", (o) -> ((Team) o).getPhoto());
-			downloadMissingFiles(src, obj, "video", (o) -> ((Team) o).getVideo());
+			downloadMissingFiles(src, obj, PHOTO, (o) -> ((Team) o).getPhoto());
+			downloadMissingFiles(src, obj, VIDEO, (o) -> ((Team) o).getVideo());
 			// downloadMissingFiles(contest, src, obj, "backup", (o) -> ((Team) o).getBackup());
 		} else if (obj instanceof TeamMember) {
-			downloadMissingFiles(src, obj, "photo", (o) -> ((TeamMember) o).getPhoto());
+			downloadMissingFiles(src, obj, PHOTO, (o) -> ((TeamMember) o).getPhoto());
 		} else if (obj instanceof Organization) {
-			downloadMissingFiles(src, obj, "logo", (o) -> ((Organization) o).getLogo());
+			downloadMissingFiles(src, obj, LOGO, (o) -> ((Organization) o).getLogo());
 		} else if (obj instanceof Submission) {
-			downloadMissingFiles(src, obj, "files", (o) -> ((Submission) o).getFiles());
-			downloadMissingFiles(src, obj, "reaction", (o) -> ((Submission) o).getReaction());
+			downloadMissingFiles(src, obj, FILES, (o) -> ((Submission) o).getFiles());
+			downloadMissingFiles(src, obj, REACTION, (o) -> ((Submission) o).getReaction());
 		}
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
@@ -93,6 +93,13 @@ public interface ITeam extends IContestObject, IPosition {
 	File getKeyLog(boolean force);
 
 	/**
+	 * The tool usage data.
+	 *
+	 * @return the tool usage data file
+	 */
+	File getToolData(boolean force);
+
+	/**
 	 * The desktop stream.
 	 *
 	 * @return the desktop stream

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -51,6 +51,16 @@ public class DiskContestSource extends ContestSource {
 	private static final String CACHE_VERSION = "ICPC Tools Cache v1.0";
 	private static final Map<String, List<FileReference>> cache = new HashMap<>();
 
+	private static final String LOGO = "logo";
+	private static final String PHOTO = "photo";
+	private static final String VIDEO = "video";
+	private static final String BANNER = "banner";
+	private static final String BACKUP = "backup";
+	private static final String KEY_LOG = "key_log";
+	private static final String TOOL_DATA = "tool_data";
+	private static final String FILES = "files";
+	private static final String REACTION = "reaction";
+
 	private File root;
 	private boolean isCache;
 	private String contestId;
@@ -709,40 +719,43 @@ public class DiskContestSource extends ContestSource {
 		String reg = ""; // "registration" + File.separator;
 		String events = ""; // "events" + File.separator;
 		if (obj instanceof Info) {
-			if ("banner".equals(property))
-				return new String[] { "config", "banner{0}.png", "banner{0}" };
-			else if ("logo".equals(property))
+			if (LOGO.equals(property))
 				return new String[] { "config", "logo{0}.png", "logo{0}" };
+			if (BANNER.equals(property))
+				return new String[] { "config", "banner{0}.png", "banner{0}" };
 		} else if (obj instanceof Team) {
-			if ("photo".equals(property))
+			if (PHOTO.equals(property))
 				return new String[] { reg + "teams" + File.separator + obj.getId(), "photo{0}.jpg",
 						"teams/" + obj.getId() + "/photo{0}" };
-			if ("video".equals(property))
+			if (VIDEO.equals(property))
 				return new String[] { reg + "teams" + File.separator + obj.getId(), "video.m2ts",
 						"teams/" + obj.getId() + "/video" };
-			if ("backup".equals(property))
+			if (BACKUP.equals(property))
 				return new String[] { reg + "teams" + File.separator + obj.getId(), "backup.zip",
 						"teams/" + obj.getId() + "/backup" };
-			if ("logkeys".equals(property))
-				return new String[] { reg + "teams" + File.separator + obj.getId(), "logkeys.txt",
-						"teams/" + obj.getId() + "/logkeys" };
+			if (KEY_LOG.equals(property))
+				return new String[] { reg + "teams" + File.separator + obj.getId(), "keys.log",
+						"teams/" + obj.getId() + "/keylog" };
+			if (TOOL_DATA.equals(property))
+				return new String[] { reg + "teams" + File.separator + obj.getId(), "tools.txt",
+						"teams/" + obj.getId() + "/tooldata" };
 		} else if (obj instanceof TeamMember) {
-			if ("photo".equals(property))
+			if (PHOTO.equals(property))
 				return new String[] { reg + "team-members" + File.separator + obj.getId(), "photo{0}.jpg",
 						"team-members/" + obj.getId() + "/photo{0}" };
 		} else if (obj instanceof Organization) {
-			if ("logo".equals(property))
+			if (LOGO.equals(property))
 				return new String[] { reg + "organizations" + File.separator + obj.getId(), "logo{0}.png",
 						"organizations/" + obj.getId() + "/logo{0}" };
 		} else if (obj instanceof Submission) {
-			if ("files".equals(property))
+			if (FILES.equals(property))
 				return new String[] { events + "submissions" + File.separator + obj.getId(), "files.zip",
 						"submissions/" + obj.getId() + "/files" };
-			if ("reaction".equals(property))
+			if (REACTION.equals(property))
 				return new String[] { events + "submissions" + File.separator + obj.getId(), "reaction.m2ts",
 						"submissions/" + obj.getId() + "/reaction" };
 		} else if (obj instanceof Group) {
-			if ("logo".equals(property))
+			if (LOGO.equals(property))
 				return new String[] { reg + "groups" + File.separator + obj.getId(), "logo{0}.png",
 						"groups/" + obj.getId() + "/logo{0}" };
 		}
@@ -752,27 +765,28 @@ public class DiskContestSource extends ContestSource {
 	public void attachLocalResources(IContestObject obj) {
 		if (obj instanceof Info) {
 			Info info = (Info) obj;
-			info.setBanner(getFilesWithPattern(obj, "banner"));
-			info.setLogo(getFilesWithPattern(obj, "logo"));
+			info.setLogo(getFilesWithPattern(obj, LOGO));
+			info.setBanner(getFilesWithPattern(obj, BANNER));
 		} else if (obj instanceof Organization) {
 			Organization org = (Organization) obj;
-			org.setLogo(getFilesWithPattern(obj, "logo"));
+			org.setLogo(getFilesWithPattern(obj, LOGO));
 		} else if (obj instanceof Team) {
 			Team team = (Team) obj;
-			team.setPhoto(getFilesWithPattern(obj, "photo"));
-			team.setVideo(getFilesWithPattern(obj, "video"));
-			team.setBackup(getFilesWithPattern(obj, "backup"));
-			team.setKeyLog(getFilesWithPattern(obj, "logkeys"));
+			team.setPhoto(getFilesWithPattern(obj, PHOTO));
+			team.setVideo(getFilesWithPattern(obj, VIDEO));
+			team.setBackup(getFilesWithPattern(obj, BACKUP));
+			team.setKeyLog(getFilesWithPattern(obj, KEY_LOG));
+			team.setToolData(getFilesWithPattern(obj, TOOL_DATA));
 		} else if (obj instanceof TeamMember) {
 			TeamMember member = (TeamMember) obj;
-			member.setPhoto(getFilesWithPattern(obj, "photo"));
+			member.setPhoto(getFilesWithPattern(obj, PHOTO));
 		} else if (obj instanceof Submission) {
 			Submission submission = (Submission) obj;
-			submission.setFiles(getFilesWithPattern(obj, "files"));
-			submission.setReaction(getFilesWithPattern(obj, "reaction"));
+			submission.setFiles(getFilesWithPattern(obj, FILES));
+			submission.setReaction(getFilesWithPattern(obj, REACTION));
 		} else if (obj instanceof Group) {
 			Group group = (Group) obj;
-			group.setLogo(getFilesWithPattern(obj, "logo"));
+			group.setLogo(getFilesWithPattern(obj, LOGO));
 		}
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -29,7 +29,8 @@ public class Team extends ContestObject implements ITeam {
 	private static final String DESKTOP = "desktop";
 	private static final String WEBCAM = "webcam";
 	private static final String AUDIO = "audio";
-	private static final String KEY_LOG = "keylog";
+	private static final String KEY_LOG = "key_log";
+	private static final String TOOL_DATA = "tool_data";
 
 	private String name;
 	private String displayName;
@@ -46,6 +47,7 @@ public class Team extends ContestObject implements ITeam {
 	private FileReferenceList audio;
 	private FileReferenceList backup;
 	private FileReferenceList keylog;
+	private FileReferenceList tooldata;
 
 	@Override
 	public ContestType getType() {
@@ -152,6 +154,19 @@ public class Team extends ContestObject implements ITeam {
 		keylog = list;
 	}
 
+	public FileReferenceList getToolData() {
+		return tooldata;
+	}
+
+	@Override
+	public File getToolData(boolean force) {
+		return getFile(getBestFileReference(tooldata, null), TOOL_DATA, force);
+	}
+
+	public void setToolData(FileReferenceList list) {
+		tooldata = list;
+	}
+
 	public void setVideo(FileReferenceList list) {
 		video = list;
 	}
@@ -206,7 +221,7 @@ public class Team extends ContestObject implements ITeam {
 
 	@Override
 	public Object resolveFileReference(String url) {
-		return FileReferenceList.resolve(url, photo, video, backup, desktop, webcam, audio, keylog);
+		return FileReferenceList.resolve(url, photo, video, backup, desktop, webcam, audio, keylog, tooldata);
 	}
 
 	@Override
@@ -274,6 +289,14 @@ public class Team extends ContestObject implements ITeam {
 				backup = new FileReferenceList(value);
 				return true;
 			}
+			case KEY_LOG: {
+				keylog = new FileReferenceList(value);
+				return true;
+			}
+			case TOOL_DATA: {
+				tooldata = new FileReferenceList(value);
+				return true;
+			}
 			case DESKTOP: {
 				desktop = new FileReferenceList(value);
 				return true;
@@ -298,6 +321,8 @@ public class Team extends ContestObject implements ITeam {
 		t.photo = photo;
 		t.video = video;
 		t.backup = backup;
+		t.keylog = keylog;
+		t.tooldata = tooldata;
 		t.desktop = desktop;
 		t.webcam = webcam;
 		t.audio = audio;
@@ -325,6 +350,8 @@ public class Team extends ContestObject implements ITeam {
 		props.put(PHOTO, photo);
 		props.put(VIDEO, video);
 		props.put(BACKUP, backup);
+		props.put(KEY_LOG, keylog);
+		props.put(TOOL_DATA, tooldata);
 		props.put(DESKTOP, desktop);
 		props.put(WEBCAM, webcam);
 		props.put(AUDIO, audio);
@@ -356,6 +383,8 @@ public class Team extends ContestObject implements ITeam {
 		je.encode(PHOTO, photo, false);
 		je.encode(VIDEO, video, false);
 		je.encode(BACKUP, backup, false);
+		je.encode(KEY_LOG, keylog, false);
+		je.encode(TOOL_DATA, tooldata, false);
 		je.encodeSubs(DESKTOP, desktop, false);
 		je.encodeSubs(WEBCAM, webcam, false);
 		je.encodeSubs(AUDIO, audio, false);


### PR DESCRIPTION
Odds seem pretty high that in a couple days we'll suddenly be asked to support live tool data requests at NAC, at a point where I won't have the bandwidth to commit. Cleaning up some of the contest resource loading code, minor fixes to key logs, and adding tentative support for tool data.