### PR TITLE
Split build images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 ---
 # GitLab build configuration
 default:
-  image: icpctools/build:full
+  image: ubuntu:20.04
 
 stages:
   - build
@@ -10,6 +10,7 @@ stages:
   - website
 
 build:
+  image: icpctools/builder
   stage: build
   rules:
     - if: '$CI_COMMIT_REF_NAME != "HEAD"'
@@ -90,18 +91,8 @@ push release to GitHub:
         fi
       done
 
-deploy to CSUS:
-  stage: deploy
-  rules:
-    - if: '$CI_COMMIT_REF_NAME == "master"'
-      when: always
-    - when: never
-  script:
-    - export BUILDNUMBER=`echo dist/wlp.CDS-*.zip | sed 's#^dist/wlp.CDS-\([0-9\.]*\).zip*#\1#'`
-    - BUILD_JOB_ID=$(cat dist/ci_job_id.txt)
-    - curl "http://pc2.ecs.csus.edu/cgi-bin/grabgitlab_icpctools_artifacts.cgi?authkey=$AUTHKEY&url=https://gitlab.com/api/v4/projects/$CI_PROJECT_ID/jobs/$BUILD_JOB_ID/artifacts&buildnumber=$BUILDNUMBER"
-
 update website:
+  image: icpctools/website
   stage: website
   rules:
     - if: '$CI_COMMIT_REF_NAME == "master"'

--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -2,11 +2,8 @@ FROM openjdk:8
 LABEL maintainer="Tim deBoer"
 
 RUN apt-get update \
-   && apt-get install -y ant httpie jq curl python3 python3-requests pandoc texlive \
-   && rm -rf /var/lib/apt/lists/* \
-   && wget -O /root/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.61.0/hugo_0.61.0_Linux-64bit.deb \
-   && dpkg -i /root/hugo.deb \
-   && rm /root/hugo.deb
+   && apt-get install -y ant pandoc texlive \
+   && rm -rf /var/lib/apt/lists/*
 COPY /cds wlp/usr/servers/cds
 RUN wget -O liberty.zip https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2020-02-04_1746/openliberty-webProfile8-20.0.0.2.zip \
    && unzip liberty.zip && /wlp/bin/server package cds --archive=../../../../cds.zip --include=minify && rm -f liberty.zip && rm -rf wlp

--- a/build/readme.build.txt
+++ b/build/readme.build.txt
@@ -1,2 +1,5 @@
-docker build . -t icpctools/build:full
-docker push icpctools/build:full
+docker build . -f builder.Dockerfile -t icpctools/builder
+docker push icpctools/builder
+
+docker build . -f website.Dockerfile -t icpctools/website
+docker push icpctools/website

--- a/build/website.Dockerfile
+++ b/build/website.Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:20.04
+LABEL maintainer="Tim deBoer"
+
+RUN apt-get update \
+   && apt-get install -y wget httpie jq curl python3 python3-requests \
+   && rm -rf /var/lib/apt/lists/* \
+   && wget -O /root/hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.80.0/hugo_0.80.0_Linux-64bit.deb \
+   && dpkg -i /root/hugo.deb \
+   && rm /root/hugo.deb


### PR DESCRIPTION
We were using one bloated container for everything. Default to ubuntu, use separate images for Java build and hugo, and stop publishing to CSUS