### PR TITLE
Website tweaks

### DIFF
--- a/website/.project
+++ b/website/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Website</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/website/content/resolver.md
+++ b/website/content/resolver.md
@@ -4,7 +4,7 @@ description: "The ICPC Resolver is a tool for graphical animation of contest res
 date: 2019-11-12T21:20:38+01:00
 draft: false
 weight: 3
-icon: fas fa-list-ol
+icon: fas fa-trophy
 ---
 
 The _ICPC Resolver_ is a tool for graphical animation of contest results.

--- a/website/data/tools.yaml
+++ b/website/data/tools.yaml
@@ -1,8 +1,8 @@
 # Mapping from tool index from JSON files to name to display on all-builds page
 - tool: wlp.CDS
-  name: CDS (WLP)
+  name: CDS (Open Liberty)
 - tool: CDS
-  name: CDS (JAR)
+  name: CDS (WAR only)
 - tool: resolver
   name: Resolver
 - tool: presentationAdmin

--- a/website/layouts/shortcodes/allbuilds.html
+++ b/website/layouts/shortcodes/allbuilds.html
@@ -14,13 +14,14 @@
             <td>{{ $build.time }}</td>
         </tr>
     </tbody>
-</table>
+    
+    <tr><td></td><td>
     
 <table class="table table-hover table-striped">
     <thead>
         <tr>
             <th style="width: 200px;">Tool</th>
-            <th style="width: 200px;">Size</th>
+            <th style="width: 125px;">Size</th>
             <th>Downloads</th>
         </tr>
     </thead>
@@ -30,7 +31,7 @@
             {{ $download := index $build.downloads $tool.tool }}
             <tr>
                 <th>{{ $tool.name }}</th>
-                <td>{{ $download.size }} MB</td>
+                <td align="right">{{ $download.size }} MB</td>
                 <td>
                     <a href="{{ $download.urls.zip }}">{{ $tool.tool }}-{{ $download.version }}.zip</a>
                     {{ if and (isset $download.urls "sha256") (isset $download.urls "sha512") }}
@@ -42,5 +43,7 @@
         {{ end }}
     </tbody>
 </table>
+
+</td></tr></table>
 
 {{ end }}


### PR DESCRIPTION
Change the resolver font-awesome to 'trophy' to match the icon I made. Add a .project file to make it easier to edit in Eclipse (not that you should...). Change the WLP download to show Open Liberty vs WAR. Tweak to builds page to indent downloads and make download size column right-justified and smaller.