### PR TITLE
Improve error messages

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
@@ -185,8 +185,8 @@ public class JSONParser {
 				}
 			}
 			// TODO: fail if not whitespace
-			if (st >= s.length())
-				throw new IllegalArgumentException("Unexpected char");
+			if (st >= s.length() - 1)
+				throw new IllegalArgumentException("Missing expected token");
 			c = s.charAt(++st);
 		}
 	}

--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -467,7 +467,7 @@ public class ImagesGenerator {
 					scImg = ImageScaler.padImage(scImg);
 					writeImageWithSize(scImg, orgFolder, mod);
 				} catch (Exception e) {
-					Trace.trace(Trace.ERROR, "Error generating image", e);
+					Trace.trace(Trace.ERROR, "Error generating image: " + imgFile.getAbsolutePath(), e);
 				}
 			}
 		}


### PR DESCRIPTION
Fix two really minor errors that I ran into with better error messages - when image generation fails show the file, and one char off when invalid JSON doesn't contain an end token