### PR TITLE
id was renamed to name post pacNW, but this change got missed

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/present.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/present.jsp
@@ -181,7 +181,7 @@
 
             // sort
             clients.sort(function (a, b) {
-                return a.id.localeCompare(b.id);
+                return a.name.localeCompare(b.name);
             });
 
             var map = new Map();


### PR DESCRIPTION
You get this JS error on the presentation admin otherwise:
![image](https://user-images.githubusercontent.com/672279/74794009-058b3980-5290-11ea-9c27-b347790a350a.png)
