### PR TITLE
Handle null values in JSON

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
@@ -217,8 +217,7 @@ public class JSONParser {
 		} else { // simple value
 			value = readUntilNextToken();
 		}
-		if (value != null)
-			obj.props.put(key, value);
+		obj.props.put(key, value);
 		return false;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
@@ -146,7 +146,8 @@ public class ContestData implements Iterable<IContestObject> {
 				boolean changed = false;
 				for (String oldK : oldP.keySet()) {
 					if (!"time".equals(oldK)) {
-						if (oldP.get(oldK).equals(newP.get(oldK))) {
+						if ((oldP.get(oldK) == null && newP.get(oldK) == null)
+								|| (oldP.get(oldK) != null && oldP.get(oldK).equals(newP.get(oldK)))) {
 							// found match
 							continue;
 						}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/SimpleMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/SimpleMap.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * A simple map backed by arrays, which automatically ignores (doesn't add) null keys or values.
+ * A simple map backed by arrays, which automatically ignores (doesn't add) null keys.
  */
 public class SimpleMap implements Map<String, Object> {
 	private static final int INITIAL_SIZE = 7;
@@ -62,7 +62,7 @@ public class SimpleMap implements Map<String, Object> {
 
 	@Override
 	public Object put(String key, Object value) {
-		if (key == null || value == null)
+		if (key == null)
 			return null;
 
 		int arrSize = keys.length;


### PR DESCRIPTION
I have no idea how this hasn't been caught before now, but null values were ignored when reading JSON, including the event feed. I guess we don't null out existing values much?
Found two downstream issues - the CDS event feed would close after the contest is finalized (should wait until no more updates), and the resolver would think a contest is done updating even though it wasn't