### PR TITLE
Add team role & login

### DIFF
--- a/CDS/README.md
+++ b/CDS/README.md
@@ -355,6 +355,25 @@ The attribute associated with the *user* element is as follows:
 
 * name: the name of a user, which must match one of the existing users.
 
+###### teamUser Element
+
+```
+<teamUser>
+  <user name="team1" teamId="1"/>
+  <user name="steven" teamId="2"/>
+  <user name="mark" teamId="2"/>
+</teamUser>
+```
+
+The global *teamUser* element allows you to map a team user login to their identity (team id) within a contest. By providing
+this mapping the team will be able to see all of their own judgements and clarifications in the contest. In the example above,
+there is one login for the team with id 1, and two logins for team 2.
+
+The attribute associated with the *user* element is as follows:
+
+* name: the name of a user, which must match one of the existing users.
+* teamId: the team's id within a contest.
+
 
 ### Starting the CDS
 

--- a/CDS/WebContent/WEB-INF/jsps/freeze.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/freeze.jsp
@@ -1,8 +1,8 @@
 <%@ page import="org.icpc.tools.contest.model.*" %>
 <% request.setAttribute("title", "Freeze"); %>
 <%@ include file="layout/head.jsp" %>
-<% IContest contest2 = cc.getContestByRole(Role.BLUE);
-    IContest contest1 = cc.getContestByRole(Role.PUBLIC);
+<% IContest contest2 = cc.getContestByRole(true);
+    IContest contest1 = cc.getContestByRole(false);
     IState state = contest1.getState(); %>
 <div class="container-fluid">
     <div class="row">

--- a/CDS/WebContent/WEB-INF/web.xml
+++ b/CDS/WebContent/WEB-INF/web.xml
@@ -20,6 +20,9 @@
   <security-role>
   	<role-name>balloon</role-name>
   </security-role>
+  <security-role>
+  	<role-name>team</role-name>
+  </security-role>
   <login-config>
     <auth-method>FORM</auth-method>
     <realm-name>CDS</realm-name>

--- a/CDS/config/tomcat/conf/config/cdsConfig.xml
+++ b/CDS/config/tomcat/conf/config/cdsConfig.xml
@@ -34,4 +34,13 @@
     <user name="presentation"/>
   </domain>
   -->
+
+  <!-- Team user to id mapping. Uncomment to assign team users to the contest team id that they belong to.
+       You can create one user login per team, one per team member, or whatever you choose.
+       Without this, team logins will only have access to public data -->
+  <!--
+  <teamUsers>
+    <user name="team1" teamId="1"/>
+  </teamUsers>
+  -->
 </cds>

--- a/CDS/config/tomcat/conf/tomcat-users.xml
+++ b/CDS/config/tomcat/conf/tomcat-users.xml
@@ -29,8 +29,10 @@
   <role rolename="balloon"/>
   <role rolename="trusted"/>
   <role rolename="public"/>
+  <role rolename="team"/>
   <user name="deboer" password="adm1n" roles="admin"/>
   <user name="balloon" password="ball00n" roles="balloon"/>
   <user name="live" password="l1ve" roles="trusted"/>
   <user name="presentation" password="presentat1on" roles="public"/>
+  <user name="team1" password="t3am" roles="team"/>
 </tomcat-users>

--- a/CDS/config/wlp/cds/config/cdsConfig.xml
+++ b/CDS/config/wlp/cds/config/cdsConfig.xml
@@ -34,4 +34,13 @@
     <user name="presentation"/>
   </domain>
   -->
+
+  <!-- Team user to id mapping. Uncomment to assign team users to the contest team id that they belong to.
+       You can create one user login per team, one per team member, or whatever you choose.
+       Without this, team logins will only have access to public data -->
+  <!--
+  <teamUsers>
+    <user name="team1" teamId="1"/>
+  </teamUsers>
+  -->
 </cds>

--- a/CDS/config/wlp/cds/server.xml
+++ b/CDS/config/wlp/cds/server.xml
@@ -35,6 +35,9 @@
             <user name="presentation"/>
             <user name="public"/>
          </security-role>
+         <security-role name="team">
+         	<user name="team1"/>
+         </security-role>
        </application-bnd>
     </webApplication>
 

--- a/CDS/config/wlp/cds/users.xml
+++ b/CDS/config/wlp/cds/users.xml
@@ -9,5 +9,6 @@
       <user name="presentation" password="presentat1on"/>
       <user name="myicpc" password="my1cpc"/>
       <user name="live" password="l1ve"/>
+      <user name="team1" password="t3am"/>
    </basicRegistry>
 </server>

--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -76,9 +76,25 @@ public class CDSConfig {
 		}
 	}
 
+	public static class TeamUser {
+		private String name = null;
+		private String id = null;
+
+		protected TeamUser(Element e) {
+			name = e.getAttribute("name");
+			id = e.getAttribute("teamId");
+		}
+
+		@Override
+		public String toString() {
+			return "Team user [" + name + "]";
+		}
+	}
+
 	private ConfiguredContest[] contests;
 	private long[] contestHashes;
 	private Domain[] domains;
+	private TeamUser[] teamUsers;
 	private File file;
 	private long lastModified;
 
@@ -229,10 +245,43 @@ public class CDSConfig {
 			}
 			domains = temp;
 		}
+
+		Element teamElement = getChild(e, "teamUsers");
+		if (teamElement != null) {
+			children = CDSConfig.getChildren(teamElement, "user");
+			int num = children.length;
+
+			TeamUser[] temp = new TeamUser[num];
+			for (int i = 0; i < num; i++) {
+				temp[i] = new TeamUser(children[i]);
+			}
+			teamUsers = temp;
+		}
 	}
 
 	public Domain[] getDomains() {
 		return domains;
+	}
+
+	public TeamUser[] getTeamLogins() {
+		return teamUsers;
+	}
+
+	/**
+	 * Converts from team user name to team id, e.g. "team57" to "57".
+	 *
+	 * @param userName
+	 * @return the team's id, or null if not found
+	 */
+	public String getTeamIdFromUser(String userName) {
+		if (teamUsers == null || userName == null)
+			return null;
+
+		for (TeamUser login : teamUsers) {
+			if (userName.equals(login.name))
+				return login.id;
+		}
+		return null;
 	}
 
 	private static Element readElement(File file) throws Exception {

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -47,7 +47,7 @@ import org.icpc.tools.contest.model.util.ScoreboardUtil;
 
 @WebServlet(urlPatterns = { "/contests", "/contests/*" }, asyncSupported = true)
 @ServletSecurity(@HttpConstraint(transportGuarantee = ServletSecurity.TransportGuarantee.CONFIDENTIAL, rolesAllowed = {
-		Role.ADMIN, Role.BLUE, Role.BALLOON, Role.TRUSTED, Role.PUBLIC }))
+		Role.ADMIN, Role.BLUE, Role.BALLOON, Role.TRUSTED, Role.TEAM, Role.PUBLIC }))
 public class ContestWebService extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 

--- a/CDS/src/org/icpc/tools/cds/util/Role.java
+++ b/CDS/src/org/icpc/tools/cds/util/Role.java
@@ -8,6 +8,7 @@ public class Role {
 	public static final String BLUE = "blue";
 	public static final String BALLOON = "balloon";
 	public static final String TRUSTED = "trusted";
+	public static final String TEAM = "team";
 	public static final String PUBLIC = "public";
 
 	public static boolean isAdmin(HttpServletRequest request) {
@@ -29,5 +30,9 @@ public class Role {
 
 	public static boolean isBalloon(HttpServletRequest request) {
 		return request.isUserInRole(BALLOON);
+	}
+
+	public static boolean isTeam(HttpServletRequest request) {
+		return request.isUserInRole(TEAM);
 	}
 }


### PR DESCRIPTION
Create a new role for teams to log into the CDS or use REST services.

Notes:
- Defining a team user, password, and role are identical to other users. cdsConfig.xml has been updated to allow mapping from team login user name to the team's id in the contest(s).
- There was some mock team contest code in ConfiguredContest from a previous test of the ability to support this. I've rewritten that to not be hard-coded and create the team's contest (view) when it is defined in the contest.
- Teams now have access to the correct data - their own judgements and clarifications.
- I simplified getContestByRole(String) to a boolean because it was only being used in one place/purpose (verifying freeze). It cannot handle the team role (and doesn't need to) so better to simplify and make this obvious.