### PR TITLE
Automatically switch Windows full screen exclusive to full screen win…

### DIFF
--- a/PresCore/src/org/icpc/tools/presentation/core/DisplayConfig.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/DisplayConfig.java
@@ -24,11 +24,9 @@ public class DisplayConfig {
 		mode = Mode.FULL_SCREEN;
 		if (displayStr.length() > 1) {
 			char c = displayStr.charAt(1);
-			if (!Character.isDigit(c)) {
-				for (int i = 0; i < PosStrs.length; i++)
-					if (PosStrs[i] == c)
-						mode = Mode.values()[i];
-			}
+			for (int i = 0; i < PosStrs.length; i++)
+				if (PosStrs[i] == c)
+					mode = Mode.values()[i];
 		}
 	}
 
@@ -47,11 +45,9 @@ public class DisplayConfig {
 			mode = Mode.FULL_SCREEN;
 			if (display.length() == 2) {
 				char c = display.charAt(1);
-				if (!Character.isDigit(c)) {
-					for (int i = 0; i < PosStrs.length; i++)
-						if (PosStrs[i] == c)
-							mode = Mode.values()[i];
-				}
+				for (int i = 0; i < PosStrs.length; i++)
+					if (PosStrs[i] == c)
+						mode = Mode.values()[i];
 			}
 		}
 


### PR DESCRIPTION
…dow when there are multiple displays

The description in the code and issue #308 should provide enough background. Windows full screen exclusive mode behaves poorly if you have multiple displays, so I've worked around it by automatically switching this mode to use a normal full-size window instead. I've tried several apps for comparison, and all either have the original problem or have implemented this same workaround.