### PR TITLE
Reconnect unless contest is done updating

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -196,13 +196,10 @@ public abstract class ContestSource {
 				contest.addListener(readListener);
 				do {
 					try {
-						// Trace.trace(Trace.INFO, "Loading contest from " +
-						// ContestSource.this.toString());
 						notifyListeners(ConnectionState.CONNECTING);
 						loadContestImpl();
-						reconnect = false; // normal termination - contest is finalized
-						Trace.trace(Trace.INFO, "Contest loaded");
-						notifyListeners(ConnectionState.COMPLETE);
+						if (reconnect && contest.isDoneUpdating())
+							reconnect = false; // normal termination - contest is done updating
 					} catch (InterruptedException e) {
 						// ignore
 					} catch (Exception e) {
@@ -216,10 +213,13 @@ public abstract class ContestSource {
 						Trace.trace(Trace.INFO, "Waiting to reconnect");
 						// wait a few seconds to reconnect
 						try {
-							Thread.sleep(4000);
+							Thread.sleep(5000);
 						} catch (Exception e) {
 							// ignore
 						}
+					} else {
+						Trace.trace(Trace.INFO, "Contest loaded");
+						notifyListeners(ConnectionState.COMPLETE);
 					}
 				} while (reconnect);
 				// thread = null;


### PR DESCRIPTION
During two of the test contests at NAC the CDS received a normal (EOF-style) event feed termination from Kattis - i.e. no errors, the endpoint was just done giving data. The CDS interpreted this as 'ok, there's no more data to get' and didn't attempt to reconnect.
Whether this was some bizarre network glitch, a bug in Kattis, or someone restarting the feed incorrectly, it seems like the far safer approach is to attempt reconnect until a contest is done updating.
Moved the completion event outside of this too (don't say we're complete if we're going to reconnect). Bumped the reconnect time up to 5s, for no particular reason other than it seems more natural and IMHO when things go down it's typically for longer periods anyway.