### PR TITLE
handle restarts when client receives sigabort(134) or sigterm(139)

### DIFF
--- a/PresContest/scripts/client.sh
+++ b/PresContest/scripts/client.sh
@@ -15,6 +15,14 @@ while true; do
     rm -rf lib
     mv -f update/* .
     continue
+  elif [ $result = 134 ]
+  then
+    # seg abort, restart
+    continue
+  elif [ $result = 139 ]
+  then
+    # seg fault, restart
+    continue
   fi
   [[ $result = 255 ]] || break
 done


### PR DESCRIPTION
This change was tested in nac2020 contest, where before this change some teams would return to the login screen and then go dark (screen saver, power saving).

fixes #217