### PR TITLE
Add ChangeLog to website. Fixes #266.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,6 +109,9 @@ update website:
     - git config --global user.name "ICPC Tools bot"
   script:
     - website/scripts/populate-releases.py
+    - cp ChangeLog.md website/
+    - sed -i 's/^# .*//' website/ChangeLog.md
+    - sed -r 's/^## (.*)/#### \1/' -i website/ChangeLog.md
     - mkdir ~/website
     - git clone git@github.com:icpctools/icpctools.github.io.git ~/website
     - ln -s ~/website $CI_PROJECT_DIR/website/public

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,2 +1,3 @@
 public
 data/releases/*
+/ChangeLog.md

--- a/website/content/all-builds.md
+++ b/website/content/all-builds.md
@@ -3,7 +3,7 @@ title: "All builds"
 description: "Download any build of the ICPC Tools"
 date: 2019-12-15T11:52:23+01:00
 draft: false
-weight: 10
+weight: 11
 icon: fas fa-download
 ---
 

--- a/website/content/changelog.md
+++ b/website/content/changelog.md
@@ -1,0 +1,12 @@
+---
+title: "Changelog"
+description: "View the changelog of the ICPC Tools"
+date: 2021-01-08T20:43:00+01:00
+draft: false
+weight: 10
+icon: fas fa-clipboard-list
+---
+
+Below you can find the changelog of the ICPC Tools. It is automatically updated when a new build is crated.
+
+{{< changelog >}}

--- a/website/layouts/shortcodes/changelog.html
+++ b/website/layouts/shortcodes/changelog.html
@@ -1,0 +1,1 @@
+{{ readFile "/Changelog.md" | markdownify }}


### PR DESCRIPTION
This adds the changelog to the website, just above the 'All builds' page. Or at least it should