### PR TITLE
Improve client reconnect

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
@@ -757,7 +757,7 @@ public class BalloonUtility {
 						msTimeDelta = time - System.currentTimeMillis();
 					}
 				};
-				client.connect(true);
+				client.connect();
 			}
 		}
 		/*runAsync(new Runnable() {

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -540,7 +540,7 @@ public class CoachView extends Panel {
 
 			if (contestSource.isCDS()) {
 				BasicClient client = new BasicClient(contestSource, "Coach");
-				client.connect(true);
+				client.connect();
 			}
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Connection to CDS was not successful, check credentials/URL", e);

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
@@ -182,7 +182,7 @@ public class View {
 	}
 
 	protected void connect() {
-		client.connect(true);
+		client.connect();
 	}
 
 	protected void addPresentations(final List<PresentationInfo> list) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -111,7 +111,7 @@ public class ClientLauncher {
 				}
 			}
 		});
-		client.connect(false);
+		client.connect();
 	}
 
 	protected static void createWindow(final PresentationClient client, final boolean sendthumbnails, boolean showFPS) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ScalingTestClient.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ScalingTestClient.java
@@ -46,7 +46,7 @@ public class ScalingTestClient {
 					}
 				}
 			});
-			client.connect(false);
+			client.connect();
 		}
 	}
 


### PR DESCRIPTION
After talking to John about Tyrus websocket clients I realized there was an unnecessary connection thread hanging around and looping every 2s, and some clients were launching it as a daemon and others not. I confirmed they can all be daemon and rewrote the reconnection logic to not require the thread to stick around.
While I was at it I implemented some basic incremental back-off. Clients used to just retry every 5s, now they retry immediately, then back off to 2s, 5s, and then 20s.