### PR TITLE
Balloon fixes

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/Balloon.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/Balloon.java
@@ -18,12 +18,12 @@ public class Balloon {
 	private boolean printed;
 	private boolean delivered;
 
-	public Balloon(String submissionId, String x) {
+	public Balloon(String submissionId) {
 		id = ID++;
 		this.submissionId = submissionId;
 	}
 
-	public Balloon(String s) throws NumberFormatException {
+	public Balloon(String s, String x) throws NumberFormatException {
 		load(s);
 	}
 
@@ -95,12 +95,7 @@ public class Balloon {
 
 	public void load(String s) throws NumberFormatException {
 		StringTokenizer st = new StringTokenizer(s, DELIM);
-		if (st.countTokens() == 5) {
-			id = new Integer(st.nextToken()).intValue();
-			if (ID <= id)
-				ID = id + 1;
-		} else
-			id = ID++;
+		id = new Integer(st.nextToken()).intValue();
 		submissionId = st.nextToken();
 		flags = new Integer(st.nextToken()).intValue();
 		printed = new Boolean(st.nextToken()).booleanValue();

--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonContest.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonContest.java
@@ -35,16 +35,6 @@ public class BalloonContest {
 	private IContest contest;
 	private List<Balloon> balloons = new ArrayList<>();
 
-	public synchronized boolean balloonAlreadyExists(ISubmission s) {
-		for (Balloon b : balloons) {
-			ISubmission r = contest.getSubmissionById(b.getSubmissionId());
-			if (r != null && s.getTeamId().equals(r.getTeamId()) && r.getProblemId().equals(s.getProblemId())) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	public synchronized Balloon getBalloon(String submissionId) {
 		if (submissionId == null)
 			return null;
@@ -145,6 +135,10 @@ public class BalloonContest {
 			flags |= Balloon.FIRST_FOR_PROBLEM;
 		if (fl[3] == YES)
 			flags |= Balloon.FIRST_FOR_TEAM;
+
+		if (flags == b.getFlags())
+			return false;
+
 		b.setFlags(flags);
 		return true;
 	}
@@ -167,22 +161,6 @@ public class BalloonContest {
 
 	public synchronized Balloon[] getBalloons() {
 		return balloons.toArray(new Balloon[0]);
-	}
-
-	public synchronized int getNumBalloons(String teamId) {
-		if (teamId == null)
-			return 0;
-
-		int count = 0;
-		for (Balloon b : balloons) {
-			ISubmission submission = contest.getSubmissionById(b.getSubmissionId());
-			if (submission != null) {
-				if (teamId.equals(submission.getTeamId()))
-					count++;
-			}
-		}
-
-		return count;
 	}
 
 	public synchronized void save() {

--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonFileUtil.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonFileUtil.java
@@ -60,7 +60,7 @@ public class BalloonFileUtil {
 
 			String s = br.readLine();
 			while (s != null) {
-				list.add(new Balloon(s));
+				list.add(new Balloon(s, null));
 				s = br.readLine();
 			}
 		} catch (Exception e) {

--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
@@ -115,10 +115,10 @@ public class BalloonPrinter {
 				Trace.trace(Trace.ERROR, "Error loading sample contest", e);
 			}
 
-			b2 = new Balloon("1", null);
+			b2 = new Balloon("1");
 			b2.setFlags(Balloon.FIRST_FOR_TEAM | Balloon.FIRST_IN_CONTEST);
 			bc2.add(b2);
-			b2 = new Balloon("2", null);
+			b2 = new Balloon("2");
 			b2.setFlags(Balloon.FIRST_FOR_PROBLEM);
 			bc2.add(b2);
 		}
@@ -707,7 +707,7 @@ public class BalloonPrinter {
 			gc.drawOval(x - (int) (d / 2f), y - (int) (d / 2f), (int) d, (int) d);
 
 			Point se = gc.stringExtent(b.getId());
-			gc.drawString(b.getId(), (int) (x - se.x / 2f), y - se.y / 2, true);
+			gc.drawString(b.getLabel(), (int) (x - se.x / 2f), y - se.y / 2, true);
 		}
 	}
 
@@ -727,10 +727,10 @@ public class BalloonPrinter {
 				Trace.trace(Trace.ERROR, "Error loading sample contest", e);
 			}
 
-			b2 = new Balloon("1", null);
+			b2 = new Balloon("1");
 			b2.setFlags(Balloon.FIRST_FOR_TEAM | Balloon.FIRST_IN_CONTEST);
 			bc2.add(b2);
-			b2 = new Balloon("2", null);
+			b2 = new Balloon("2");
 			b2.setFlags(Balloon.FIRST_FOR_PROBLEM);
 			bc2.add(b2);
 		}


### PR DESCRIPTION
As I'm going through each of the tools to verify the dependency updates, I noticed a few issues in the balloon util:
- I've noticed it before, but connecting to a finished contest took ~38s to show all ~500 balloons. Modified the code to be async, now it loads in ~8s.
- Removed a couple unnecessary methods on BalloonContest and avoided updating flags if they haven't changed.
- Switched the Balloon constructors so that the default one is the normal one.
- On the printed floor map the balloons showed id instead of label, fixed.
- On Big Sur there are some new warnings on the console (SWT issue, bug opened: https://bugs.eclipse.org/bugs/show_bug.cgi?id=569825).