### PR TITLE
Update URL's to CCS spec and ICPC tools page

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/about.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/about.jsp
@@ -20,9 +20,9 @@
                            target="_blank">http://tools.icpc.global</a></td>
                 </tr>
                 <tr>
-                    <td>ICPC Specifications (CLICS)</td>
-                    <td><a href="https://clics.ecs.baylor.edu"
-                           target="_blank">https://clics.ecs.baylor.edu</a></td>
+                    <td>ICPC Specifications</td>
+                    <td><a href="https://ccs-specs.icpc.io"
+                           target="_blank">https://ccs-specs.icpc.io</a></td>
                 </tr>
                 <tr>
                     <td>Github (private)</td>

--- a/CDS/WebContent/WEB-INF/jsps/errorPage.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/errorPage.jsp
@@ -15,8 +15,8 @@
                    All I know is that it has something to do with this: 
                    <pre><%= HttpHelper.sanitize(pageContext.getErrorData().getThrowable().getMessage()) %></pre>
 
-                   <p>Please visit <a href="http://icpctools.org" target="_blank">icpctools.org</a> for help or go to 
-                   <a href="http://clics.ecs.baylor.edu" target="_blank">clics.ecs.baylor.edu</a> for more info on the Contest API.</p>
+                   <p>Please visit <a href="https://tools.icpc.global" target="_blank">tools.icpc.global</a> for help or go to
+                   <a href="https://ccs-specs.icpc.io" target="_blank">clics.ecs.baylor.edu</a> for more info on the Contest API.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
The readme's also contain a lot of links to the CLICS pages, but some of them should stay. It seems the readme's are out of date anyway wrt links so I didn't update these for now.