### PR TITLE
Base64 encoding for client logs

### DIFF
--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,7 +147,8 @@ public class View {
 			@Override
 			protected void handleLogResponse(JsonObject obj) throws IOException {
 				int sourceUID = getUID(obj, "source");
-				clientsControl.handleLog(sourceUID, obj.getString("data"));
+				byte[] b = Base64.getDecoder().decode(obj.getString("data"));
+				clientsControl.handleLog(sourceUID, new String(b));
 			}
 
 			@Override

--- a/PresCore/src/org/icpc/tools/client/core/BasicClient.java
+++ b/PresCore/src/org/icpc/tools/client/core/BasicClient.java
@@ -365,7 +365,7 @@ public class BasicClient {
 		createJSON(Type.LOG, je -> {
 			je.encode("source", Integer.toHexString(uid));
 			je.encode("target", Integer.toHexString(toUID));
-			je.encode("data", Trace.getLogContents2());
+			je.encode("data", Base64.getEncoder().encodeToString(Trace.getLogContents2().getBytes()));
 		});
 	}
 


### PR DESCRIPTION
At the NAC I couldn't pull a client log from the admin. Logs didn't show the entire problem, but really highly likely it was caused by transfer parsing failure due to not encoding the logs during transfer over JSON, so fixing that here.