### PR TITLE
Sanitize contest data in html

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/details.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details.jsp
@@ -1,5 +1,6 @@
 <%@ page import="java.util.List" %>
 <%@ page import="org.icpc.tools.contest.model.*" %>
+<%@ page import="org.icpc.tools.cds.util.HttpHelper" %>
 <% request.setAttribute("title", "Details"); %>
 <%@ include file="layout/head.jsp" %>
 <% IState state = contest.getState(); %>
@@ -23,7 +24,7 @@
                         <tbody>
                             <tr>
                                 <td><b>Name:</b></td>
-                                <td><%= contest.getName() %></td>
+                                <td><%= HttpHelper.sanitizeHTML(contest.getName()) %></td>
                                 <td><b>Start:</b></td>
                                 <td><%= ContestUtil.formatStartTime(contest) %></td>
                             </tr>

--- a/CDS/WebContent/WEB-INF/jsps/details/awards.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/awards.jsp
@@ -43,7 +43,7 @@
                 if (t != null)
                     teamsStr += t.name;
             }
-            return $('<td><a href="<%= apiRoot %>/awards/' + award.id + '">' + award.id + '</td><td>' + award.citation + '</td><td>' + teamsStr + '</td>');
+            return $('<td><a href="<%= apiRoot %>/awards/' + award.id + '">' + award.id + '</td><td>' + sanitizeHTML(award.citation) + '</td><td>' + teamsStr + '</td>');
         }
 
         $.when(contest.loadAwards(), contest.loadTeams()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/clarifications.jsp
@@ -66,7 +66,7 @@
 
             return $('<td><a href="<%= apiRoot %>/clarifications/' + clar.id + '">' + clar.id + '</a></td>' +
                 '<td>' + time + '</td><td>' + problem + '</td><td>' + fromTeam + '</td>' +
-                '<td>' + toTeam + '</td><td class="pre-line">' + clar.text + '</td>');
+                '<td>' + toTeam + '</td><td class="pre-line">' + sanitizeHTML(clar.text) + '</td>');
         }
 
         $.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/groups.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/groups.jsp
@@ -43,7 +43,7 @@
             if (group.hidden != null)
                 hidden = "true";
             return $('<td><a href="<%= apiRoot %>/groups/' + group.id + '">' + group.id + '</td><td>' + group.icpc_id + '</td><td>'
-                + group.name + '</td><td>' + typ + '</td><td>' + hidden + '</td>');
+                + sanitizeHTML(group.name) + '</td><td>' + typ + '</td><td>' + hidden + '</td>');
         }
 
         $.when(contest.loadGroups()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/judgementTypes.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/judgementTypes.jsp
@@ -38,7 +38,7 @@
         function judgementTypeTd(jt) {
             var penalty = jt.penalty;
             var solved = jt.solved;
-            return $('<td><a href="<%= apiRoot %>/judgement-types/' + jt.id + '">' + jt.id + '</td><td>' + jt.name + '</td><td>' + penalty + '</td><td>' + solved + '</td>');
+            return $('<td><a href="<%= apiRoot %>/judgement-types/' + jt.id + '">' + jt.id + '</td><td>' + sanitizeHTML(jt.name) + '</td><td>' + penalty + '</td><td>' + solved + '</td>');
         }
 
         $.when(contest.loadJudgementTypes()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/languages.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/languages.jsp
@@ -33,7 +33,7 @@
         contest.setContestId("<%= cc.getId() %>");
 
         function langTd(lang) {
-            return $('<td><a href="<%= apiRoot %>/languages/' + lang.id + '">' + lang.id + '</td><td>' + lang.name + '</td>');
+            return $('<td><a href="<%= apiRoot %>/languages/' + lang.id + '">' + lang.id + '</td><td>' + sanitizeHTML(lang.name) + '</td>');
         }
 
         $.when(contest.loadLanguages()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/orgs.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/orgs.jsp
@@ -51,7 +51,7 @@
                 country = org.country;
 
             return $('<td><a href="<%= apiRoot %>/organizations/' + org.id + '">' + org.id + '</a></td><td align=middle><img src="' + logoSrc + '" height=20/></td>' +
-                '<td>' + org.name + '</td><td>' + formal_name + '</td><td>' + country + '</td>');
+                '<td>' + sanitizeHTML(org.name) + '</td><td>' + sanitizeHTML(formal_name) + '</td><td>' + country + '</td>');
         }
 
         $.when(contest.loadOrganizations()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/problems.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/problems.jsp
@@ -38,7 +38,7 @@
 
         function problemTd(problem) {
             return $('<td><a href="<%= apiRoot %>/problems/' + problem.id + '">' + problem.id + '</td><td>' + problem.label
-                + '</td><td>' + problem.name + '</td><td>' + problem.color + '</td><td>' + problem.rgb + '</td><td><div class="circle" style="background-color:' + problem.rgb + '"></div></td>');
+                + '</td><td>' + sanitizeHTML(problem.name) + '</td><td>' + problem.color + '</td><td>' + problem.rgb + '</td><td><div class="circle" style="background-color:' + problem.rgb + '"></div></td>');
         }
 
         $.when(contest.loadProblems()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/teams.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/teams.jsp
@@ -65,7 +65,7 @@
                 }
             }
 
-            return $('<td><a href="<%= apiRoot %>/teams/' + team.id + '">' + team.id + '</td><td>' + name + '</td><td align=center><img src="' + logoSrc + '" height=20/></td><td>' + orgName + '</td><td>' + orgFormalName + '</td><td>' + groupNames + '</td>'
+            return $('<td><a href="<%= apiRoot %>/teams/' + team.id + '">' + team.id + '</td><td>' + sanitizeHTML(name) + '</td><td align=center><img src="' + logoSrc + '" height=20/></td><td>' + sanitizeHTML(orgName) + '</td><td>' + sanitizeHTML(orgFormalName) + '</td><td>' + sanitizeHTML(groupNames) + '</td>'
                 + '<td><a href="<%= webroot  %>/teamSummary/' + team.id + '">summary</a></td>');
         }
 

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -2,6 +2,7 @@
 <%@page import="org.icpc.tools.cds.CDSConfig" %>
 <%@page import="org.icpc.tools.cds.ConfiguredContest" %>
 <%@page import="org.icpc.tools.cds.util.Role" %>
+<%@page import="org.icpc.tools.cds.util.HttpHelper" %>
 <% ConfiguredContest cc = (ConfiguredContest) request.getAttribute("cc");
     IContest contest = null;
     String webroot = null;
@@ -166,7 +167,7 @@
               <% String contestName = "";
                if (contest != null && contest.getName() != null)
                    contestName = contest.getName() + " "; %>
-              <h1 class="m-0 text-dark"><%= contestName %><%= request.getAttribute("title") %></h1>
+              <h1 class="m-0 text-dark"><%= HttpHelper.sanitizeHTML(contestName) %><%= request.getAttribute("title") %></h1>
             </div><!-- /.col -->
           </div><!-- /.row -->
         </div><!-- /.container-fluid -->

--- a/CDS/WebContent/WEB-INF/jsps/reports.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/reports.jsp
@@ -110,7 +110,7 @@
             var col = '';
             for (k in rep)
                 if (k !== 'id')
-                    col += '<td>' + rep[k] + '</td>';
+                    col += '<td>' + sanitizeHTML(rep[k]) + '</td>';
             row = $('<tr></tr>');
             row.append($(col));
             $(table).find('tbody').append(row);

--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -87,7 +87,7 @@
                             var logo = bestSquareLogo(org.logo, 20);
                             if (logo != null)
                                 logoSrc = '/api/' + logo.href;
-                            org = org.name;
+                            orgName = org.name;
                         }
                         if (team.display_name != null)
                             team = team.id + ': ' + team.display_name;
@@ -96,7 +96,7 @@
                     }
                 }
 
-                var col = $('<td class="text-right">' + scr.rank + '</td><td class="text-center"><img src="' + logoSrc + '" height=20/></td><td>' + team + '</td><td>' + orgName + '</td>');
+                var col = $('<td class="text-right">' + scr.rank + '</td><td class="text-center"><img src="' + logoSrc + '" height=20/></td><td>' + sanitizeHTML(team) + '</td><td>' + sanitizeHTML(orgName) + '</td>');
                 var row = $('<tr></tr>');
                 row.append(col);
                 for (var j = 0; j < problems.length; j++) {

--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -1,4 +1,5 @@
 <%@ page import="org.icpc.tools.contest.model.*" %>
+<%@ page import="org.icpc.tools.cds.util.HttpHelper" %>
 <%@ page import="java.util.List" %>
 <% request.setAttribute("title", "Team Summary"); %>
 <%@ include file="layout/head.jsp" %>
@@ -33,17 +34,17 @@
                         </tr>
                         <tr>
                             <td><b>Display Name:</b></td>
-                            <td><%= team.getDisplayName() == null ? "" : team.getDisplayName() %>
+                            <td><%= team.getDisplayName() == null ? "" : HttpHelper.sanitizeHTML(team.getDisplayName()) %>
                             </td>
                         </tr>
                         <tr>
                             <td><b>Name:</b></td>
-                            <td><%= team.getName() %>
+                            <td><%= HttpHelper.sanitizeHTML(team.getName()) %>
                             </td>
                         </tr>
                         <tr>
                             <td><b>Group:</b></td>
-                            <td><%= groupName %>
+                            <td><%= HttpHelper.sanitizeHTML(groupName) %>
                             </td>
                         </tr>
                         <% if (organization != null) { %>
@@ -54,12 +55,12 @@
                         </tr>
                         <tr>
                             <td><b>Org formal name:</b></td>
-                            <td><%= organization.getFormalName() == null ? "" : organization.getFormalName() %>
+                            <td><%= organization.getFormalName() == null ? "" : HttpHelper.sanitizeHTML(organization.getFormalName()) %>
                             </td>
                         </tr>
                         <tr>
                             <td><b>Org name:</b></td>
-                            <td><%= organization.getName() %>
+                            <td><%= HttpHelper.sanitizeHTML(organization.getName()) %>
                             </td>
                         </tr>
                         <tr>
@@ -179,7 +180,7 @@
                             if (id != null) {
                                 ILanguage lang = contest.getLanguageById(id);
                                 if (lang != null)
-                                    langStr = lang.getName();
+                                    langStr = HttpHelper.sanitizeHTML(lang.getName());
                                 else
                                     langStr = "<font color=\"red\">" + id + "</font>";
                             }

--- a/CDS/WebContent/WEB-INF/jsps/video.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/video.jsp
@@ -1,6 +1,7 @@
 <%@page import="org.icpc.tools.contest.model.ContestUtil" %>
 <%@page import="org.icpc.tools.contest.model.IOrganization" %>
 <%@page import="org.icpc.tools.contest.model.ITeam" %>
+<%@page import="org.icpc.tools.cds.util.HttpHelper" %>
 <%@page import="java.util.Arrays" %>
 <% request.setAttribute("title", "Video"); %>
 <%@ include file="layout/head.jsp" %>
@@ -45,9 +46,9 @@
                             <tr>
                                 <td><%= tId %>
                                 </td>
-                                <td><%= t.getActualDisplayName() %>
+                                <td><%= HttpHelper.sanitizeHTML(t.getActualDisplayName()) %>
                                 </td>
-                                <td><%= orgName %>
+                                <td><%= HttpHelper.sanitizeHTML(orgName) %>
                                 </td>
                                 <td id="desktop-<%= tId %>" class="text-center">-</td>
                                 <td id="desktop-<%= tId %>m" class="text-center"></td>
@@ -323,7 +324,7 @@
                     //window.location.reload(false);
                     verifyVideo();
                 } else {
-                	console.log("Error checking video - " xmlhttp.status + ": " + xmlhttp.responseText)
+                	console.log("Error checking video - " + xmlhttp.status + ": " + xmlhttp.responseText)
                 }
             }
         };

--- a/CDS/WebContent/WEB-INF/jsps/welcome.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/welcome.jsp
@@ -38,7 +38,7 @@
            String apiRootH = "/api/contests/" + cch.getId(); %>
         <div class="card-header <%= headerClass %> <%= textClass %>">
           <a href="<%= webRootH %>">
-            <h2 class="card-title <%= textClass %>"><%= contestH.getActualFormalName() != null ? contestH.getActualFormalName() : "(unnamed contest)" %></h2>
+            <h2 class="card-title <%= textClass %>"><%= contestH.getActualFormalName() != null ? HttpHelper.sanitizeHTML(contestH.getActualFormalName()) : "(unnamed contest)" %></h2>
           </a>
           <div class="card-tools"><a href="<%= apiRootH %>" class="<%= textClass %>">/<%= cch.getId() %></a></div>
         </div>

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -49,3 +49,19 @@ function fillContestObjectTable(name, objs, tdGen) {
     	x.html(objs.length);
     }
 }
+
+var tagsToReplace = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;'
+};
+
+function replaceTag(tag) {
+    return tagsToReplace[tag] || tag;
+}
+	
+function sanitizeHTML(str) {
+	if (str == null)
+		return "";
+	return str.replace(/[&<>]/g, replaceTag);
+}

--- a/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
+++ b/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
@@ -120,4 +120,40 @@ public class HttpHelper {
 		}
 		return sb.toString();
 	}
+
+	public static String sanitizeHTML(String s) {
+		if (s == null || s.isEmpty())
+			return "";
+
+		int len = s.length();
+		StringBuilder sb = new StringBuilder(len + 10);
+
+		for (int i = 0; i < len; i++) {
+			char c = s.charAt(i);
+			switch (c) {
+				case '<':
+					sb.append("&lt;");
+					break;
+				case '>':
+					sb.append("&gt;");
+					break;
+				case '&':
+					sb.append("&amp;");
+					break;
+				case '\'':
+					sb.append("&apos;");
+					break;
+				case '"':
+					sb.append("&quot;");
+					break;
+				default:
+					if (c < 0x0020 || c > 0x007e) {
+						String t = "000" + Integer.toHexString(c);
+						sb.append("&" + t.substring(t.length() - 4));
+					} else
+						sb.append(c);
+			}
+		}
+		return sb.toString();
+	}
 }


### PR DESCRIPTION
Fixing the security scan issues for Baylor made me realize that contest data (esp. team names) could also potentially contain html. This fix sanitizes CDS web pages in case a contest, team, org, group, problem, judgement type, language, clarification, or award citation ever contains <b>html tags</b>.