### PR TITLE
Automatic presentation switching

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -14,6 +14,7 @@ import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.websocket.Session;
 
+import org.icpc.tools.cds.presentations.PresentationServer;
 import org.icpc.tools.cds.util.PlaybackContest;
 import org.icpc.tools.cds.util.Role;
 import org.icpc.tools.cds.video.VideoAggregator;
@@ -41,6 +42,7 @@ import org.icpc.tools.contest.model.feed.EventFeedContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.feed.Timestamp;
 import org.icpc.tools.contest.model.internal.Contest;
+import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.State;
 import org.w3c.dom.Element;
@@ -595,14 +597,15 @@ public class ConfiguredContest {
 				if (obj2 == null)
 					return;
 
+				long time = ContestObject.getContestTime(obj);
+				PresentationServer.getInstance().onTime(time);
+
 				// all - don't show any submissions or judgements from outside the contest
 				// public - show judgments until the freeze, only public clars, no runs
 				// balloon - show judgments until the freeze and then any after if the
 				// team has less than 3, only public clars, no runs
 				// trusted - show runs & judgments until the freeze, show all clars
 				if (obj instanceof ISubmission) {
-					ISubmission s = (ISubmission) obj;
-					int time = s.getContestTime();
 					if (time >= 0 && time < contest.getDuration()) {
 						trustedContest.add(obj2);
 						balloonContest.add(obj2);

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
@@ -1009,5 +1009,37 @@ public class View {
 				}
 			}
 		});
+
+		MenuItem timeSubmenu = new MenuItem(submenu, SWT.CASCADE);
+		timeSubmenu.setText("Set &Timed Presentation");
+		// submenu.setMenu(timeSubmenu);
+
+		submenu = new Menu(shell, SWT.DROP_DOWN);
+		timeSubmenu.setMenu(submenu);
+
+		for (int i = 0; i < 10; i++) {
+			final MenuItem timePres0Menu = new MenuItem(submenu, SWT.PUSH);
+			final int min = i * 30;
+			timePres0Menu.setText(min + " min contest time");
+			timePres0Menu.setToolTipText("Set a presentation to show at the given contest time");
+			registerAction(timePres0Menu, new ClientAction() {
+				@Override
+				public boolean isEnabled() {
+					return getSelectedClients() != null && getSelectedClients().length > 0
+							&& getSelectedPresentation() != null;
+				}
+
+				@Override
+				public void run() throws Exception {
+					PresentationInfo info = getSelectedPresentation();
+					String s = info.getClassName();
+					long timeMs = min * 60 * 1000;
+					writeProperty("time:" + timeMs + ":presentation", "1000|" + s);
+					if (propCombo.getText().length() > 0) {
+						writeProperty("time:" + timeMs + ":" + getPresentationKey(info.getClassName()), propCombo.getText());
+					}
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
This change is a first pass at automatically switching presentations at a given contest time. It adds support in the admin UI for assigning a presentation at a given contest time, and the presentation server support for managing and firing these as events later on.
This change forgets the settings if the CDS has to be restarted. It waits for the first contest event after the given time (should have a real timer). It's simplistic. There's no way to see what you've set or clear it. However, I believe this is the minimum change set to try this out in sysops at the NAC and start to talk about whether it's a good thing or not, and if so how it should fit into the UI better.