### PR TITLE
Consistent error reporting

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestFeedService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestFeedService.java
@@ -172,7 +172,7 @@ public class ContestFeedService {
 				Trace.trace(Trace.WARNING, "Couldn't write contest hash file", e);
 			}
 		} catch (IllegalArgumentException e) {
-			response.sendError(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
 		} catch (Exception e) {
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
 			Trace.trace(Trace.ERROR, "Error updating contest hash", e);

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -434,7 +434,7 @@ public class ContestRESTService extends HttpServlet {
 	// {"id":"finals","start_time":null,"countdown_pause_time":"0:12:15.000"}
 	protected void doPatch(HttpServletRequest request, HttpServletResponse response) throws IOException {
 		if (!Role.isAdmin(request)) {
-			response.sendError(HttpServletResponse.SC_FORBIDDEN);
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 			return;
 		}
 
@@ -515,7 +515,7 @@ public class ContestRESTService extends HttpServlet {
 		if (segments.length == 3)
 			id = segments[2];
 		else if (!IContestObject.isSingleton(cType)) {
-			response.sendError(HttpServletResponse.SC_FORBIDDEN);
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing id");
 			return;
 		}
 
@@ -561,7 +561,7 @@ public class ContestRESTService extends HttpServlet {
 	@Override
 	protected void doPut(HttpServletRequest request, HttpServletResponse response) throws IOException {
 		if (!Role.isAdmin(request)) {
-			response.sendError(HttpServletResponse.SC_FORBIDDEN);
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 			return;
 		}
 
@@ -594,7 +594,7 @@ public class ContestRESTService extends HttpServlet {
 		if (segments.length == 3)
 			id = segments[2];
 		else if (!IContestObject.isSingleton(cType)) {
-			response.sendError(HttpServletResponse.SC_FORBIDDEN);
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing id");
 			return;
 		}
 

--- a/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
+++ b/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
@@ -236,7 +236,7 @@ public class ReactionVideoRecorder {
 		// security - reject after freeze
 		final IContest contest = cc.getContest();
 		if (!Role.isBlue(request) && !contest.isBeforeFreeze(submission)) {
-			response.sendError(HttpServletResponse.SC_FORBIDDEN);
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 			return;
 		}
 

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -175,7 +175,7 @@ public class VideoServlet extends HttpServlet {
 			for (ConfiguredContest cc : CDSConfig.getContests()) {
 				IState state = cc.getContest().getState();
 				if (state.isFrozen() && state.isRunning()) {
-					response.sendError(HttpServletResponse.SC_FORBIDDEN, "Contest is frozen");
+					response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Contest is frozen");
 					return;
 				}
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -824,7 +824,7 @@ public class RESTContestSource extends DiskContestSource {
 				throw new IOException(conn.getResponseCode() + ": " + conn.getResponseMessage());
 		} catch (IOException e) {
 			Trace.trace(Trace.ERROR, "Error setting contest start time", e);
-			throw new IOException("500: Could not connect: " + e.getMessage());
+			throw e;
 		} catch (Exception e) {
 			throw new IOException("Connection error", e);
 		}


### PR DESCRIPTION
At the NAC there were a couple cases where a CCS error showed up oddly or part of a long error message got cut off. I did a full pass of making things break to see how they show up. Fixed a case there the plain error reporting should be used, switched use of FORBIDDEN to more accurate cases, and shortened error messages so that when a CCS doesn't respond it's more clear.