### PR TITLE
Reorder log file setup and option parsing

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -179,6 +179,14 @@ public class Resolver {
 	}
 
 	public static void main(String[] args) {
+		String log = "resolver";
+		List<String> argList = Arrays.asList(args);
+		if (argList.contains("--client"))
+			log += "-client";
+		else if (argList.contains("--team"))
+			log += "-team";
+		Trace.init("ICPC Resolver", log, args);
+
 		// create the Resolver object
 		final Resolver r = new Resolver();
 		ContestSource[] contestSource = ArgumentParser.parseMulti(args, new OptionParser() {
@@ -198,15 +206,7 @@ public class Resolver {
 			return;
 		}
 
-		String log = "resolver";
-		List<String> argList = Arrays.asList(args);
-		if (argList.contains("--client"))
-			log += "-client";
-		else if (argList.contains("--team"))
-			log += "-team";
-		Trace.init("ICPC Resolver", log, args);
 		System.setProperty("apple.awt.application.name", "Resolver");
-
 		BufferedImage iconImage = null;
 		try {
 			iconImage = ImageIO.read(r.getClass().getClassLoader().getResource("images/resolverIcon.png"));


### PR DESCRIPTION
The resolver logs to one of three log files to make it easy to have client and server running on the same machine and view the logs - but b/c option parsing happens before this you would see output like "Option found: --speed 0.3" on the command line. Reordering where this happens to avoid log file escapes.