### PR TITLE
Baylor security scan fix

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/search.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/search.jsp
@@ -51,7 +51,7 @@
                     text = text.substring(0, 30) + "...";
                 var col = $('<td><a href="/contests/' + contestId + '">' + contestId + '</a></td><td>' + type + '</td>' +
                     '<td><a href="/api/contests/' + contestId + '/' + type + '/' + id + '">' + id + '</a></td>' +
-                    '<td>' + text + '</td>');
+                    '<td>' + sanitize(text) + '</td>');
                 var row = $('<tr></tr>');
                 row.append(col);
                 $('#search-table tbody').append(row);

--- a/CDS/src/org/icpc/tools/cds/service/SearchService.java
+++ b/CDS/src/org/icpc/tools/cds/service/SearchService.java
@@ -49,36 +49,12 @@ public class SearchService extends HttpServlet {
 
 		String path = request.getPathInfo();
 		if (path == null || !path.startsWith("/")) {
-			request.setCharacterEncoding("UTF-8");
-			response.setCharacterEncoding("UTF-8");
-			response.setHeader("X-Frame-Options", "sameorigin");
 			response.setHeader("Content-Security-Policy", "frame-ancestors");
 			request.getRequestDispatcher("/WEB-INF/jsps/search.jsp").forward(request, response);
 			return;
 		}
 
-		try {
-			searchTerm = path.substring(1);
-		} catch (Exception e) {
-			response.sendError(HttpServletResponse.SC_NOT_FOUND);
-			return;
-		}
-
-		if (searchTerm.length() < 3) {
-			response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE, "Search string too short");
-			return;
-		}
-
-		if (!searchTerm.matches("[\\w*\\s*]*")) {
-			response.sendError(HttpServletResponse.SC_NOT_ACCEPTABLE, "Please enter only letters, numbers, and spaces.");
-			return;
-		}
-
-		response.setCharacterEncoding("UTF-8");
-		response.setHeader("Cache-Control", "no-cache");
-		response.setContentType("application/json");
-		JSONEncoder en = new JSONEncoder(response.getWriter());
-		search(request, searchTerm, en);
+		response.sendError(HttpServletResponse.SC_BAD_REQUEST);
 	}
 
 	protected static void write(JSONEncoder e, IContestObject obj, String text) {
@@ -90,10 +66,9 @@ public class SearchService extends HttpServlet {
 	}
 
 	protected static void search(HttpServletRequest request, String searchTerm, JSONEncoder en) {
-		Trace.trace(Trace.INFO, "Searching for: " + searchTerm);
+		Trace.trace(Trace.INFO, "Searching for: " + HttpHelper.sanitize(searchTerm));
 		en.openArray();
 		en.open();
-		en.encode("search_term", searchTerm);
 		en.openChildArray("results");
 
 		String search = searchTerm.toLowerCase();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
@@ -23,8 +23,8 @@ public class NDJSONFeedParser implements Closeable {
 		if (in == null)
 			return;
 
-		// {"event": "<event type>", "id": "<id>", "op":"create/update/delete" "data": <data from
-		// endpoint> }
+		// { "id": "<id>", "type": "<event type>", "op":"create/update/delete", "data": { <data from
+		// endpoint> } }
 		String s = null;
 		try {
 			br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
@@ -107,9 +107,5 @@ public class NDJSONFeedParser implements Closeable {
 
 	public String getLastEventId() {
 		return lastId;
-	}
-
-	protected void handleNewObject(ContestObject obj) {
-		// hook for subclasses to perform actions on new elements
 	}
 }


### PR DESCRIPTION
Ok, time to go all out: don't include the search term in the response JSON, remove code that's unused after the last few commits, and sanitize both the result text and log output while we're at it. And drop in removal of an unused method and comment cleanup in NDJSONFeedParser because I had nowhere else to put it.