### PR TITLE
Push CDS image to Docker Hub.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ stages:
   - test
   - deploy
   - website
+  - docker
 
 build:
   image: icpctools/builder
@@ -121,3 +122,21 @@ update website:
     - git add .
     - git commit --allow-empty -m "Update website for icpctools commit $CI_COMMIT_SHA"
     - git push
+
+push cds docker image:
+  image: docker:19.03.12
+  stage: docker
+  rules:
+    - if: '$CI_COMMIT_REF_NAME == "master"'
+      when: always
+    - when: never
+  services:
+    - docker:19.03.12-dind
+  before_script:
+    - apk add git
+    - docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_ACCESS_TOKEN}
+  script:
+    - VERSION=2.2.$(git rev-list $CI_COMMIT_SHA --count)
+    - cd build/cds/Docker
+    - docker build -t icpctools/cds:${VERSION} --build-arg CDS_VERSION=${VERSION} .
+    - docker push icpctools/cds:${VERSION}

--- a/build/cds/Docker/Dockerfile
+++ b/build/cds/Docker/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:focal
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG CDS_VERSION
+
+# Install dependencies
+RUN apt-get update && \ 
+    apt-get install -y --no-install-recommends openjdk-14-jdk-headless unzip ca-certificates curl && \
+    rm -rf /var/lib/apt/lists/
+
+# Install CDS
+RUN mkdir -p /opt && \
+    curl -L -o /opt/wlp.CDS-${CDS_VERSION}.zip https://github.com/icpctools/builds/releases/download/v${CDS_VERSION}/wlp.CDS-${CDS_VERSION}.zip && \
+    unzip /opt/wlp.CDS-${CDS_VERSION}.zip -d /opt
+
+COPY users.xml /opt/wlp/usr/servers/cds/users.xml
+COPY cdsConfig.xml /opt/wlp/usr/servers/cds/config/cdsConfig.xml
+COPY start.sh /usr/local/bin/start.sh
+
+RUN mkdir -p /contest && \
+    mkdir -p /contest/teams && \
+    mkdir -p /contest/organizations
+
+VOLUME /contest
+
+EXPOSE 8443
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/start.sh"]
+CMD /opt/wlp/bin/server run cds

--- a/build/cds/Docker/cdsConfig.xml
+++ b/build/cds/Docker/cdsConfig.xml
@@ -1,0 +1,5 @@
+<cds>
+  <contest location="/contest" recordReactions="false">
+    <ccs url="CCS_URL" user="CCS_USER" password="CCS_PASSWORD"/>
+  </contest>
+</cds>

--- a/build/cds/Docker/start.sh
+++ b/build/cds/Docker/start.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -n "${ADMIN_PASSWORD}" ]; then
+    sed -i "s|ADMIN_PASSWORD|${ADMIN_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${PRESADMIN_PASSWORD}" ]; then
+    sed -i "s|PRESADMIN_PASSWORD|${PRESADMIN_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${BLUE_PASSWORD}" ]; then
+    sed -i "s|BLUE_PASSWORD|${BLUE_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${BALLOON_PASSWORD}" ]; then
+    sed -i "s|BALLOON_PASSWORD|${BALLOON_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${PUBLIC_PASSWORD}" ]; then
+    sed -i "s|PUBLIC_PASSWORD|${PUBLIC_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${PRESENTATION_PASSWORD}" ]; then
+    sed -i "s|PRESENTATION_PASSWORD|${PRESENTATION_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${MYICPC_PASSWORD}" ]; then
+    sed -i "s|MYICPC_PASSWORD|${MYICPC_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+if [ -n "${LIVE_PASSWORD}" ]; then
+    sed -i "s|LIVE_PASSWORD|${LIVE_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
+fi
+
+if [ -n "${CCS_URL}" ]; then
+    sed -i "s|CCS_URL|${CCS_URL}|" /opt/wlp/usr/servers/cds/config/cdsConfig.xml
+fi
+if [ -n "${CCS_USER}" ]; then
+    sed -i "s|CCS_USER|${CCS_USER}|" /opt/wlp/usr/servers/cds/config/cdsConfig.xml
+fi
+if [ -n "${CCS_PASSWORD}" ]; then
+    sed -i "s|CCS_PASSWORD|${CCS_PASSWORD}|" /opt/wlp/usr/servers/cds/config/cdsConfig.xml
+fi
+
+exec "$@"

--- a/build/cds/Docker/users.xml
+++ b/build/cds/Docker/users.xml
@@ -1,0 +1,13 @@
+<server description="ICPC contest clients">
+   <!-- Change passwords immediately to secure the contest -->
+   <basicRegistry>
+      <user name="admin" password="ADMIN_PASSWORD"/>
+      <user name="presAdmin" password="PRESADMIN_PASSWORD"/>
+      <user name="blue" password="BLUE_PASSWORD"/>
+      <user name="balloon" password="BALLOON_PASSWORD"/>
+      <user name="public" password="PUBLIC_PASSWORD"/>
+      <user name="presentation" password="PRESENTATION_PASSWORD"/>
+      <user name="myicpc" password="MYICPC_PASSWORD"/>
+      <user name="live" password="LIVE_PASSWORD"/>
+   </basicRegistry>
+</server>

--- a/website/content/cds.md
+++ b/website/content/cds.md
@@ -34,4 +34,6 @@ required and that the CA configures their use into the CDS) include:
 * an RSS feed for the contest
 * the set of files which a team submitted to the judges for a specific run
 
+Note that a [Docker image](https://hub.docker.com/r/icpctools/cds) also exists for the CDS.
+
 {{< tooldownload name=CDS toolname=wlp.CDS doc=ContestDataServer >}}


### PR DESCRIPTION
This should push a Docker image to https://hub.docker.com/repository/docker/icpctools/cds. I have seen multiple people doing this on their own, so might as well create an 'official' image.

I have created a small readme there on how to run the CDS inside Docker.