### PR TITLE
Fix Resolver NPE

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -193,6 +193,11 @@ public class Resolver {
 			}
 		});
 
+		if (contestSource == null) {
+			showHelp();
+			return;
+		}
+
 		String log = "resolver";
 		List<String> argList = Arrays.asList(args);
 		if (argList.contains("--client"))


### PR DESCRIPTION
Avoid an NPE if you launch the resolver with no arguments, show the help instead