### PR TITLE
Admin support for multiple display clients

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
@@ -215,21 +215,36 @@ public class ArgumentParser {
 					option = s.toLowerCase();
 					list = new ArrayList<>(2);
 				} else {
-					try {
-						int i = Integer.parseInt(s);
-						list.add(i);
-					} catch (Exception e) {
-						try {
-							float f = Float.parseFloat(s);
-							list.add(f);
-						} catch (Exception ex) {
-							if ("true".equalsIgnoreCase(s))
-								list.add(Boolean.TRUE);
-							else if ("false".equalsIgnoreCase(s))
-								list.add(Boolean.FALSE);
-							else
-								list.add(s);
+					if ("true".equalsIgnoreCase(s))
+						list.add(Boolean.TRUE);
+					else if ("false".equalsIgnoreCase(s))
+						list.add(Boolean.FALSE);
+					else {
+						boolean isInt = true;
+						boolean isFloat = true;
+						for (char c : s.toCharArray()) {
+							if (!Character.isDigit(c) && c != '-') {
+								isInt = false;
+								isFloat = false;
+							}
+							if (c != '.')
+								isFloat = false;
 						}
+						if (isInt)
+							try {
+								list.add(Integer.parseInt(s));
+								continue;
+							} catch (Exception e) {
+								// ignore
+							}
+						if (isFloat)
+							try {
+								list.add(Float.parseFloat(s));
+								continue;
+							} catch (Exception e) {
+								// ignore
+							}
+						list.add(s);
 					}
 				}
 			}


### PR DESCRIPTION
Admin updated to support multi-display clients:
 - When there are multi-display clients, the space in the UI is shared to make it look more like a single client.
 - Label shows 'Multi-display' instead of the client names, and fps is removed.
 - Each thumbnail is scaled and drawn to just show the portion that each client is displaying.
 - Selection automatically selects all clients that belong to the same display so that you can send properties or set presentation to all of them at once.

Forgot to mention in commit - argument parser interpreted '1d' as '1.0', so I fixed it.
<img width="351" alt="Screen Shot 2021-01-26 at 10 59 29 AM" src="https://user-images.githubusercontent.com/19958075/105877788-56da9780-5fce-11eb-8e67-0c5df401ea8e.png">
