### PR TITLE
Command line support for --multi-display

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 -----------------
 * Move to Github and Gitlab.
 * Moved to new hostname and [website](https://tools.icpc.global).
-* New icons.
+* New logo and icons!
 * Common command line parser and further command line consistency.
 * XML event feed removed everywhere but CDS. If your CCS only supports the XML feed, you must use the CDS as a proxy to use the other tools.
 * Support for Contest API improvements and numerous fixes.
@@ -18,18 +18,22 @@
   * Support for contest commentary events.
   * Support for team audio streaming.
   * Ability to drive resolver clients from web UI.
+* Presentation admin:
+  * Show presentations that extend across multiple displays as one.
 * Presentation client:
   * Initial new fireworks presentation.
   * New organization logo presentations.
   * New ICPC Tools presentation.
   * New CCS presentation.
   * Fixed calculation of 'recent' events.
+  * Support for presentations extending across multiple displays.
 * Resolver:
   * Ability to provide custom resolution steps.
   * Refactored resolution into core contest API. Resolution no longer a bunch of custom code in the resolver, and other tools could use it as well.
   * Award templates - ability to apply awards based on a spec. Useful for easily applying the same awards to test & real contests.
   * Odd solution awards removed.
-  * Ability to filtering teams by group.
+  * Ability to filter teams by group.
+  * Support for presentations extending across multiple displays.
 * Numerous release improvements:
   * Switched from asciidoc to markdown for documentation.
   * Build improvements & simplification.

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/DisplayConfig.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/DisplayConfig.java
@@ -34,12 +34,15 @@ public class DisplayConfig {
 
 	/**
 	 *
-	 * @param displayStr - 1, 1a
-	 * @param multiDisplay - 2@3x2, 1@2x2c
+	 * display - 1, 1a. multiDisplay - 2@3x2, 1@2x2c
 	 */
-	public DisplayConfig(String display, String multiDisplay) {
+	public DisplayConfig(String display, String multiDisplay) throws IllegalArgumentException {
 		if (display != null) {
-			device = Integer.parseInt(display.charAt(0) + "") - 1;
+			try {
+				device = Integer.parseInt(display.charAt(0) + "") - 1;
+			} catch (Exception e) {
+				throw new IllegalArgumentException("Invalid display argument, should be a digit");
+			}
 
 			mode = Mode.FULL_SCREEN;
 			if (display.length() == 2) {
@@ -58,13 +61,17 @@ public class DisplayConfig {
 			ww = 1;
 			hh = 1;
 		} else {
-			pos = Integer.parseInt(multiDisplay.charAt(0) + "") - 1;
-			ww = Integer.parseInt(multiDisplay.charAt(2) + "");
-			hh = Integer.parseInt(multiDisplay.charAt(4) + "");
-			if (multiDisplay.length() > 5)
-				id = multiDisplay.charAt(5) - 'a';
-			else
-				id = 0;
+			try {
+				pos = Integer.parseInt(multiDisplay.charAt(0) + "") - 1;
+				ww = Integer.parseInt(multiDisplay.charAt(2) + "");
+				hh = Integer.parseInt(multiDisplay.charAt(4) + "");
+				if (multiDisplay.length() > 5)
+					id = multiDisplay.charAt(5) - 'a';
+				else
+					id = 0;
+			} catch (Exception e) {
+				throw new IllegalArgumentException("Invalid multi-display argument, should be in p@wxh format");
+			}
 		}
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -30,6 +30,9 @@ public class ClientLauncher {
 		System.out.println("     --display #");
 		System.out.println("         Use the specified display");
 		System.out.println("         1 = primary display, 2 = secondary display, etc.");
+		System.out.println("     --multi-display p@wxh");
+		System.out.println("         This presentation is stretched across multiple client displays");
+		System.out.println("         Use \"2@3x2\" to indicate this client is position 2 (top middle) in a 3x2 grid");
 		System.out.println("     --fps");
 		System.out.println("         Show the frame rate on screen");
 		System.out.println("     --help");
@@ -57,7 +60,7 @@ public class ClientLauncher {
 					displayStr[0] = (String) options.get(0);
 					return true;
 				} else if ("--multi-display".equals(option)) {
-					ArgumentParser.expectOptions(option, options, "#:string");
+					ArgumentParser.expectOptions(option, options, "p@wxh:string");
 					displayStr[1] = (String) options.get(0);
 					return true;
 				} else if ("--fps".equals(option)) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -46,7 +46,7 @@ public class StandaloneLauncher {
 					displayStr[0] = (String) options.get(0);
 					return true;
 				} else if ("--multi-display".equals(option)) {
-					ArgumentParser.expectOptions(option, options, "#:string");
+					ArgumentParser.expectOptions(option, options, "p@wxh:string");
 					displayStr[1] = (String) options.get(0);
 					return true;
 				} else if ("--fps".equals(option)) {
@@ -100,6 +100,9 @@ public class StandaloneLauncher {
 		System.out.println("     --display #");
 		System.out.println("         Use the specified display");
 		System.out.println("         1 = primary display, 2 = secondary display, etc.");
+		System.out.println("     --multi-display p@wxh");
+		System.out.println("         This presentation is stretched across multiple client displays");
+		System.out.println("         Use \"2@3x2\" to indicate this client is position 2 (top middle) in a 3x2 grid");
 		System.out.println("     --fps");
 		System.out.println("         Show the frame rate on screen");
 		System.out.println("     --help");

--- a/PresCore/src/org/icpc/tools/presentation/core/DisplayConfig.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/DisplayConfig.java
@@ -34,12 +34,15 @@ public class DisplayConfig {
 
 	/**
 	 *
-	 * @param displayStr - 1, 1a
-	 * @param multiDisplay - 2@3x2, 1@2x2c
+	 * display - 1, 1a. multiDisplay - 2@3x2, 1@2x2c
 	 */
-	public DisplayConfig(String display, String multiDisplay) {
+	public DisplayConfig(String display, String multiDisplay) throws IllegalArgumentException {
 		if (display != null) {
-			device = Integer.parseInt(display.charAt(0) + "") - 1;
+			try {
+				device = Integer.parseInt(display.charAt(0) + "") - 1;
+			} catch (Exception e) {
+				throw new IllegalArgumentException("Invalid display argument, should be a digit");
+			}
 
 			mode = Mode.FULL_SCREEN;
 			if (display.length() == 2) {
@@ -58,13 +61,17 @@ public class DisplayConfig {
 			ww = 1;
 			hh = 1;
 		} else {
-			pos = Integer.parseInt(multiDisplay.charAt(0) + "") - 1;
-			ww = Integer.parseInt(multiDisplay.charAt(2) + "");
-			hh = Integer.parseInt(multiDisplay.charAt(4) + "");
-			if (multiDisplay.length() > 5)
-				id = multiDisplay.charAt(5) - 'a';
-			else
-				id = 0;
+			try {
+				pos = Integer.parseInt(multiDisplay.charAt(0) + "") - 1;
+				ww = Integer.parseInt(multiDisplay.charAt(2) + "");
+				hh = Integer.parseInt(multiDisplay.charAt(4) + "");
+				if (multiDisplay.length() > 5)
+					id = multiDisplay.charAt(5) - 'a';
+				else
+					id = 0;
+			} catch (Exception e) {
+				throw new IllegalArgumentException("Invalid multi-display argument, should be in p@wxh format");
+			}
 		}
 	}
 

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -80,7 +80,7 @@ public class ResolverUI {
 	private ResolutionControl control;
 	private boolean isPresenter;
 	private Screen screen = Screen.MAIN;
-	private String displayStr;
+	private DisplayConfig displayConfig;
 	private boolean showInfo;
 	private boolean pauseScroll = false;
 	private Style style;
@@ -104,11 +104,11 @@ public class ResolverUI {
 	private long lastClickTime = -1;
 	private Thread thread;
 
-	public ResolverUI(List<ResolutionStep> steps, boolean showInfo, String display, boolean isPresenter, Screen screen,
-			ClickListener listener, Style style) {
+	public ResolverUI(List<ResolutionStep> steps, boolean showInfo, DisplayConfig displayConfig, boolean isPresenter,
+			Screen screen, ClickListener listener, Style style) {
 		this.steps = steps;
 		this.showInfo = showInfo;
-		this.displayStr = display;
+		this.displayConfig = displayConfig;
 		this.isPresenter = isPresenter;
 		this.screen = screen;
 		if (screen == null)
@@ -191,9 +191,9 @@ public class ResolverUI {
 		window = PresentationWindow.open("Resolver", iconImage);
 
 		try {
-			window.setDisplayConfig(new DisplayConfig(displayStr));
+			window.setDisplayConfig(displayConfig);
 		} catch (Exception e) {
-			Trace.trace(Trace.WARNING, "Invalid display option: " + displayStr + " " + e.getMessage());
+			Trace.trace(Trace.WARNING, "Invalid display option: " + displayConfig + " " + e.getMessage());
 		}
 
 		window.addKeyListener(new KeyAdapter() {


### PR DESCRIPTION
Clean up and expose the --multi-display option so that it can be used from the command line. Added basic validation.
Added to presentation clients & resolver. Although the last is unlikely to be used, you never know and it keeps all clients in sync.
I did not update the readmes since they already do not show all cli options. IMHO this is ok, advanced options can just be shown in --help.