### PR TITLE
Use main repository for releases.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,25 +41,13 @@ push release to GitHub:
     - if: '$CI_COMMIT_REF_NAME == "master"'
       when: always
     - when: never
-  before_script:
-    - eval $(ssh-agent -s)
-    - echo "$SSH_PRIVATE_KEY" | tr -d '\r' | ssh-add -
-    - mkdir -p ~/.ssh
-    - chmod 700 ~/.ssh
-    - ssh-keyscan -t rsa github.com >> ~/.ssh/known_hosts
-    - git config --global user.email "bot@icpctools.org"
-    - git config --global user.name "ICPC Tools bot"
   script:
-    - VERSION=2.2.$(git rev-list $CI_COMMIT_SHA --count)
-    - mkdir ~/builds
-    - cd ~/builds
-    - git clone git@github.com:icpctools/builds.git .
-    - git commit --allow-empty -m "Add build $VERSION"
-    - git push
+    - export VERSION_PREFIX=$(awk -F '=' '{ print $2 } ' version.properties)
+    - VERSION=${VERSION_PREFIX}.$(git rev-list $CI_COMMIT_SHA --count)
     - RELEASE_COMMIT=$(git rev-parse HEAD)
     - |
       http --ignore-stdin POST \
-        https://api.github.com/repos/icpctools/builds/releases \
+        https://api.github.com/repos/icpctools/icpctools/releases \
         "Authorization: token $GITHUB_TOKEN" \
         "Accept: application/vnd.github.v3+json" \
         tag_name=v$VERSION \
@@ -67,7 +55,7 @@ push release to GitHub:
         name=v$VERSION \
         prerelease:=true | tee ~/new-release.txt
     - RELEASE_ID=$(cat ~/new-release.txt | jq .id)
-    - RELEASE_ASSET_UPLOAD_URL=https://uploads.github.com/repos/icpctools/builds/releases/${RELEASE_ID}/assets
+    - RELEASE_ASSET_UPLOAD_URL=https://uploads.github.com/repos/icpctools/icpctools/releases/${RELEASE_ID}/assets
     - cd $CI_PROJECT_DIR/dist
     - echo "Uploading release $VERSION"
     - |
@@ -134,7 +122,8 @@ push cds docker image:
     - apk add git
     - docker login -u ${DOCKER_HUB_USERNAME} -p ${DOCKER_HUB_ACCESS_TOKEN}
   script:
-    - VERSION=2.2.$(git rev-list $CI_COMMIT_SHA --count)
+    - export VERSION_PREFIX=$(awk -F '=' '{ print $2 } ' version.properties)
+    - VERSION=${VERSION_PREFIX}.$(git rev-list $CI_COMMIT_SHA --count)
     - cd build/cds/Docker
     - docker build -t icpctools/cds:${VERSION} --build-arg CDS_VERSION=${VERSION} .
     - docker push icpctools/cds:${VERSION}

--- a/website/scripts/populate-releases.py
+++ b/website/scripts/populate-releases.py
@@ -10,7 +10,7 @@ destination = "website/data/releases/"
 def all_releases():
     result = []
 
-    url = 'https://api.github.com/repos/icpctools/builds/releases'
+    url = 'https://api.github.com/repos/icpctools/icpctools/releases'
 
     linkPattern = re.compile(r'<(?P<url>.*)>; rel="(?P<type>.*)"')
 
@@ -28,7 +28,7 @@ def all_releases():
         if not nextFound:
             break
 
-    return sorted(result, key=lambda release: release["published_at"], reverse=True)
+    return sorted(result, key=lambda release: release["created_at"], reverse=True)
 
 def request_from_github(url):
     token = os.environ["GITHUB_TOKEN"]
@@ -44,8 +44,8 @@ def release_info(release):
     assetPattern = re.compile(r'(?P<tool>.*)-(?P<version>\d+\.\d+\.\d+)\.zip\.?(?P<check>.*)?')
     info = {
         'version': release['tag_name'].replace('v', ''),
-        'date': datetime.datetime.strptime(release['published_at'], "%Y-%m-%dT%H:%M:%SZ").strftime("%d %B %Y"),
-        'time': datetime.datetime.strptime(release['published_at'], "%Y-%m-%dT%H:%M:%SZ").strftime("%H:%M:%S"),
+        'date': datetime.datetime.strptime(release['created_at'], "%Y-%m-%dT%H:%M:%SZ").strftime("%d %B %Y"),
+        'time': datetime.datetime.strptime(release['created_at'], "%Y-%m-%dT%H:%M:%SZ").strftime("%H:%M:%S"),
         'downloads': {}
     }
 


### PR DESCRIPTION
This will use the main repository for the releases.
My script that uploads ZIP's to the old releases is still running for a while but when it is done and we have merged this, we can get rid of the `build` repo.

I also fixed that the .gitlab-ci.yml will now get the version string from `version.properties` so we have only one place where it is stored.