### PR TITLE
CDS resolution support

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -197,10 +197,39 @@
            </div>
         <div class="card-body">
             <p>Click <a href="<%= webroot %>/balloon">here</a> for a printable page that contains all the balloon labels and colours.</p>
-              
-         </div>
-         </div>
-     </div>
+        </div>
+        </div>
+     
+        <div class="card">
+           <div class="card-header">
+             <h3 class="card-title">Resolver Info (Beta)</h3>
+           </div>
+        <div class="card-body">
+          Initializing the resolver does three things:
+          <ul>
+            <li>Shows the status of the resolution</li>
+            <li>Allows you to control the resolution (for extreme circumstances)</li>
+            <li>Makes judgements public as they are resolved</li>
+          </ul>
+            <table id="resolver-table" class="table table-sm table-hover table-striped">
+              <tbody>
+                <tr>
+                  <td>Current pause:</td><td id="resolver-current-pause">-</td>
+                  <td>Total pauses:</td><td id="resolver-total-pauses">-</td>
+                  <td>Stepping:</td><td id="resolver-stepping">-</td>
+                </tr>
+              </tbody>
+            </table>
+            <div class="form-group">
+                <button class="btn btn-info" onclick="resolve('init')">Init</button>
+                <button class="btn btn-info" onclick="resolve('reset')">Reset</button>
+                <button class="btn btn-info" onclick="resolve('fast-rewind')">&lt;&lt;</button>
+                <button class="btn btn-info" onclick="resolve('rewind')">&lt;</button>
+                <button class="btn btn-info" onclick="resolve('forward')">&gt;</button>
+                <button class="btn btn-info" onclick="resolve('fast-forward')">&gt;&gt;</button>
+            </div>
+        </div>
+        </div></div>
     </div>
 </div>
 <script>
@@ -463,11 +492,48 @@
     		$('#object-status').text("Delete failed: " + result.responseText);
     	})
     }
+    
+    function resolve(cmd) {
+    	if (cmd == null)
+    		return;
+    	
+    	console.log("Resolve: " + cmd);
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function () {
+            if (xmlhttp.readyState == 4) {
+            	updateResolver();
+            }
+        };
+        xmlhttp.open("PUT", "<%= webroot %>/admin/resolve/" + cmd, true);
+        xmlhttp.send();
+    }
+
+    function updateResolver() {
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function () {
+            if (xmlhttp.readyState == 4) {
+                var resp = xmlhttp.responseText;
+                if (xmlhttp.status == 200) {
+                   resp = JSON.parse(resp);
+                   document.getElementById("resolver-current-pause").innerHTML = resp.pause;
+                   document.getElementById("resolver-total-pauses").innerHTML = resp.total_pauses;
+                   document.getElementById("resolver-stepping").innerHTML = resp.stepping;
+                } else {
+                   document.getElementById("resolver-current-pause").innerHTML = "?";
+                   document.getElementById("resolver-total-pauses").innerHTML = "?";
+                   document.getElementById("resolver-stepping").innerHTML = "?";
+                }
+            }
+        };
+        xmlhttp.open("GET", "<%= webroot %>/resolver", true);
+        xmlhttp.send();
+    }
 
     function updateInBackground() {
         document.getElementById("bg-status").innerHTML = "Updating status...";
         updateCountdown();
         updateStartStatusTable();
+        updateResolver();
 
         setInterval(updateCountdown, 5000);
         setInterval(updateStartStatusTable, 5000);

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -962,7 +962,7 @@ public class ConfiguredContest {
 				try {
 					list.add(clients.get(obj));
 				} catch (Exception e) {
-					e.printStackTrace();
+					Trace.trace(Trace.ERROR, "Error getting clients", e);
 					remove(obj);
 				}
 			}
@@ -979,6 +979,18 @@ public class ConfiguredContest {
 		else if (ccs != null)
 			return Mode.LIVE;
 		return Mode.ARCHIVE;
+	}
+
+	/**
+	 * Expose a contest object from during the freeze (typically judgements) to the publicly visible
+	 * contests (trusted, balloon, and public roles).
+	 *
+	 * @param co
+	 */
+	public void exposeContestObject(IContestObject co) {
+		trustedContest.add(co);
+		balloonContest.add(co);
+		publicContest.add(co);
 	}
 
 	@Override

--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationServer.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationServer.java
@@ -79,6 +79,14 @@ public class PresentationServer {
 		return clients;
 	}
 
+	public int[] getAllClientUIDs() {
+		Client[] cl = clients.toArray(new Client[0]);
+		int[] cli = new int[cl.length];
+		for (int i = 0; i < cl.length; i++)
+			cli[i] = cl[i].getUID();
+		return cli;
+	}
+
 	protected boolean doesClientExist(int uid) {
 		for (Client cl : clients) {
 			if (uid == cl.getUID())

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -135,6 +135,8 @@ public class ContestWebService extends HttpServlet {
 						StartTimeService.doPut(response, command, cc);
 					else if (segments[2].equals("finalize"))
 						FinalizeService.doPut(response, command, cc);
+					else if (segments[2].equals("resolve"))
+						ResolverService.doPut(response, command, cc);
 				}
 				return;
 			} else if (segments.length == 3 && segments[1].equals("video") && segments[2].equals("status")) {
@@ -381,6 +383,10 @@ public class ContestWebService extends HttpServlet {
 					return;
 				}
 				request.getRequestDispatcher("/WEB-INF/jsps/balloon.jsp").forward(request, response);
+				return;
+			} else if (segments[1].equals("resolver")) {
+				request.setCharacterEncoding("UTF-8");
+				ResolverService.doGet(response, cc);
 				return;
 			} /* else if (segments.length == 4 && segments[1].equals("video") && segments[2].equals("map")) {
 				VideoMapper va = null;

--- a/CDS/src/org/icpc/tools/cds/service/ResolverService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ResolverService.java
@@ -1,0 +1,207 @@
+package org.icpc.tools.cds.service;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.icpc.tools.cds.ConfiguredContest;
+import org.icpc.tools.cds.presentations.PresentationServer;
+import org.icpc.tools.cds.presentations.PresentationServer.IPropertyListener;
+import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IJudgement;
+import org.icpc.tools.contest.model.IJudgementType;
+import org.icpc.tools.contest.model.ISubmission;
+import org.icpc.tools.contest.model.feed.JSONEncoder;
+import org.icpc.tools.contest.model.internal.Contest;
+import org.icpc.tools.contest.model.resolver.ResolutionControl;
+import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.ContestStateStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.SubmissionSelectionStep;
+import org.icpc.tools.contest.model.resolver.ResolverLogic;
+
+public class ResolverService {
+	private static final String DATA_RESOLVER_CLICKS = "org.icpc.tools.presentation.contest.resolver.clicks";
+	private static final String DATA_RESOLVER_SETTINGS = "org.icpc.tools.presentation.contest.resolver.settings";
+	private static final String DATA_RESOLVER_SPEED = "org.icpc.tools.presentation.contest.resolver.speed";
+
+	protected static List<ResolutionStep> steps;
+	protected static ResolutionControl control;
+	protected static ScheduledExecutorService executor;
+	protected static boolean localControl;
+
+	protected static void doGet(HttpServletResponse response, ConfiguredContest cc) throws IOException {
+		if (control == null)
+			return;
+
+		response.setCharacterEncoding("UTF-8");
+		response.setHeader("Access-Control-Allow-Origin", "*");
+		response.setContentType("application/json");
+		PrintWriter pw = response.getWriter();
+		JSONEncoder je = new JSONEncoder(pw);
+		je.open();
+		je.encode("pause", control.getCurrentPause());
+		je.encode("total_pauses", ResolutionUtil.getTotalPauses(steps));
+		je.encode("total_time", ResolutionUtil.getTotalTime(steps));
+		je.encode("stepping", control.isStepping());
+		je.close();
+	}
+
+	protected static void doPut(HttpServletResponse response, String command, ConfiguredContest cc) throws IOException {
+		IContest contest = cc.getContest();
+		if (contest.getState().isRunning()) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Contest still running");
+			return;
+		}
+
+		Trace.trace(Trace.USER, "Resolver command: " + command);
+		try {
+			Contest c = (Contest) contest;
+			if ("init".equals(command)) {
+				if (steps != null)
+					return;
+
+				if (executor == null)
+					executor = ExecutorListener.getExecutor();
+
+				// The resolver skips over non-solution/non-penalty judgements (e.g. compile error)
+				// since these typically 'disappear' from scoreboards during the regular contest.
+				// Resolve these first to avoid confusing the presenter
+				int count = 0;
+				for (IJudgement j : contest.getJudgements()) {
+					IJudgementType jt = contest.getJudgementTypeById(j.getJudgementTypeId());
+					if (!jt.isSolved() && !jt.isPenalty()) {
+						cc.exposeContestObject(j);
+						count++;
+					}
+				}
+				Trace.trace(Trace.USER, "Auto-resolved " + count + " judgements");
+
+				ResolverLogic resolver = new ResolverLogic(c, 12, -1, false, null);
+				steps = resolver.resolveFrom(false);
+				control = new ResolutionControl(steps);
+				control.addListener(new IResolutionListener() {
+					protected List<IJudgement> judgements;
+
+					@Override
+					public void atStep(ResolutionStep step) {
+						if (step instanceof SubmissionSelectionStep) {
+							SubmissionSelectionStep step2 = (SubmissionSelectionStep) step;
+							if (step2.subInfo == null)
+								return;
+
+							String teamId = step2.subInfo.getTeam().getId();
+							int pInd = step2.subInfo.getProblemIndex();
+							String pId = contest.getProblems()[pInd].getId();
+							ISubmission[] subs = contest.getSubmissions();
+							judgements = new ArrayList<>();
+							for (ISubmission s : subs) {
+								if (s.getTeamId().equals(teamId) && s.getProblemId().equals(pId)) {
+									if (s.getContestTime() < contest.getDuration()) {
+										IJudgement[] j = contest.getJudgementsBySubmissionId(s.getId());
+										judgements.addAll(Arrays.asList(j));
+									}
+								}
+							}
+						} else if (step instanceof ContestStateStep) {
+							if (judgements == null)
+								return;
+
+							for (IJudgement j : judgements)
+								cc.exposeContestObject(j);
+
+							judgements = null;
+						}
+					}
+
+					@Override
+					public void atPause(int pause) {
+						Trace.trace(Trace.INFO, "Resolver at pause " + pause);
+					}
+
+					@Override
+					public void toPause(int pause, boolean includeDelays) {
+						// send out changes coming from the local/CDS control
+						if (!localControl)
+							return;
+
+						localControl = false;
+
+						Trace.trace(Trace.INFO, "Resolver going to pause " + pause);
+
+						PresentationServer ps = PresentationServer.getInstance();
+						int[] cl = ps.getAllClientUIDs();
+						if (!includeDelays)
+							ps.setProperty(cl, DATA_RESOLVER_CLICKS, (pause + 1000) + "");
+						else
+							ps.setProperty(cl, DATA_RESOLVER_CLICKS, pause + "");
+					}
+				});
+
+				PresentationServer.getInstance().addListener(new IPropertyListener() {
+					@Override
+					public void propertyUpdated(int[] clients, String key, String value) {
+						Trace.trace(Trace.INFO, "New property: " + key + ": " + value);
+						if (DATA_RESOLVER_CLICKS.equals(key)) {
+							int pause = Integer.parseInt(value);
+							boolean includeDelays = true;
+							if (pause > 999) {
+								pause -= 1000;
+								includeDelays = false;
+							} else if (Math.abs(pause - control.getCurrentPause()) > 1)
+								includeDelays = false;
+
+							final int pause2 = pause;
+							boolean includeDelays2 = includeDelays;
+							executor.submit(new Runnable() {
+								@Override
+								public void run() {
+									control.moveToPause(pause2, includeDelays2);
+								}
+							});
+						} else if (DATA_RESOLVER_SPEED.equals(key)) {
+							double sf = Double.parseDouble(value);
+							control.setSpeedFactor(sf);
+						} else if (DATA_RESOLVER_SETTINGS.equals(key)) {
+							String[] clientArgs = value.split(",");
+							control.setSpeedFactor(Double.parseDouble(clientArgs[0]));
+						}
+					}
+				});
+				return;
+			}
+
+			if (control == null || control.isStepping())
+				return;
+
+			localControl = true;
+			executor.submit(new Runnable() {
+				@Override
+				public void run() {
+					if ("fast-forward".equals(command))
+						control.forward(false);
+					else if ("forward".equals(command))
+						control.forward(true);
+					else if ("rewind".equals(command))
+						control.rewind(true);
+					else if ("fast-rewind".equals(command))
+						control.rewind(false);
+					else if ("reset".equals(command))
+						control.reset();
+				}
+			});
+		} catch (IllegalArgumentException e) {
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());
+		} catch (Exception e) {
+			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Internal error");
+			Trace.trace(Trace.ERROR, "Error durng finalization", e);
+		}
+	}
+}

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionControl.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionControl.java
@@ -111,10 +111,23 @@ public class ResolutionControl {
 		return stepping;
 	}
 
+	/**
+	 * Step forward or backward to the given pause, optionally including delays. This method is
+	 * blocking and will not return until it is complete, run on non-critical thread if you are
+	 * using delays!
+	 *
+	 * @param includeDelays
+	 */
 	public synchronized void moveToPause(int pause, boolean includeDelays) {
 		stepToPause(pause, includeDelays);
 	}
 
+	/**
+	 * Step forward to the next pause, optionally including delays. This method is blocking and will
+	 * not return until it is complete, run on non-critical thread if you are using delays!
+	 *
+	 * @param includeDelays
+	 */
 	public synchronized void forward(boolean includeDelays) {
 		if (currentStep == steps.size() - 1)
 			return;
@@ -122,6 +135,12 @@ public class ResolutionControl {
 		stepToPause(currentPause + 1, includeDelays);
 	}
 
+	/**
+	 * Rewind to the previous pause, optionally including delays. This method is blocking and will
+	 * not return until it is complete, run on non-critical thread if you are using delays!
+	 *
+	 * @param includeDelays
+	 */
 	public synchronized void rewind(boolean includeDelays) {
 		if (currentStep == 0)
 			return;
@@ -129,6 +148,9 @@ public class ResolutionControl {
 		stepToPause(currentPause - 1, includeDelays);
 	}
 
+	/**
+	 * Reset resolution to the beginning.
+	 */
 	public synchronized void reset() {
 		if (currentStep == 0)
 			return;


### PR DESCRIPTION
Basic support for the CDS to participate in the resolving process. Adds a new section to the admin page that is opt-in. If you enable, it shows the status of the resolving, allows you to control the stepping (not normally expected to be used) and exposes resolved judgements to public contest clients (for instance, you'd see the judgements on a presentation scoreboard).