### PR TITLE
Switch link parser to better XML parser

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/LinkParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/LinkParser.java
@@ -3,13 +3,13 @@ package org.icpc.tools.contest.model.feed;
 import java.io.IOException;
 import java.io.InputStream;
 
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
-
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.SAXParseException;
-import org.xml.sax.helpers.DefaultHandler;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.EndElement;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
 
 public class LinkParser {
 
@@ -17,40 +17,39 @@ public class LinkParser {
 		void linkFound(String s);
 	}
 
-	public static void parse(final ILinkListener listener, InputStream in) throws Exception {
+	public static void parse(final ILinkListener listener, InputStream in) throws IOException {
 		if (in == null)
 			return;
 
-		SAXParserFactory factory = SAXParserFactory.newInstance();
-		factory.setValidating(false);
-		SAXParser sp = factory.newSAXParser();
-
 		try {
-			sp.parse(in, new DefaultHandler() {
-				boolean inTd = false;
-				@Override
-				public void startElement(String uri, String localName, String qName, Attributes attributes)
-						throws SAXException {
-					if (inTd && "a".endsWith(qName)) {
-						String href = attributes.getValue("href");
-						if (href != null && href.length() > 0) {
+			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+			inputFactory.setProperty(XMLInputFactory.IS_VALIDATING, false);
+			inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+			XMLEventReader reader = inputFactory.createXMLEventReader(in);
+
+			boolean inTd = false;
+			while (reader.hasNext()) {
+				XMLEvent event = reader.nextEvent();
+				if (event.isStartElement()) {
+					StartElement ref = (StartElement) event;
+					String name = ref.getName().toString();
+					if (inTd && "a".equals(name)) {
+						String href = ref.getAttributeByName(new QName("href")).getValue();
+						if (href != null && href.length() > 0)
 							listener.linkFound(href);
-						}
-					} else if ("td".endsWith(qName)) {
+					} else if ("td".equals(name)) {
 						inTd = true;
 					}
 				}
-
-				@Override
-				public void endElement(String uri, String localName, String qName) throws SAXException {
-					if ("td".endsWith(qName)) {
+				if (event.isEndElement()) {
+					EndElement ref = (EndElement) event;
+					String name = ref.getName().toString();
+					if ("td".equals(name)) {
 						inTd = false;
 					}
 				}
-			});
-		} catch (SAXParseException e) {
-			// Trace.trace(Trace.ERROR, "Could not parse xml: '" + e.getMessage() + "' on line " +
-			// e.getLineNumber());
+			}
+		} catch (XMLStreamException e) {
 			throw new IOException("Error reading xml", e);
 		}
 	}


### PR DESCRIPTION
The link parser (used to determine if there are newer copies of any of the clients available on the CDS) is broken by the AdminLte upgrade. Last time this happened it was the same issue (&nbsp is not understood by the SAX parser) and I just removed the space, this time I'll switch to a parser that can handle it.