### PR TITLE
Code cleanup

### DIFF
--- a/CDS/WebContent/js/model.js
+++ b/CDS/WebContent/js/model.js
@@ -83,18 +83,19 @@ function bestLogo(logos, width, height) {
 
 function parseTime(contestTime) {
 	match = contestTime.match("-?([0-9]+):([0-9]{2}):([0-9]{2})(\\.[0-9]{3})?");
-	
+
 	h = parseInt(match[0]);
 	m = parseInt(match[1]);
 	s = parseInt(match[2]);	
 	ms = 0;
 	if (match.length == 4)
 		ms = parseInt(match[3].substring(1));
-	
-	if (contestTime.startsWith("-"))
-		return -(h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms);
 
-	return h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
+	ret = h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
+	if (contestTime.startsWith("-"))
+	  return -ret;
+	
+	return ret;
 } 
 
 var isInt = (function() {

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -52,7 +52,6 @@ public class ContestRESTService extends HttpServlet {
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 		HttpHelper.setThreadHost(request);
 		response.setHeader("Cache-Control", "no-cache");
-		response.setHeader("ICPC-Tools", "CDS");
 		response.setHeader("X-Frame-Options", "sameorigin");
 
 		String path = request.getPathInfo();
@@ -417,9 +416,9 @@ public class ContestRESTService extends HttpServlet {
 	@Override
 	protected void service(HttpServletRequest request, HttpServletResponse response)
 			throws ServletException, IOException {
-		request.setAttribute("error-type", "plain");
 		request.setCharacterEncoding("UTF-8");
 		response.setCharacterEncoding("UTF-8");
+		response.setHeader("ICPC-Tools", "CDS");
 
 		String method = request.getMethod();
 		if (method.equals("PATCH"))
@@ -458,9 +457,14 @@ public class ContestRESTService extends HttpServlet {
 
 		if (segments.length == 1) {
 			// attempting to change the start time
-			InputStream is = request.getInputStream();
-			JSONParser parser = new JSONParser(is);
-			JsonObject obj = parser.readObject();
+			JsonObject obj = null;
+			try {
+				InputStream is = request.getInputStream();
+				JSONParser parser = new JSONParser(is);
+				obj = parser.readObject();
+			} catch (Exception e) {
+				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Could not parse body as JSON");
+			}
 
 			// confirm the contest id is correct
 			String id = obj.getString("id");

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -119,7 +119,6 @@ public class ContestWebService extends HttpServlet {
 
 		if (segments.length >= 2) {
 			request.setAttribute("cc", cc);
-			request.setAttribute("error-type", "plain");
 			cc.incrementWeb();
 			if (segments[1].equals("admin")) {
 				if (!Role.isAdmin(request)) {

--- a/CDS/src/org/icpc/tools/cds/service/ErrorService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ErrorService.java
@@ -22,7 +22,8 @@ public class ErrorService extends HttpServlet {
 		response.setHeader("ICPC-Tools", "CDS");
 		response.setHeader("X-Frame-Options", "sameorigin");
 
-		if ("plain".equals(request.getAttribute("error-type"))) {
+		String accept = request.getHeader("Accept");
+		if (accept == null || !accept.contains("html")) {
 			PrintWriter pw = response.getWriter();
 			pw.write(request.getAttribute("javax.servlet.error.message") + " (" + response.getStatus() + ")");
 			pw.flush();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RelativeTime.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RelativeTime.java
@@ -44,10 +44,12 @@ public class RelativeTime {
 		if (match.group(4) != null) {
 			ms = Integer.parseInt(match.group(4).substring(1));
 		}
-		if (contestTime.startsWith("-"))
-			return -(h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms);
 
-		return h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
+		int val = h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
+		if (contestTime.startsWith("-"))
+			return -val;
+
+		return val;
 	}
 
 	public static String format(Integer contestTimeMs) {


### PR DESCRIPTION
Avoid duplicate value in time parsing code (Java & JS). Detect what kind of error output should be returned based on client request instead of which endpoint. Avoid internal parsing error on bad request.