### PR TITLE
Resolver org logo side screen

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
@@ -3,6 +3,8 @@ package org.icpc.tools.contest.model;
 import java.awt.image.BufferedImage;
 import java.io.File;
 
+import org.icpc.tools.contest.model.internal.FileReferenceList;
+
 /**
  * An organization.
  */
@@ -69,6 +71,14 @@ public interface IOrganization extends IContestObject {
 	 * @return the longitude
 	 */
 	double getLongitude();
+
+	/**
+	 * The file references for the logo, which clients can use to see exactly what resolutions of
+	 * logos are available.
+	 *
+	 * @return the file reference list
+	 */
+	FileReferenceList getLogo();
 
 	/**
 	 * The logo of the organization.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -97,6 +97,7 @@ public class Organization extends ContestObject implements IOrganization {
 		return getRefImage(LOGO, logo, width, height, forceLoad, resizeToFit);
 	}
 
+	@Override
 	public FileReferenceList getLogo() {
 		return logo;
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/Animator2D.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/Animator2D.java
@@ -19,6 +19,11 @@ public class Animator2D {
 		yAnim = new Animator(p.getY(), yMove);
 	}
 
+	public Animator2D(double x, Movement xMove, double y, Movement yMove) {
+		xAnim = new Animator(x, xMove);
+		yAnim = new Animator(y, yMove);
+	}
+
 	public void incrementTimeMs(long dt) {
 		xAnim.incrementTimeMs(dt);
 		yAnim.incrementTimeMs(dt);
@@ -33,9 +38,18 @@ public class Animator2D {
 		yAnim.reset(p.getY());
 	}
 
+	public void resetToTarget() {
+		xAnim.resetToTarget();
+		yAnim.resetToTarget();
+	}
+
 	public void setTarget(Point2D p) {
-		xAnim.setTarget(p.getX());
-		yAnim.setTarget(p.getY());
+		setTarget(p.getX(), p.getY());
+	}
+
+	public void setTarget(double x, double y) {
+		xAnim.setTarget(x);
+		yAnim.setTarget(y);
 
 		double xTime = xAnim.getMoveTime();
 		double yTime = yAnim.getMoveTime();
@@ -45,5 +59,13 @@ public class Animator2D {
 			else
 				xAnim.setTimeScale(xTime / yTime);
 		}
+	}
+
+	public double getXTarget() {
+		return xAnim.getTarget();
+	}
+
+	public double getYTarget() {
+		return yAnim.getTarget();
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/Animator3D.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/Animator3D.java
@@ -60,4 +60,16 @@ public class Animator3D {
 		if (zTime != 0)
 			zAnim.setTimeScale(zTime / max);
 	}
+
+	public double getXTarget() {
+		return xAnim.getTarget();
+	}
+
+	public double getYTarget() {
+		return yAnim.getTarget();
+	}
+
+	public double getZTarget() {
+		return zAnim.getTarget();
+	}
 }

--- a/Resolver/src/org/icpc/tools/resolver/OrgsPresentation.java
+++ b/Resolver/src/org/icpc/tools/resolver/OrgsPresentation.java
@@ -1,0 +1,271 @@
+package org.icpc.tools.resolver;
+
+import java.awt.AlphaComposite;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IOrganization;
+import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.internal.FileReference;
+import org.icpc.tools.contest.model.internal.FileReferenceList;
+import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
+import org.icpc.tools.presentation.contest.internal.Animator;
+import org.icpc.tools.presentation.contest.internal.Animator.Movement;
+import org.icpc.tools.presentation.contest.internal.Animator3D;
+import org.icpc.tools.presentation.contest.internal.ICPCColors;
+import org.icpc.tools.presentation.contest.internal.scoreboard.AbstractScoreboardPresentation.SelectType;
+
+public class OrgsPresentation extends AbstractICPCPresentation {
+	protected static final Movement SIZE_MOVEMENT = new Movement(30, 30);
+	protected static final Movement FADE_MOVEMENT = new Movement(220, 220);
+
+	private Map<String, BufferedImage> map = new HashMap<>();
+	private Map<String, Animator3D> anim = new HashMap<>();
+	private Animator sizeAnim = new Animator(25.0, SIZE_MOVEMENT);
+	private int numTeams = Integer.MAX_VALUE;
+	private int lastImgSize;
+	private SelectType selectType = SelectType.NORMAL;
+	private List<ITeam> selectedTeams = null;
+
+	private void setTargets() {
+		IContest contest = getContest();
+		if (contest == null)
+			return;
+
+		if (numTeams == 0 || width == 0 || height == 0)
+			return;
+
+		// find size
+		int size = (int) (Math.sqrt(width * height / numTeams) * 1.0);
+
+		int num2 = width / size * (height / size) - ((height / size) / 2);
+		while (num2 < numTeams && size > 5) {
+			size--;
+			num2 = (width / size) * (height / size) - ((height / size) / 2);
+		}
+		sizeAnim.setTarget(size * 0.9);
+
+		int dx = (width - (width / size) * size + size) / 2;
+		int dy = (height - (height / size) * size + size) / 2;
+
+		int i = dx;
+		int j = dy;
+		boolean oddRow = false;
+		ITeam[] teams = contest.getOrderedTeams();
+		int count = 0;
+		for (int ii = 0; ii < teams.length; ii++) {
+			Animator3D an = anim.get(teams[ii].getId());
+			if (count >= numTeams) {
+				an.setTarget(an.getXTarget(), an.getYTarget(), 0);
+				continue;
+			}
+			count++;
+
+			an.setTarget(i, j, 255);
+			i += size;
+			if (i > width - size / 2) {
+				i = dx;
+				if (!oddRow)
+					i += size / 2;
+
+				oddRow = !oddRow;
+				j += size;
+			}
+		}
+	}
+
+	@Override
+	public void setContest(IContest newContest) {
+		super.setContest(newContest);
+
+		if (anim.isEmpty()) {
+			Dimension d = getSize();
+			double mx = Math.min(d.width, d.height) / 10.0;
+			mx = 250;
+			Movement mov = new Movement(mx, mx);
+
+			ITeam[] teams = newContest.getOrderedTeams();
+			for (ITeam team : teams) {
+				anim.put(team.getId(), new Animator3D(0, mov, 0, mov, 0, FADE_MOVEMENT));
+			}
+
+			numTeams = teams.length + 1;
+		}
+		setTargets();
+	}
+
+	public void setSelectedTeams(List<ITeam> teams, SelectType type) {
+		selectType = type;
+		selectedTeams = teams;
+
+		if (selectedTeams == null)
+			return;
+
+		int last = 0;
+		ITeam[] ordTeams = getContest().getOrderedTeams();
+		for (int i = 0; i < ordTeams.length; i++) {
+			if (teams.contains(ordTeams[i]))
+				last = i;
+		}
+		if (last > 0)
+			numTeams = last + 1;
+
+		setTargets();
+	}
+
+	@Override
+	public void aboutToShow() {
+		IContest contest = getContest();
+		if (contest == null)
+			return;
+
+		IOrganization[] orgs = contest.getOrganizations();
+		if (orgs.length == 0)
+			return;
+
+		// set initial positions
+		setTargets();
+
+		if (sizeAnim.getValue() == 0)
+			sizeAnim.resetToTarget();
+
+		loadLogos();
+	}
+
+	protected void loadLogos() {
+		IContest contest = getContest();
+		if (contest == null)
+			return;
+
+		// load logo images
+		int size2 = (int) (sizeAnim.getTarget() * 1.3);
+		if (lastImgSize == size2)
+			return;
+		lastImgSize = size2;
+
+		execute(new Runnable() {
+			@Override
+			public void run() {
+				ITeam[] teams = contest.getOrderedTeams();
+				for (int i = 0; i < teams.length; i++) {
+					ITeam team = teams[i];
+					IOrganization org = contest.getOrganizationById(team.getOrganizationId());
+					if (org == null)
+						continue;
+
+					BufferedImage img = map.get(org.getId());
+
+					// don't load a new image if we already have one and it is big enough or the team is
+					// already out
+					if (img != null && (img.getWidth() > size2 || img.getHeight() > size2 || i >= numTeams))
+						continue;
+
+					FileReference bestRef = null;
+					FileReferenceList list = org.getLogo();
+					if (list != null) {
+						for (FileReference ref : list) {
+							if (bestRef == null)
+								bestRef = ref;
+							else {
+								if (bestRef.width < width && bestRef.height < height) {
+									// current best image is too small - is this one better (larger than
+									// current)?
+									if (ref.width > bestRef.width || ref.height > bestRef.height)
+										bestRef = ref;
+								} else if (bestRef.width > width && bestRef.height > height) {
+									// current image is too big - is this one better (smaller but still big
+									// enough)?
+									if (ref.width < bestRef.width || ref.height < bestRef.height) {
+										if (ref.width >= width || ref.height >= height)
+											bestRef = ref;
+									}
+								}
+							}
+						}
+					}
+
+					if (bestRef != null) {
+						if (img == null || bestRef.width != img.getWidth() || bestRef.height != img.getHeight()) {
+							map.put(org.getId(), org.getLogoImage(bestRef.width, bestRef.height, true, false));
+							if (img != null)
+								img.flush();
+						}
+					}
+				}
+			}
+		});
+	}
+
+	@Override
+	public void incrementTimeMs(long dt) {
+		for (Animator3D an : anim.values())
+			an.incrementTimeMs(dt);
+
+		sizeAnim.incrementTimeMs(dt);
+
+		super.incrementTimeMs(dt);
+	}
+
+	@Override
+	public void setSize(Dimension d) {
+		super.setSize(d);
+
+		setTargets();
+	}
+
+	@Override
+	public void paint(Graphics2D g) {
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+
+		IContest contest = getContest();
+		if (contest == null)
+			return;
+
+		double size = sizeAnim.getValue();
+
+		ITeam[] teams = contest.getOrderedTeams();
+		for (int i = teams.length - 1; i >= 0; i--) {
+			ITeam team = teams[i];
+			IOrganization org = contest.getOrganizationById(team.getOrganizationId());
+			if (org == null)
+				continue;
+
+			BufferedImage img = map.get(org.getId());
+			if (img != null) {
+				Animator3D an = anim.get(team.getId());
+				if (an == null)
+					continue;
+
+				Graphics2D gg = (Graphics2D) g.create();
+				if ((selectedTeams != null && selectedTeams.contains(team))) {
+					if (selectType == SelectType.FTS || selectType == SelectType.FTS_HIGHLIGHT)
+						gg.setColor(ICPCColors.FIRST_TO_SOLVE_COLOR);
+					else
+						gg.setColor(ICPCColors.SELECTION_COLOR);
+
+					gg.fillRect((int) (an.getXValue() - size / 2) - 4, (int) (an.getYValue() - size / 2) - 4, (int) size + 8,
+							(int) size + 8);
+				}
+
+				int w = img.getWidth();
+				int h = img.getHeight();
+				double scale = Math.min(size / w, size / h);
+				int nw = (int) Math.round(w * scale);
+				int nh = (int) Math.round(h * scale);
+
+				if (an.getZValue() < 252)
+					gg.setComposite(AlphaComposite.SrcOver.derive((float) an.getZValue() / 255f));
+
+				gg.drawImage(img, (int) (an.getXValue() - nw / 2), (int) (an.getYValue() - nh / 2), nw, nh, null);
+				gg.dispose();
+			}
+		}
+	}
+}

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -266,7 +266,7 @@ public class Resolver {
 			// INCREASE
 			// the resolution speed; values greater than one DECREASE the speed; values <= zero are
 			// ignored.
-			ArgumentParser.expectOptions(option, options, "speedFactor:float");
+			ArgumentParser.expectOptions(option, options, "speed:float");
 			float fastVal = (float) options.get(0);
 			if (fastVal <= 0) {
 				// illegal value; ignore and use default
@@ -293,12 +293,15 @@ public class Resolver {
 			ArgumentParser.expectOptions(option, options, "#:int");
 			clicks = (int) options.get(0);
 		} else if ("--client".equalsIgnoreCase(option) || "--presenter".equalsIgnoreCase(option)
-				|| "--team".equalsIgnoreCase(option) || "--side".equalsIgnoreCase(option)) {
+				|| "--team".equalsIgnoreCase(option) || "--side".equalsIgnoreCase(option)
+				|| "--org".equalsIgnoreCase(option)) {
 			ArgumentParser.expectNoOptions(option, options);
 			if ("--presenter".equalsIgnoreCase(option))
 				isPresenter = true;
 			else if ("--team".equalsIgnoreCase(option))
 				screen = Screen.TEAM;
+			else if ("--org".equalsIgnoreCase(option))
+				screen = Screen.ORG;
 			else if ("--side".equalsIgnoreCase(option))
 				screen = Screen.SIDE;
 			else

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -65,7 +65,7 @@ public class ResolverUI {
 	}
 
 	public static enum Screen {
-		MAIN, TEAM, SIDE
+		MAIN, TEAM, SIDE, ORG
 	}
 
 	private static final String[] MESSAGES = new String[] { "John, click me!", "I'm waiting for you...",
@@ -99,6 +99,7 @@ public class ResolverUI {
 	private TeamListSidePresentation teamListSidePresentation;
 	private JudgePresentation2 judgePresentation;
 	private StaticLogoPresentation logoPresentation;
+	private OrgsPresentation orgPresentation;
 	private Presentation currentPresentation;
 
 	private long lastClickTime = -1;
@@ -222,7 +223,7 @@ public class ResolverUI {
 			}
 		};
 
-		if (screen == Screen.TEAM || screen == Screen.SIDE) {
+		if (screen == Screen.TEAM || screen == Screen.SIDE || screen == Screen.ORG) {
 			logoPresentation = new StaticLogoPresentation();
 			logoPresentation.addMouseListener(nullMouse);
 			splashPresentation = logoPresentation;
@@ -233,6 +234,11 @@ public class ResolverUI {
 
 				teamListSidePresentation = new TeamListSidePresentation();
 				teamListSidePresentation.addMouseListener(nullMouse);
+			}
+			if (screen == Screen.ORG) {
+				orgPresentation = new OrgsPresentation();
+				orgPresentation.setContest(contest);
+				orgPresentation.addMouseListener(nullMouse);
 			}
 		} else {
 			splashPresentation = new SplashPresentation();
@@ -410,7 +416,7 @@ public class ResolverUI {
 			return;
 
 		long[] startTime = new long[] { System.nanoTime() };
-		if (!includeDelays || screen != Screen.MAIN)
+		if (!includeDelays || (screen != Screen.MAIN && screen != Screen.ORG))
 			startTime = null;
 
 		if (listener != null) {
@@ -439,7 +445,7 @@ public class ResolverUI {
 			return;
 
 		long[] startTime = new long[] { System.nanoTime() };
-		if (!includeDelays || screen != Screen.MAIN)
+		if (!includeDelays || (screen != Screen.MAIN && screen != Screen.ORG))
 			startTime = null;
 
 		if (listener != null) {
@@ -497,6 +503,8 @@ public class ResolverUI {
 			awardPresentation.setContest(state.contest);
 			if (teamLogoPresentation != null)
 				teamLogoPresentation.setContest(state.contest);
+			if (orgPresentation != null)
+				orgPresentation.setContest(state.contest);
 		} else if (step instanceof PauseStep) {
 			PauseStep pause = (PauseStep) step;
 			return pause.num;
@@ -507,6 +515,8 @@ public class ResolverUI {
 		} else if (step instanceof TeamSelectionStep) {
 			TeamSelectionStep sel = (TeamSelectionStep) step;
 			scoreboardPresentation.setSelectedTeams(sel.teams, sel.type);
+			if (orgPresentation != null)
+				orgPresentation.setSelectedTeams(sel.teams, sel.type);
 		} else if (step instanceof SubmissionSelectionStep2) {
 			SubmissionSelectionStep2 sel = (SubmissionSelectionStep2) step;
 			judgePresentation.handleSubmission(sel.submissionId);
@@ -630,6 +640,8 @@ public class ResolverUI {
 				pres2 = teamListSidePresentation;
 			if (pres == awardPresentation)
 				pres2 = teamLogoPresentation;
+		} else if (screen == Screen.ORG) {
+			pres2 = orgPresentation;
 		}
 
 		if (currentPresentation == pres2)


### PR DESCRIPTION
Someone suggested another 'side-screen' for the resolver that would show all of the team logos on screen, and slowly fade each one out as they were resolved until you got to the winner. I actually wrote this on the way to NAC, but finally got it tidied up now. As logos are removed it automatically scales the remaining ones up to fit the screen.
This change required one 'internal' method on IOrganization so that the presentation can see exactly which logo sizes are available and know when to grab the next size up. This should probably be exposed differently (likely public interface for FileReferenceList?) but I thought it was ok for now.