### PR TITLE
Ability to filter resolver by problem

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1674,6 +1674,43 @@ public class Contest implements IContest {
 		return remove.size();
 	}
 
+	public void removeProblems(List<String> problemIds) {
+		List<IContestObject> remove = new ArrayList<>();
+
+		for (IProblem p : problems) {
+			if (problemIds.contains(p.getId())) {
+				remove.add(p);
+			}
+		}
+
+		for (ISubmission s : getSubmissions()) {
+			String problemId = s.getProblemId();
+			if (problemIds.contains(problemId))
+				removeSubmission(remove, s);
+		}
+
+		for (IClarification clar : getClarifications()) {
+			String problemId = clar.getProblemId();
+			if (problemId != null && problemIds.contains(problemId))
+				remove.add(clar);
+		}
+
+		for (IAward award : getAwards()) {
+			if (award.getAwardType() == IAward.FIRST_TO_SOLVE) {
+				for (String pId : problemIds) {
+					if (award.getId().endsWith("-" + pId)) {
+						remove.add(award);
+						break;
+					}
+				}
+			}
+		}
+
+		Trace.trace(Trace.INFO, "Removing " + problemIds.size() + " problems and " + remove.size() + " total objects");
+		for (IContestObject obj : remove)
+			removeFromHistory(obj);
+	}
+
 	public void setHashCode(int hash) {
 		this.hash = hash;
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -826,9 +826,11 @@ public class ResolverLogic {
 			for (PredeterminedStep ps : predeterminedSteps) {
 				if (ps.teamId.equals(team.getId())) {
 					int pInd = contest.getProblemIndexByLabel(ps.problemLabel);
-					IResult r1 = contest.getResult(team, pInd);
-					if (r1.getStatus() == Status.SUBMITTED) {
-						return new SubmissionInfo(team, pInd);
+					if (pInd >= 0) {
+						IResult r1 = contest.getResult(team, pInd);
+						if (r1.getStatus() == Status.SUBMITTED) {
+							return new SubmissionInfo(team, pInd);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Due to issues at the PacNW I'm adding (back) the ability to filter a contest by problem labels, undocumented for now. This will allow someone to run the resolver on a subset of a contest based on regex of the group ids and problem labels, e.g.:
 --groups 123|125 --problems A|B|C