### PR TITLE
Team display style improvements

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -66,6 +66,9 @@ public class ClientLauncher {
 				} else if ("--fps".equals(option)) {
 					showFPS[0] = true;
 					return true;
+				} else if ("--style".equals(option)) {
+					org.icpc.tools.presentation.contest.internal.TeamUtil.setDefaultStyle((String) options.get(0));
+					return true;
 				}
 				return false;
 			}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/TeamUtil.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/TeamUtil.java
@@ -5,62 +5,51 @@ import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
 
 public class TeamUtil {
-	public enum Style {
-		TEAM_NAME, ORGANIZATION_NAME, ORGANIZATION_FORMAL_NAME, TEAM_AND_ORG_NAME
+	protected static String defaultStyle;
+
+	private static final String DEFAULT_TEAM = "{team.display_name}";
+	private static final String DEFAULT_TEAM_AND_ORG = "{team.display_name} ({org.name})";
+
+	public static void setDefaultStyle(String s) {
+		System.setProperty("ICPC_PRESENTATION_STYLE", s);
 	}
 
-	private static final String[] STYLE_STR = new String[] { "team_name", "org_name", "org_formal_name",
-			"team_and_org_name" };
-
-	protected static Style defaultStyle;
-
-	public static Style getDefaultStyle(IContest contest) {
+	protected static String getDefaultStyle(IContest contest) {
 		// set default style
 		String styleSt = System.getProperty("ICPC_PRESENTATION_STYLE");
 		if (styleSt != null)
-			return getStyleByString(styleSt);
+			return styleSt;
 
 		if (contest.getNumOrganizations() == contest.getNumTeams())
-			return Style.ORGANIZATION_FORMAL_NAME;
+			return DEFAULT_TEAM;
 
-		return Style.TEAM_AND_ORG_NAME;
+		return DEFAULT_TEAM_AND_ORG;
 	}
 
 	public static String getTeamName(IContest contest, ITeam team) {
-		if (defaultStyle == null)
-			defaultStyle = getDefaultStyle(contest);
-
-		return getTeamName(defaultStyle, contest, team);
+		return getTeamName(null, contest, team);
 	}
 
-	public static String getTeamName(Style style, IContest contest, ITeam team) {
-		String s = team.getActualDisplayName();
-		Style style2 = style;
-		if (style2 == null) {
+	public static String getTeamName(String style, IContest contest, ITeam team) {
+		String style2 = style;
+		if (style == null) {
 			if (defaultStyle == null)
 				defaultStyle = getDefaultStyle(contest);
 			style2 = defaultStyle;
 		}
-		if (Style.TEAM_NAME == style2)
+
+		String s = style2.replace("{team.display_name}", team.getActualDisplayName());
+		s = s.replace("{team.name}", team.getName());
+
+		if (!s.contains("{org."))
 			return s;
 
 		IOrganization org = contest.getOrganizationById(team.getOrganizationId());
-		if (org == null)
-			return s;
-
-		if (style2 == Style.TEAM_AND_ORG_NAME)
-			s = s + " (" + org.getName() + ")";
-		else if (style2 == Style.ORGANIZATION_NAME)
-			s = org.getName();
-		else if (style2 == Style.ORGANIZATION_FORMAL_NAME)
-			s = org.getActualFormalName();
-		return s;
-	}
-
-	public static Style getStyleByString(String styleSt) {
-		for (int i = 0; i < STYLE_STR.length; i++)
-			if (styleSt.equalsIgnoreCase(STYLE_STR[i]))
-				return Style.values()[i];
-		return null;
+		if (org == null) {
+			s = s.replace("{org.name}", "");
+			return s = s.replace("{org.formal_name}", "");
+		}
+		s = s.replace("{org.name}", org.getName());
+		return s.replace("{org.formal_name}", org.getActualFormalName());
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -36,7 +36,6 @@ import org.icpc.tools.presentation.contest.internal.ICPCColors;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.ShadedRectangle;
 import org.icpc.tools.presentation.contest.internal.TeamUtil;
-import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
 import org.icpc.tools.presentation.contest.internal.TextImage;
 
 public abstract class AbstractScoreboardPresentation extends AbstractICPCPresentation {
@@ -63,7 +62,7 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 	private BufferedImage headerImg;
 	private boolean showClock = true;
 
-	protected static Style style;
+	protected static String style;
 
 	protected SelectType selectType = SelectType.NORMAL;
 	protected List<ITeam> selectedTeams = null;
@@ -517,9 +516,6 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 		}
 
 		IContest contest = getContest();
-		if (style == null)
-			style = TeamUtil.getDefaultStyle(contest);
-
 		s = TeamUtil.getTeamName(style, contest, team);
 
 		if (s == null)
@@ -757,7 +753,7 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 		}
 	}
 
-	public void setStyle(Style s) {
+	public void setStyle(String s) {
 		style = s;
 	}
 
@@ -781,7 +777,7 @@ public abstract class AbstractScoreboardPresentation extends AbstractICPCPresent
 			showClock = false;
 		else if (value.startsWith("style:")) {
 			try {
-				style = TeamUtil.getStyleByString(value.substring(6));
+				style = value.substring(6);
 				setSize(getSize());
 			} catch (Exception e) {
 				// ignore

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -52,6 +52,9 @@ public class StandaloneLauncher {
 				} else if ("--fps".equals(option)) {
 					showFPS[0] = true;
 					return true;
+				} else if ("--style".equals(option)) {
+					org.icpc.tools.presentation.contest.internal.TeamUtil.setDefaultStyle((String) options.get(0));
+					return true;
 				}
 				return false;
 			}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/AbstractTileScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/AbstractTileScoreboardPresentation.java
@@ -13,8 +13,6 @@ import org.icpc.tools.contest.model.internal.Recent;
 import org.icpc.tools.contest.model.resolver.SelectType;
 import org.icpc.tools.contest.model.resolver.SubmissionInfo;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
-import org.icpc.tools.presentation.contest.internal.TeamUtil;
-import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
 
 public abstract class AbstractTileScoreboardPresentation extends AbstractICPCPresentation {
 	protected static final int DEFAULT_COLUMNS = 2;
@@ -24,7 +22,7 @@ public abstract class AbstractTileScoreboardPresentation extends AbstractICPCPre
 
 	protected int rows = DEFAULT_ROWS;
 	protected int columns = DEFAULT_COLUMNS;
-	protected Style overrideStyle;
+	protected String overrideStyle;
 
 	protected TeamTileHelper tileHelper;
 	protected Dimension tileDim = null;
@@ -294,8 +292,7 @@ public abstract class AbstractTileScoreboardPresentation extends AbstractICPCPre
 			}
 		} else if (value.startsWith("style:")) {
 			try {
-				String s = value.substring(6);
-				overrideStyle = TeamUtil.getStyleByString(s);
+				overrideStyle = value.substring(6);
 				setSize(getSize());
 			} catch (Exception e) {
 				// ignore

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
@@ -25,7 +25,6 @@ import org.icpc.tools.contest.model.internal.Recent;
 import org.icpc.tools.presentation.contest.internal.ICPCColors;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.TeamUtil;
-import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
 
 public class TeamTileHelper {
 	private static final int IN_TILE_GAP = 1;
@@ -39,7 +38,7 @@ public class TeamTileHelper {
 
 	private Dimension tileDim = null;
 	private IContest contest;
-	private Style style;
+	private String style;
 	private boolean hasBg = false;
 
 	private final Map<String, BufferedImage> tileImages = new HashMap<>();
@@ -52,18 +51,15 @@ public class TeamTileHelper {
 		this(tileDim, contest, null);
 	}
 
-	public TeamTileHelper(Dimension tileDim, IContest contest, Style style) {
+	public TeamTileHelper(Dimension tileDim, IContest contest, String style) {
 		this.tileDim = tileDim;
 		this.contest = contest;
 		this.style = style;
 
-		if (style == null)
-			this.style = TeamUtil.getDefaultStyle(contest);
-
 		setup();
 	}
 
-	public Style getStyle() {
+	public String getStyle() {
 		return style;
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileListScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileListScoreboardPresentation.java
@@ -3,9 +3,8 @@ package org.icpc.tools.presentation.contest.internal.tile;
 import java.awt.geom.Point2D;
 
 import org.icpc.tools.contest.model.IContest;
-import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
+import org.icpc.tools.presentation.contest.internal.TeamUtil;
 
 public class TileListScoreboardPresentation extends ScrollingTileScoreboardPresentation {
 	@Override
@@ -19,20 +18,13 @@ public class TileListScoreboardPresentation extends ScrollingTileScoreboardPrese
 			return;
 
 		IContest contest = getContest();
-		Style style = tileHelper.getStyle();
+		String style = tileHelper.getStyle();
 		int size = teams.length;
 		int[] sort = new int[size];
 		String[] names = new String[size];
 		for (int i = 0; i < size; i++) {
 			sort[i] = i;
-			names[i] = teams[i].getName();
-			IOrganization org = contest.getOrganizationById(teams[i].getOrganizationId());
-			if (org != null) {
-				if (style == Style.ORGANIZATION_NAME)
-					names[i] = org.getName();
-				else if (style == Style.ORGANIZATION_FORMAL_NAME)
-					names[i] = org.getActualFormalName();
-			}
+			names[i] = TeamUtil.getTeamName(style, contest, teams[i]);
 		}
 
 		for (int i = 0; i < size - 1; i++) {

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -34,7 +34,6 @@ import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
 import org.icpc.tools.contest.model.util.AwardUtil;
 import org.icpc.tools.presentation.contest.internal.PresentationClient;
 import org.icpc.tools.presentation.contest.internal.TeamUtil;
-import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
 import org.icpc.tools.presentation.core.DisplayConfig;
 import org.icpc.tools.resolver.ResolverUI.ClickListener;
 import org.icpc.tools.resolver.ResolverUI.Screen;
@@ -75,7 +74,6 @@ public class Resolver {
 	private boolean show_info;
 	private boolean bill;
 	private boolean test;
-	private Style style;
 	private String[] groups;
 
 	// client/server variables
@@ -365,7 +363,7 @@ public class Resolver {
 			multiDisplayStr = (String) options.get(0);
 		} else if ("--style".equalsIgnoreCase(option)) {
 			ArgumentParser.expectOptions(option, options, "style:string");
-			style = TeamUtil.getStyleByString((String) options.get(0));
+			TeamUtil.setDefaultStyle((String) options.get(0));
 		} else if ("--groups".equalsIgnoreCase(option)) {
 			ArgumentParser.expectOptions(option, options, "group-id:string", "*");
 			groups = options.toArray(new String[0]);
@@ -572,7 +570,7 @@ public class Resolver {
 					public void speedFactor(double d) {
 						sendSpeedFactor(d);
 					}
-				}, style);
+				});
 
 		ui.setSpeedFactor(speedFactor);
 		ui.display();

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -36,7 +36,6 @@ import org.icpc.tools.contest.model.resolver.ResolutionUtil.TeamSelectionStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ToJudgeStep;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
-import org.icpc.tools.presentation.contest.internal.TeamUtil.Style;
 import org.icpc.tools.presentation.contest.internal.presentations.StaticLogoPresentation;
 import org.icpc.tools.presentation.contest.internal.scoreboard.ScoreboardPresentation;
 import org.icpc.tools.presentation.core.DisplayConfig;
@@ -83,7 +82,6 @@ public class ResolverUI {
 	private DisplayConfig displayConfig;
 	private boolean showInfo;
 	private boolean pauseScroll = false;
-	private Style style;
 
 	private ClickListener listener;
 
@@ -105,7 +103,7 @@ public class ResolverUI {
 	private Thread thread;
 
 	public ResolverUI(List<ResolutionStep> steps, boolean showInfo, DisplayConfig displayConfig, boolean isPresenter,
-			Screen screen, ClickListener listener, Style style) {
+			Screen screen, ClickListener listener) {
 		this.steps = steps;
 		this.showInfo = showInfo;
 		this.displayConfig = displayConfig;
@@ -114,7 +112,6 @@ public class ResolverUI {
 		if (screen == null)
 			this.screen = Screen.MAIN;
 		this.listener = listener;
-		this.style = style;
 		control = new ResolutionControl(steps);
 		control.addListener(new IResolutionListener() {
 			@Override
@@ -284,8 +281,6 @@ public class ResolverUI {
 		scoreboardPresentation.setProperty("clockOff");
 		scoreboardPresentation.setContest(contest);
 		scoreboardPresentation.addMouseListener(nullMouse);
-		if (style != null)
-			scoreboardPresentation.setStyle(style);
 
 		judgePresentation = new JudgePresentation2() {
 			@Override
@@ -295,8 +290,6 @@ public class ResolverUI {
 			}
 		};
 		judgePresentation.addMouseListener(nullMouse);
-		if (style != null)
-			judgePresentation.setStyle(style);
 
 		awardPresentation = new TeamAwardPresentation() {
 			@Override


### PR DESCRIPTION
Currently the ability to override the default team naming behaviour (usually the team's display name) is only visible as an option to the resolver. Due to some issues at a regional we want to enable this in the other tools and give a more wide open way to specify the name.

- Change style to a string.
- Change from enum of options like team_name to string substitution like "{team.display_name} - {org.name}". {team.name} and {org.formal_name} are also supported.
- Give a better way of setting the default (vs setting on every presentation) and use it in the resolver.
- Enable --style option in both presentation clients (matching what the resolver had).
- Fix up all the dependent presentations.

Readme updates will follow...