### PR TITLE
Support submission interface

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -761,11 +761,9 @@ public class ContestRESTService extends HttpServlet {
 			File f = dsource.getNewFile(ContestType.SUBMISSION, sId, "files");
 			if (!f.getParentFile().exists())
 				f.getParentFile().mkdirs();
-			String fs = (String) obj.get("files");
-			JSONParser parser2 = new JSONParser(fs);
-			Object[] files = parser2.readArray();
-			JsonObject obj2 = (JsonObject) files[0];
-			String fb = obj2.getString("data");
+			Object[] files = (Object[]) obj.get("files");
+			JsonObject file = (JsonObject) files[0];
+			String fb = (String) file.get("data");
 			Trace.trace(Trace.INFO, "Saving submission " + sId + " to " + f);
 			BufferedOutputStream out = null;
 			try {

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -673,7 +673,7 @@ public class ContestRESTService extends HttpServlet {
 		String type = segments[1];
 		ContestType cType = IContestObject.getTypeByName(type);
 		if (cType != ContestType.SUBMISSION) {
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid type");
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "POST can only be used for submissions");
 			return;
 		}
 
@@ -743,7 +743,7 @@ public class ContestRESTService extends HttpServlet {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "No CCS configured");
 			return;
 		} else if (!(source instanceof RESTContestSource)) {
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "CCS does not support submissions via the CCS");
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "CCS does not support submissions via the CDS");
 			return;
 		} else {
 			try {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
@@ -153,7 +153,14 @@ public class JSONParser {
 		}
 	}
 
-	private String readValue() {
+	public String readValue() {
+		Token t = nextToken();
+		if (t != Token.QUOTE)
+			throw new IllegalArgumentException("Unexpected token");
+		return readValueBody();
+	}
+
+	private String readValueBody() {
 		int st = ind;
 		char c = s.charAt(st);
 		while (c != '"' || s.charAt(ind - 1) == '\\') {
@@ -196,7 +203,7 @@ public class JSONParser {
 		if (t != Token.QUOTE)
 			throw new IllegalArgumentException("Unexpected " + t);
 
-		String key = readValue();
+		String key = readValueBody();
 
 		t = nextToken();
 		if (t != Token.COLON)
@@ -207,7 +214,7 @@ public class JSONParser {
 		Object value = null;
 		if (t == Token.QUOTE) {
 			// quoted value
-			value = readValue();
+			value = readValueBody();
 		} else if (t == Token.OBJECT_START) {
 			ind--;
 			value = readObject();
@@ -234,7 +241,7 @@ public class JSONParser {
 			Object value = null;
 			if (t == Token.QUOTE) {
 				// quoted value
-				value = readValue();
+				value = readValueBody();
 			} else if (t == Token.OBJECT_START) {
 				ind--;
 				value = readObject();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
@@ -91,6 +91,10 @@ public class JSONParser {
 			}
 		}
 
+		public void put(String key, Object value) {
+			props.put(key, value);
+		}
+
 		@Override
 		public String toString() {
 			StringBuilder sb = new StringBuilder("JSON [");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONWriter.java
@@ -1,0 +1,127 @@
+package org.icpc.tools.contest.model.feed;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.text.NumberFormat;
+import java.util.Locale;
+
+import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
+
+public class JSONWriter extends Writer {
+	private static final NumberFormat nf = NumberFormat.getInstance(Locale.US);
+	private static final NumberFormat df = NumberFormat.getInstance(Locale.US);
+
+	static {
+		nf.setGroupingUsed(false);
+		nf.setMaximumFractionDigits(0);
+		df.setGroupingUsed(false);
+	}
+
+	private Writer w;
+
+	public JSONWriter(Writer w) {
+		this.w = w;
+	}
+
+	private static String escape(String s) {
+		if (s == null || s.isEmpty())
+			return "";
+
+		int len = s.length();
+		StringBuilder sb = new StringBuilder(len + 10);
+
+		for (int i = 0; i < len; i++) {
+			char c = s.charAt(i);
+			switch (c) {
+				case '\\':
+				case '"':
+					sb.append('\\');
+					sb.append(c);
+					break;
+				case '\b':
+					sb.append("\\b");
+					break;
+				case '\t':
+					sb.append("\\t");
+					break;
+				case '\n':
+					sb.append("\\n");
+					break;
+				case '\f':
+					sb.append("\\f");
+					break;
+				case '\r':
+					sb.append("\\r");
+					break;
+				default:
+					if (c < 0x0020 || c > 0x007e) {
+						String t = "000" + Integer.toHexString(c);
+						sb.append("\\u" + t.substring(t.length() - 4));
+					} else
+						sb.append(c);
+			}
+		}
+		return sb.toString();
+	}
+
+	private void writeValue(Object value) throws IOException {
+		if (value == null)
+			w.write("null");
+		else if (value instanceof String)
+			w.write("\"" + escape((String) value) + "\"");
+		else if (value instanceof Boolean)
+			w.write((Boolean) value ? "true" : "false");
+		else if (value instanceof Double)
+			w.write(df.format(((Double) value).doubleValue()));
+		else if (value instanceof Integer)
+			w.write(nf.format(((Integer) value).intValue()));
+		else if (value instanceof Long)
+			w.write(nf.format(((Long) value).longValue()));
+		else if (value instanceof JsonObject)
+			writeObject((JsonObject) value);
+		else if (value instanceof Object[])
+			writeArray((Object[]) value);
+	}
+
+	public void writeObject(JsonObject obj) throws IOException {
+		w.write("{");
+		boolean isFirst = true;
+		for (String key : obj.props.keySet()) {
+			if (!isFirst)
+				w.write(",");
+			isFirst = false;
+
+			w.write("\"" + key + "\":");
+			writeValue(obj.get(key));
+		}
+		w.write("}");
+	}
+
+	public void writeArray(Object[] obj) throws IOException {
+		w.write("[");
+		boolean isFirst = true;
+		for (Object o : obj) {
+			if (!isFirst)
+				w.write(",");
+			isFirst = false;
+
+			writeValue(o);
+		}
+		w.write("]");
+	}
+
+	@Override
+	public void write(char[] cbuf, int off, int len) throws IOException {
+		w.write(cbuf, off, len);
+	}
+
+	@Override
+	public void flush() throws IOException {
+		w.flush();
+	}
+
+	@Override
+	public void close() throws IOException {
+		w.close();
+	}
+}


### PR DESCRIPTION
First commit to support POST for submissions. RESTContestSource is updated to provide a method to perform a submit against a Contest API that supports it and the CDS' ContestRESTService supports POST by team or admin. The CDS acts as a simple proxy to the CCS.

Some details may need to be tweaked based on the final spec, but this has been tested with a local client able to submit to either the CDS or a temporary DOMjudge instance.