### PR TITLE
Don't create contest view if no login exists

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -78,11 +78,11 @@ public class CDSConfig {
 
 	public static class TeamUser {
 		private String name = null;
-		private String id = null;
+		private String teamId = null;
 
 		protected TeamUser(Element e) {
 			name = e.getAttribute("name");
-			id = e.getAttribute("teamId");
+			teamId = e.getAttribute("teamId");
 		}
 
 		@Override
@@ -268,6 +268,23 @@ public class CDSConfig {
 	}
 
 	/**
+	 * Returns true if there are any user logins for the given team id, and false otherwise.
+	 *
+	 * @param team id
+	 * @return true if there is a login, and false otherwise
+	 */
+	public boolean hasLoginForId(String teamId) {
+		if (teamUsers == null || teamId == null)
+			return false;
+
+		for (TeamUser user : teamUsers) {
+			if (teamId.equals(user.teamId))
+				return true;
+		}
+		return false;
+	}
+
+	/**
 	 * Converts from team user name to team id, e.g. "team57" to "57".
 	 *
 	 * @param userName
@@ -277,9 +294,9 @@ public class CDSConfig {
 		if (teamUsers == null || userName == null)
 			return null;
 
-		for (TeamUser login : teamUsers) {
-			if (userName.equals(login.name))
-				return login.id;
+		for (TeamUser user : teamUsers) {
+			if (userName.equals(user.name))
+				return user.teamId;
 		}
 		return null;
 	}

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -641,9 +641,8 @@ public class ConfiguredContest {
 				if (obj instanceof ITeam) {
 					ITeam team = (ITeam) obj;
 					String teamId = team.getId();
-					Contest c = teamContests.get(teamId);
-					if (c == null) {
-						c = new Contest();
+					if (CDSConfig.getInstance().hasLoginForId(teamId) && teamContests.get(teamId) == null) {
+						Contest c = new Contest();
 						c.setHashCode(contest.hashCode());
 						IContestObject[] objs = publicContest.getObjects();
 						for (IContestObject co : objs)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # ICPC Tools Changelog
 
+## V2.3 - TBD
+-----------------
+* CDS:
+  * Support for team login and team-specific contest views
+
 ## V2.2 - February, 2021
 -----------------
 * First open release!


### PR DESCRIPTION
15 minutes later and I already thought of an obvious improvement: if there is no login for a team, don't bother creating a contest view for it. Although the memory bump per team is small, this means no change from 2.2 if you aren't adding team logins, or less memory use if you aren't creating logins for every team in every contest.

Also realized I can update the changelog for 2.3!