### PR TITLE
Admin button to apply end of updates

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -109,8 +109,9 @@
            </div>
         <div class="card-body">
           Finalize (signal end of updates for) the contest.
+          <form class="form-inline">
             <div class="form-group">
-                <label for="bSelect">Value of b:</label>
+                <label for="bSelect">B value</label>
                 <select id="bSelect" class="form-control">
                     <option value="0">0</option>
                     <option value="1">1</option>
@@ -120,13 +121,15 @@
                     <option value="5">5</option>
                     <option value="6">6</option>
                 </select>
-            
                 <button id="finalize" class="btn btn-info"
                     onclick="var e = document.getElementById('bSelect'); sendFinalizeCommand('finalize', 'b:' + e.options[e.selectedIndex].value)">Apply</button>
-                <button id="finalize" class="btn btn-info"
-                    onclick="sendFinalizeCommand('finalize', 'template')">Template</button>
-                <span id="final-status">&nbsp;</span>
             </div>
+          </form>
+            <div class="form-group">
+                <button id="finalize2" class="btn btn-info" onclick="sendFinalizeCommand('finalize2', 'template')">Apply from Template</button></div>
+            <div class="form-group">
+                <button id="finalize3" class="btn btn-info" onclick="sendFinalizeCommand('finalize3', 'eou')">End of Updates</button></div>
+            <span id="final-status">&nbsp;</span>
         </div>
         </div></div>
         
@@ -161,19 +164,19 @@
               <div class="box-body">
                 <div class="form-group">
                   <label for="input-type" class="col-sm-2 control-label">Type</label>
-                  <div class="col-sm-10">
+                  <div class="col-sm-12">
                     <input class="form-control" id="input-type" placeholder="contest type, e.g. 'teams'">
                   </div>
                 </div>
                 <div class="form-group">
                   <label for="input-id" class="col-sm-2 control-label">Id</label>
-                  <div class="col-sm-10">
+                  <div class="col-sm-12">
                     <input class="form-control" id="input-id" placeholder="id">
                   </div>
                 </div>
                 <div class="form-group">
                   <label for="input-body" class="col-sm-2 control-label">Body</label>
-                  <div class="col-sm-10">
+                  <div class="col-sm-12">
                     <textarea class="form-control" rows="3" id="input-body" placeholder="JSON body"></textarea>
                   </div>
                 </div>

--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -20,10 +20,10 @@
     } %>
 <div class="container-fluid">
     <div class="row">
-        <div class="col-12">
+        <div class="col-4">
             <div class="card">
                 <div class="card-header">
-                    <h3 class="card-title">Team Summary</h3>
+                    <h3 class="card-title">Team Information</h3>
                 </div>
                 <div class="card-body p-0">
                     <table class="table table-sm table-hover table-striped">
@@ -72,7 +72,9 @@
                     </table>
                 </div>
             </div>
-
+         </div>
+         
+         <div class="col-8">
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Scoreboard</h3>
@@ -123,7 +125,7 @@
                     </table>
                 </div>
             </div>
-
+        
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Submissions</h3>

--- a/CDS/src/org/icpc/tools/cds/service/FinalizeService.java
+++ b/CDS/src/org/icpc/tools/cds/service/FinalizeService.java
@@ -15,6 +15,7 @@ import org.icpc.tools.contest.model.feed.JSONParser;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.Award;
 import org.icpc.tools.contest.model.internal.Contest;
+import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.util.AwardUtil;
 
 public class FinalizeService {
@@ -43,6 +44,14 @@ public class FinalizeService {
 				Award[] template = loadFromFile(f);
 				Trace.trace(Trace.USER, "Assigning awards: " + template.length);
 				AwardUtil.applyAwards(c, template);
+			} else if ("eou".equals(command)) {
+				// send end of updates
+				State state = (State) contest.getState();
+				if (state.getEndOfUpdates() != null)
+					return;
+				state = (State) state.clone();
+				state.setEndOfUpdates(System.currentTimeMillis());
+				((Contest) contest).add(state);
 			}
 		} catch (IllegalArgumentException e) {
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());


### PR DESCRIPTION
With the fix in PR #234 I have realized that there have been a few times in the last couple years where we've run the resolver on a contest that is over, final, and has no unjudged runs, but didn't have the end_of_updates flag set. Prior to the fix this would have gone unnoticed, now (with the fix) it will correctly block the resolver from starting.
This fix just adds an admin button that would apply the end of updates in a pinch, so that you wouldn't need to go back to the CCS or manually edit the event feed if this happens.

Forgot to mention in the commit that I also dropped in a minor formatting change to the team summary page.