### PR TITLE
Handle Windows scaling

### DIFF
--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/DisplayConfig.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/DisplayConfig.java
@@ -101,6 +101,11 @@ public class DisplayConfig {
 
 	@Override
 	public String toString() {
-		return "DisplayConfig " + getDisplay() + " " + getMultiDisplay();
+		String md = getMultiDisplay();
+		if (md == null)
+			md = "";
+		else
+			md = " " + md;
+		return "DisplayConfig " + getDisplay() + md;
 	}
 }

--- a/PresCore/src/org/icpc/tools/presentation/core/DisplayConfig.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/DisplayConfig.java
@@ -97,6 +97,11 @@ public class DisplayConfig {
 
 	@Override
 	public String toString() {
-		return "DisplayConfig " + getDisplay() + " " + getMultiDisplay();
+		String md = getMultiDisplay();
+		if (md == null)
+			md = "";
+		else
+			md = " " + md;
+		return "DisplayConfig " + getDisplay() + md;
 	}
 }

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -582,7 +582,7 @@ public class PresentationWindowImpl extends PresentationWindow {
 		// the taskbar.
 
 		// To mitigate the difference on Windows when there are multiple displays, automatically
-		// switch full screen exclusive mode to full screen window with no insets
+		// switch full screen exclusive mode to full screen window with no insets.
 		GraphicsDevice[] gds = GraphicsEnvironment.getLocalGraphicsEnvironment().getScreenDevices();
 		if (dc.device >= gds.length)
 			throw new IllegalArgumentException("Invalid device: " + device);
@@ -604,6 +604,15 @@ public class PresentationWindowImpl extends PresentationWindow {
 		if (isWindowsMultiDisplay && dc.mode == Mode.FULL_SCREEN) {
 			dc.mode = Mode.FULL_WINDOW;
 		} else {
+			DisplayMode mode = gDevice.getDisplayMode();
+			Trace.trace(Trace.INFO, "Device: " + mode.getWidth() + "x" + mode.getHeight());
+			double scaling = mode.getWidth() / (double) r.width;
+			if (scaling > 1 && dc.mode == Mode.FULL_SCREEN_MAX) {
+				Trace.trace(Trace.INFO, "Scaling by " + scaling);
+				r.width *= scaling;
+				r.height *= scaling;
+			}
+
 			r.x += in.left;
 			r.y += in.top;
 			r.height -= in.top + in.bottom;
@@ -631,8 +640,10 @@ public class PresentationWindowImpl extends PresentationWindow {
 
 		if (dc.mode != Mode.FULL_SCREEN && dc.mode != Mode.FULL_SCREEN_MAX) {
 			requestFocus();
+			createBufferStrategy(2);
 			return;
 		}
+		gDevice.setFullScreenWindow(this);
 
 		if (dc.mode == Mode.FULL_SCREEN_MAX) {
 			DisplayMode bestMode = null;
@@ -650,8 +661,8 @@ public class PresentationWindowImpl extends PresentationWindow {
 			}
 		}
 
-		gDevice.setFullScreenWindow(this);
 		requestFocus();
+		createBufferStrategy(2);
 	}
 
 	@Override


### PR DESCRIPTION
When I was working on the last PR I noticed that the presentation window wasn't covering the full screen on a display that Windows was scaling. After a bit of digging and trial and error I've found how to correctly scale the window.

At the same time I fixed a separate bug: the display config to use the max screen resolution (e.g. "--display 1x") wasn't working on Windows because it requires you to enter full screen exclusive mode before setting the display mode. I switched the order of those.

I also added calls to (re-)create the background buffer strategy after changing the display - this is most likely overkill, but felt safer.

One big caveat: Windows scaling can only be used on the primary display. Based on testing, stack overflow, and googling, there is no way to support a secondary display using scaling. I can get the window position correct, but then can't draw on it. This is likely a bug that could be fixed in a future JDK, but in the meantime the scaling needs to be 100% on all non-primary displays.