### PR TITLE
Show freeze on scoreboards

### DIFF
--- a/PresContest/src/META-INF/presentations.xml
+++ b/PresContest/src/META-INF/presentations.xml
@@ -239,7 +239,7 @@
       id="org.icpc.tools.presentation.contest.scoreboard"
       name="Scoreboard"
       category="Scoreboard"
-      properties="focusTeam:# - a team to focus on,style - set team name style"
+      properties="focusTeam:# - a team to focus on,style - set team name style,clockOn,clockOff"
       description="Contest scoreboard."
       image="images/presentations/scoreboard.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.ScoreboardPresentation"/>
@@ -247,14 +247,14 @@
       id="org.icpc.tools.presentation.contest.scoreboard.timeline"
       name="Timeline"
       category="Scoreboard"
-      properties="style - set team name style"
+      properties="style - set team name style,clockOn,clockOff"
       image="images/presentations/scoreboardTimeline.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.TimelinePresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.judge"
       name="Judge queue"
       category="Scoreboard"
-      properties="style - set team name style"
+      properties="style - set team name style,clockOn,clockOff"
       description="The judgement queue. Shows all incoming submissions and what the result is."
       image="images/presentations/judgeQueue.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.JudgePresentation"/>
@@ -269,6 +269,7 @@
       id="org.icpc.tools.presentation.contest.first.solution"
       name="First solution"
       category="Scoreboard"
+      properties="style - set team name style,clockOn,clockOff"
       description="Tracking the first solution in the contest."
       image="images/presentations/firstSolution.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.FirstSolutionPresentation"/>
@@ -276,6 +277,7 @@
       id="org.icpc.tools.presentation.contest.first.to.solve"
       name="First to solve"
       category="Scoreboard"
+      properties="style - set team name style,clockOn,clockOff"
       description="Shows which team was the first to solve each problem."
       image="images/presentations/firstToSolve.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.FirstToSolvePresentation"/>
@@ -283,21 +285,21 @@
       id="org.icpc.tools.presentation.contest.leaderboard"
       name="Leaderboard"
       category="Scoreboard"
-      properties="style - set team name style"
+      properties="style - set team name style,clockOn,clockOff"
       image="images/presentations/leaderboard.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.LeaderboardPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.leaderboard.group"
       name="Group leaderboard"
       category="Scoreboard"
-      properties="style - set team name style"
+      properties="style - set team name style,clockOn,clockOff"
       image="images/presentations/groupLeaderboard.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.GroupLeaderboardPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.leaderboard.group.all"
       name="All Groups leaderboard"
       category="Scoreboard"
-      properties="style - set team name style"
+      properties="style - set team name style,clockOn,clockOff"
       image="images/presentations/allGroups.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.AllGroupsLeaderboardPresentation"/>
 
@@ -307,14 +309,14 @@
       id="org.icpc.tools.presentation.contest.tile.scoreboard"
       name="Tiles"
       category="Tile Scoreboards"
-      properties="rows:,columns:,style:"
+      properties="rows:,columns:,style:,clockOn,clockOff"
       image="images/presentations/tile.png"
       class="org.icpc.tools.presentation.contest.internal.tile.TileScoreboardPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.tile.scoreboard.rank"
       name="Tile rank"
       category="Tile Scoreboards"
-      properties="rows:,columns:,style:"
+      properties="rows:,columns:,style:,clockOn,clockOff"
       image="images/presentations/tileRank.png"
       class="org.icpc.tools.presentation.contest.internal.tile.TileRankScoreboardPresentation"/>
    <presentation
@@ -327,7 +329,7 @@
       id="org.icpc.tools.presentation.contest.tile.scoreboard.list"
       name="Tile list"
       category="Tile Scoreboards"
-      properties="rows:,columns:,style:"
+      properties="rows:,columns:,style:,clockOn,clockOff"
       image="images/presentations/tile2.png"
       class="org.icpc.tools.presentation.contest.internal.tile.TileListScoreboardPresentation"/>
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -368,7 +368,10 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 		g.drawImage(headerImg, 0, h + titleHeight, null);
 
 		if (showClock) {
-			g.setColor(Color.WHITE);
+			if (getContest().getState().isFrozen())
+				g.setColor(ICPCColors.YELLOW);
+			else
+				g.setColor(Color.WHITE);
 			g.setFont(clockFont);
 			FontMetrics fm = g.getFontMetrics();
 			String s = getContestTime();
@@ -376,8 +379,6 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 				g.drawString(s, width / 12 - fm.stringWidth(s) / 2, fm.getAscent() + CLOCK_MARGIN);
 
 			s = getRemainingTime();
-			// TODO - if 10 min left, go red
-			// g.setColor(Color.RED);
 			if (s != null)
 				g.drawString(s, width * 11 / 12 - fm.stringWidth(s) / 2, fm.getAscent() + CLOCK_MARGIN);
 		}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/ScrollingTileScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/ScrollingTileScoreboardPresentation.java
@@ -13,6 +13,7 @@ import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.presentation.contest.internal.Animator;
 import org.icpc.tools.presentation.contest.internal.Animator.Movement;
+import org.icpc.tools.presentation.contest.internal.ICPCColors;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.ScrollAnimator;
 
@@ -43,6 +44,7 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 	protected int margin = 50;
 	private Font titleFont;
 	private Font clockFont;
+	private boolean showClock = true;
 
 	public ScrollingTileScoreboardPresentation() {
 		// defaults
@@ -169,24 +171,27 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 				gg.dispose();
 			}
 
-			// if (showClock) {
-			g.setColor(Color.WHITE);
-			g.setFont(clockFont);
-			FontMetrics fm = g.getFontMetrics();
-			String s = getContestTime();
-			if (s != null) {
-				String[] ss = splitString(g, s, margin);
-				for (int i = 0; i < ss.length; i++)
-					g.drawString(ss[i], (margin - fm.stringWidth(ss[i])) / 2, fm.getHeight() * (i + 1) + TILE_V_GAP);
-			}
+			if (showClock) {
+				if (getContest().getState().isFrozen())
+					g.setColor(ICPCColors.YELLOW);
+				else
+					g.setColor(Color.WHITE);
+				g.setFont(clockFont);
+				FontMetrics fm = g.getFontMetrics();
+				String s = getContestTime();
+				if (s != null) {
+					String[] ss = splitString(g, s, margin);
+					for (int i = 0; i < ss.length; i++)
+						g.drawString(ss[i], (margin - fm.stringWidth(ss[i])) / 2, fm.getHeight() * (i + 1) + TILE_V_GAP);
+				}
 
-			s = getRemainingTime();
-			// TODO - if 10 min left, go red?
-			if (s != null) {
-				String[] ss = splitString(g, s, margin);
-				for (int i = 0; i < ss.length; i++)
-					g.drawString(ss[i], (margin - fm.stringWidth(ss[i])) / 2,
-							h - TILE_V_GAP - (ss.length - i - 1) * fm.getHeight());
+				s = getRemainingTime();
+				if (s != null) {
+					String[] ss = splitString(g, s, margin);
+					for (int i = 0; i < ss.length; i++)
+						g.drawString(ss[i], (margin - fm.stringWidth(ss[i])) / 2,
+								h - TILE_V_GAP - (ss.length - i - 1) * fm.getHeight());
+				}
 			}
 		}
 	}
@@ -300,5 +305,14 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 					tileHelper.paintTile(g, x, y, anim.getZoom(), teams[i], timeMs);
 			}
 		}
+	}
+
+	@Override
+	public void setProperty(String value) {
+		super.setProperty(value);
+		if (value.startsWith("clockOn"))
+			showClock = true;
+		else if (value.startsWith("clockOff"))
+			showClock = false;
 	}
 }


### PR DESCRIPTION
At NAC someone requested that the clock change on the main scoreboard so that you can tell if it's during the contest freeze. Adding additional text makes it too long, so I've just changed the colour. Tried blue but it was too pale so I went with yellow instead. Also added the ability to disable the clock on the tile presentations, since you could do this with the other scoreboards (in case of contest pause or some other unforseen case). Updated the presentation properties for the admin, including a bunch that were missing.