### PR TITLE
Improve website text

### DIFF
--- a/website/content/changelog.md
+++ b/website/content/changelog.md
@@ -7,6 +7,6 @@ weight: 10
 icon: fas fa-clipboard-list
 ---
 
-Below you can find the changelog of the ICPC Tools. It is automatically updated when a new build is crated.
+You can find the changelog of the ICPC Tools below. It is automatically updated when a new build is created.
 
 {{< changelog >}}

--- a/website/layouts/shortcodes/toolblock.html
+++ b/website/layouts/shortcodes/toolblock.html
@@ -9,8 +9,8 @@
     </p>
     <p>
         Downloads: <br/> 
-        Stable: <a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} version {{ $stableTool.version }}</a><br />
-        Prerelease: <a href="{{ $prerelaseTool.urls.zip }}">{{ .Get "shortname" }} version {{ $prerelaseTool.version }}</a><br />
+        Stable: <a href="{{ $stableTool.urls.zip }}">{{ .Get "shortname" }} v{{ $stableTool.version }}</a><br />
+        Prerelease: <a href="{{ $prerelaseTool.urls.zip }}">{{ .Get "shortname" }} v{{ $prerelaseTool.version }}</a><br />
         Documentation: <a href="/docs/{{ .Get "doc" }}.pdf">PDF</a><br />
     </p>
     <p>

--- a/website/layouts/shortcodes/tooldownload.html
+++ b/website/layouts/shortcodes/tooldownload.html
@@ -8,13 +8,13 @@
     The latest stable {{ .Get "name" }} version is {{ $stableTool.version }}, released on {{ $stableRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-primary" href="{{ $stableTool.urls.zip }}"><i class="fas fa-download"></i> Download stable <i>{{ .Get "name" }}</i> (version {{ $stableTool.version }})</a>
+    <a class="btn btn-primary" href="{{ $stableTool.urls.zip }}"><i class="fas fa-download"></i> Download stable release v{{ $stableTool.version }}</a>
 </p>
 <p>
-    The latest prerelease {{ .Get "name" }} version is {{ $prerelaseTool.version }}, released on {{ $preRelease.date }}.
+    The latest prerelease is v{{ $prerelaseTool.version }}, built on {{ $preRelease.date }}.
 </p>
 <p>
-    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.zip }}"><i class="fas fa-download"></i> Download prerelease <i>{{ .Get "name" }}</i> (version {{ $prerelaseTool.version }})</a>
+    <a class="btn btn-danger" href="{{ $prerelaseTool.urls.zip }}"><i class="fas fa-download"></i> Download prerelease build v{{ $prerelaseTool.version }}</a>
 </p>
 
 <h2>Documentation</h2>


### PR DESCRIPTION
Fix typo, reduce 'version' to 'v' in several places, and reduce the number of times it uses the tool name.