### PR TITLE
Avoid Java 11 reflection errors setting dock image

### DIFF
--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -846,7 +846,7 @@ public class CoachView extends Panel {
 		try {
 			BufferedImage image = ImageIO.read(CoachView.class.getClassLoader().getResource("images/coachViewIcon.png"));
 			frame.setIconImage(image);
-			setMacIconImage(image);
+			setTaskbarImage(image);
 		} catch (Exception e) {
 			// could not set icon
 		}
@@ -939,9 +939,24 @@ public class CoachView extends Panel {
 		requestFocus();
 	}
 
-	private static void setMacIconImage(Image iconImage) {
-		// call com.apple.eawt.Application.getApplication().setDockIconImage(img) without a direct
-		// dependency
+	private static void setTaskbarImage(Image iconImage) {
+		// call java.awt.Taskbar.getTaskbar().setIconImage() (Java 9+) or
+		// for Mac Java 8 call com.apple.eawt.Application.getApplication().setDockIconImage()
+		// without direct dependencies
+		try {
+			Class<?> c = Class.forName("java.awt.Taskbar");
+			Method m = c.getDeclaredMethod("getTaskbar");
+			Object o = m.invoke(null);
+			m = c.getDeclaredMethod("setIconImage", Image.class);
+			m.invoke(o, iconImage);
+			return;
+		} catch (Exception e) {
+			// ignore
+		}
+
+		if (!System.getProperty("os.name").contains("Mac"))
+			return;
+
 		try {
 			Class<?> c = Class.forName("com.apple.eawt.Application");
 			Method m = c.getDeclaredMethod("getApplication");
@@ -949,7 +964,7 @@ public class CoachView extends Panel {
 			m = c.getDeclaredMethod("setDockIconImage", Image.class);
 			m.invoke(o, iconImage);
 		} catch (Exception e) {
-			// ignore, we're not on Mac
+			// ignore
 		}
 	}
 

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -149,9 +149,24 @@ public class Resolver {
 		System.out.println("     i      - Toggle additional info");
 	}
 
-	private static void setMacIconImage(Image iconImage) {
-		// call com.apple.eawt.Application.getApplication().setDockIconImage(img) without a direct
-		// dependency
+	private static void setTaskbarImage(Image iconImage) {
+		// call java.awt.Taskbar.getTaskbar().setIconImage() (Java 9+) or
+		// for Mac Java 8 call com.apple.eawt.Application.getApplication().setDockIconImage()
+		// without direct dependencies
+		try {
+			Class<?> c = Class.forName("java.awt.Taskbar");
+			Method m = c.getDeclaredMethod("getTaskbar");
+			Object o = m.invoke(null);
+			m = c.getDeclaredMethod("setIconImage", Image.class);
+			m.invoke(o, iconImage);
+			return;
+		} catch (Exception e) {
+			// ignore
+		}
+
+		if (!System.getProperty("os.name").contains("Mac"))
+			return;
+
 		try {
 			Class<?> c = Class.forName("com.apple.eawt.Application");
 			Method m = c.getDeclaredMethod("getApplication");
@@ -159,7 +174,7 @@ public class Resolver {
 			m = c.getDeclaredMethod("setDockIconImage", Image.class);
 			m.invoke(o, iconImage);
 		} catch (Exception e) {
-			// ignore, we're not on Mac
+			// ignore
 		}
 	}
 
@@ -193,7 +208,7 @@ public class Resolver {
 		} catch (Exception e) {
 			// could not set title or icon
 		}
-		setMacIconImage(iconImage);
+		setTaskbarImage(iconImage);
 
 		for (ContestSource cs : contestSource)
 			cs.outputValidation();


### PR DESCRIPTION
To set the dock image on Mac on Java 8 you have to use reflection. The correct API to do this was added in Java 9, and Java 11 now warns that access to this class will be removed. In order to support both environments we need reflection that tries both paths.

Avoids warnings like the following:
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.icpc.tools.coachview.CoachView (file:/.../lib/coachview.jar) to method com.apple.eawt.Application.getApplication()
WARNING: Please consider reporting this to the maintainers of org.icpc.tools.coachview.CoachView
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release