### PR TITLE
Video fixes and trace improvements

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
+++ b/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
@@ -101,7 +101,7 @@ public class ReactionVideoRecorder {
 		if (scheduledExecutor.isShutdown())
 			return;
 
-		final VideoMapper va = VideoMapper.WEBCAM;
+		final VideoMapper map = VideoMapper.WEBCAM;
 
 		String teamId = submission.getTeamId();
 		ITeam team = contest.getTeamById(teamId);
@@ -126,7 +126,6 @@ public class ReactionVideoRecorder {
 		info.file = file;
 
 		// create marker file
-		Trace.trace(Trace.INFO, "Recording reaction for " + submissionId);
 		info.tempFile = new File(reactDir, file.getName() + "-temp");
 		boolean secondary = false;
 		if (info.tempFile.exists()) // another CDS already recording
@@ -158,13 +157,15 @@ public class ReactionVideoRecorder {
 
 			info.listener = new VideoStreamListener(info.out, true);
 			try {
-				info.stream = va.getVideoStream(teamId);
+				info.stream = map.getVideoStream(teamId);
 			} catch (Exception e) {
 				// invalid team
 				return;
 			}
 
 			VideoAggregator aggregator = VideoAggregator.getInstance();
+			Trace.trace(Trace.INFO, "Recording reaction for " + submissionId + " from " + teamId + " on "
+					+ aggregator.getStreamName(info.stream));
 			aggregator.addStreamListener(info.stream, info.listener);
 		}
 
@@ -199,6 +200,7 @@ public class ReactionVideoRecorder {
 			public void run() {
 				if (info.out != null) {
 					VideoAggregator aggregator = VideoAggregator.getInstance();
+					Trace.trace(Trace.INFO, "Reaction recording done: " + aggregator.getStreamName(info.stream));
 					aggregator.removeStreamListener(info.stream, info.listener);
 
 					try {

--- a/CDS/src/org/icpc/tools/cds/video/VideoAggregator.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoAggregator.java
@@ -114,7 +114,7 @@ public class VideoAggregator {
 		int numReserved = videoStream.size();
 		videoStream.add(info);
 
-		Trace.trace(Trace.INFO, "Video reservation for " + name + " " + url + " " + numReserved);
+		Trace.trace(Trace.INFO, "Video reservation for " + name + " at " + url + " on stream " + numReserved);
 
 		return numReserved;
 	}
@@ -166,6 +166,13 @@ public class VideoAggregator {
 			VideoStream info = videoStream.get(stream);
 			info.addListener(listener);
 		}
+	}
+
+	public String getStreamName(int stream) {
+		if (stream < 0 || stream >= videoStream.size())
+			return null;
+
+		return videoStream.get(stream).getName();
 	}
 
 	public void addStreamListener(int stream, VideoStreamListener listener) {

--- a/CDS/src/org/icpc/tools/cds/video/VideoMapper.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoMapper.java
@@ -122,7 +122,6 @@ public class VideoMapper {
 				}
 				in = va.addReservation(namePattern.replace("{0}", id), urlPattern.replace("{0}", id), mode, ord);
 				map.put(id, in);
-				Trace.trace(Trace.INFO, "Mapped video: " + id + " -> " + in);
 			}
 		}
 	}

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -167,9 +167,6 @@ public class VideoServlet extends HttpServlet {
 			return;
 		}
 
-		Trace.trace(Trace.INFO,
-				"Video request: " + teamId + " -> " + stream + " " + ConfiguredContest.getUser(request) + " " + channel);
-
 		// check if any contests are in freeze
 		if (!trusted) {
 			for (ConfiguredContest cc : CDSConfig.getContests()) {
@@ -193,11 +190,15 @@ public class VideoServlet extends HttpServlet {
 			}
 		}
 
+		Trace.trace(Trace.INFO, "Video request: " + ConfiguredContest.getUser(request) + " requesting team " + teamId
+				+ " -> " + va.getStreamName(stream) + " (channel: " + channel + ")");
+
 		doVideo(request, response, filename, stream, channel, trusted);
 	}
 
 	public static void doVideo(HttpServletRequest request, HttpServletResponse response, final String filename,
 			final int stream, boolean channel, boolean trusted) throws IOException {
+
 		response.setHeader("Cache-Control", "no-cache");
 		response.setContentType("application/octet");
 


### PR DESCRIPTION
This commit does three things:

1. When the CDS gets a read timeout the status appears as active (since it connected ok) and the failure count was reset, which means that it never gives up trying. Since there are no bytes being sent we can't detect disconnecting clients either, which means that it goes on forever. I fixed this by not setting status until we get bytes, and also reduced the number of tries to 5 (typically around 62s), and intentionally disconnects all clients after this.
2. Reduces unnecessary tracing (2 messages for every reservation down to 1, 3 messages for every connection down to 1, 2 messages for normal disconnect down to 1) and adds a little more useful content to the ones that remain.
3. When the connection is closed it was resetting the status to unknown, since you know, it isn't. I removed this so that the admin page shows the more recent status instead. We could still change the page to show different colours for active status vs inactive, but at least you can get a quick view of what was/is working and failures don't disappear just because the client gave up.