### PR TITLE
Update presentation list in the readme

### DIFF
--- a/PresContest/README.md
+++ b/PresContest/README.md
@@ -276,34 +276,86 @@ their identifying number and name, the internal specification by which they are 
 and notes on their operation. (Note that the numbers will be different, and some
 presentations are only useful when used in conjunction with the Presentation Admin.)
 
- | # | Name | Internal Id | Notes
- | -: | ------ | --------- | ------------------
- | 1 | Bill Poucher | .bill | The venerable ICPC Executive Director.
- | 2 | Chart - Languages | .chart.language | 
- | 3 | Chart - Problem detail | .chart.problem.detail | 
- | 4 | Chart - Problem summary | .chart.problem.summary | Shows attempts, solutions, and fastest solution time for each problem.
- | 5 | Chart - Scoreboard | .chart.scoreboard | The current contest standings; scrolls through all teams and updates dynamically as new data arrives.
- | 6 | Chart - Total Problems | .chart.total.problems | 
- | 7 | Contest clock | .clock | The contest clock (time remaining in the contest).
- | 8 | Countdown | .countdown | A countdown clock, initialized by data in the contest event feed.
- | 9 | Do not touch anything | .doNotTouch | 
- | 10 | Fireworks | .fireworks | 
- | 11 | First solution | .first.solution | Tracking the first solution.
- | 12 | First to solve | .first.to.solve | First to solve each problem.
- | 13 | Judge queue | .judge | The judgement queue: shows all incoming runs and what the result is.
- | 14 | Leaderboard | .leaderboard | 
- | 15 | Logo | .logo | Displays the contest logo.
- | 16 | Message | .message | Displays a message and contest banner. The message is set via a property in the Presentation Admin.
- | 17 | Photo | .single.photo | Displays a single photo, taken from the CDP/present folder in file _photo.jpg_.
- | 18 | Pictures | .photos | Displays a rotating set of pictures found in the CDP/present/photos folder.
- | 19 | Problem summary | .problem.summary | 
- | 20 | Promotions | .promo | Displays a rotating set of promotional images.
- | 21 | Group leaderboard | .leaderboard.group | 
- | 22 | Scoreboard | .scoreboard | Contest scoreboard.
- | 23 | Team Display | .team.display | Display for team machines, shows the team logo and name. The team is is set via a property in the Presentation Admin.
- | 24 | Test - Alignment | .test.align | A grid to help with projector alignment.
- | 25 | Test - Clock | .test.clock | The current system time (on the presentation machine).
- | 26 | Test - Synchronization | .test.sync | A moving ball to test synchronization of the system clock.
+Available presentations:
+  #  | Name | Id  | Description
+ --: | ---- | --- | ---
+Beta
+   1 | Better Fireworks | .better.fireworks
+   2 | Contest Floor | .floor | Shows the contest floor and all the teams competing
+   3 | Floor Activity | .old.floor | Displays the contest floor
+Chart
+   4 | Historical comparison | .chart.historical
+   5 | Judge Queue Depth | .chart.queue.depth
+   6 | Judgement time | .chart.judgement.time
+   7 | Languages | .chart.language
+   8 | Problem comparison | .chart.problem.comparison
+   9 | Problem detail | .chart.problem.detail
+  10 | Problem summary | .chart.problem.summary | Shows attempts, solutions, and fastest solution time for each problem.
+  11 | Scoreboard | .chart.score | Shows position of contest leaders through the contest.
+  12 | Total Problems | .chart.total.problems
+Clock
+  13 | Contest clock | .clock | The contest time remaining.
+  14 | Countdown | .countdown | A countdown clock for start and end of a contest.
+  15 | Polar countdown | .polar | A polar countdown clock for start and end of a contest.
+Fun
+  16 | Bill Poucher | .bill | The venerable ICPC Executive Director.
+  17 | Do not touch anything | .doNotTouch | A pre-contest message from the ICPC World Finals Systems Director.
+  18 | Fireworks | .fireworks
+  19 | Mohamed Fouad | .mohamed
+ICPC
+  20 | Balloon Path | .balloon.path | Contest floor showing moving submissions and balloons
+  21 | Fading Logos | .org.logo.fade | Shows the logos of all organizations by fading between them
+  22 | Logo Wall | .org.logo.wall | Shows all organization logos
+  23 | Photo and caption | .single.photo | The photo at CDP/present/photo.jpg and an optional message.
+  24 | Photos | .photos | A rotating set of photos found in CDP/present/photos/.
+  25 | Problem Colours | .problems.colors | The problem colors
+  26 | Problem summary | .problem.summary
+  27 | Single Team | .team | A team photo and name.
+  28 | Sliding Logos | .org.logo.slide | Slides the logos of all organizations
+  29 | Staff | .staff | ICPC staff titles
+Logos and Messages
+  30 | CCS | .ccs | The primary (and optional shadow) CCS images found in CDP/present/ccs/primary.png and shadow.png.
+  31 | ICPC Tools | .icpc.tools | The ICPC Tools logo
+  32 | Image progression | .imagebuild | Fades through a set of images in progression (CDP/present/path*).
+  33 | Logo A | .logo | Displays the contest logo (CDP/present/logoA*.png).
+  34 | Logo B | .logo2 | Displays the contest logo (CDP/present/logoB*.png).
+  35 | Message | .message | A message and contest banner.
+  36 | Promotions | .promo | A rotating set of promotional images found in CDP/present/promo/.
+Maps
+  37 | Group | .map.group | Shows where groups are from on a map.
+  38 | Submissions | .map.balloon | A world map with team submissions coming from their location
+  39 | Team Intro | .map.team | Steps through all teams on a map.
+  40 | World | .map.world | Map of the world.
+Scoreboard
+  41 | All Groups leaderboard | .leaderboard.group.all
+  42 | First solution | .first.solution | Tracks the first solution in the contest.
+  43 | First to solve | .first.to.solve | Shows which team was the first to solve each problem.
+  44 | Group leaderboard | .leaderboard.group
+  45 | Judge queue | .judge | The judgement queue. Shows all incoming submissions and the judgement.
+  46 | Leaderboard | .leaderboard
+  47 | Scoreboard | .scoreboard | The current contest standings.
+  48 | Team Judgements | .judge.team | A team judgement queue. Shows all incoming submissions and the judgement.
+  49 | Timeline | .scoreboard.timeline
+Team
+  50 | Desktop | .icpc.team | Team machine desktop display. Shows the team logo and name.
+  51 | Logo | .icpc.logo | The ICPC identifier.
+  52 | Snake | .icpc.team.snake | Wave based on team labels
+  53 | Sync | .icpc.sync | Flashing ICPC in sync.
+  54 | Video test | .icpc.team.video | A tool to verify video.
+  55 | Wave | .icpc.team.wave | Do the wave!
+Test
+  56 | Alignment | .test.align | A grid to help with projector alignment.
+  57 | BSoD | .test.bsod | A special hello from the other Bill
+  58 | Chart | .test.chart | A test chart
+  59 | Clock | .test.clock | The current system time on the presentation machine.
+  60 | FPS | .test.fps | A frame rate guage
+  61 | Synchronization | .test.sync | A moving ball to test synchronization of the system clock.
+Tile Scoreboards
+  62 | Team scoreboard | .tile.team | Team picture with overlayed scoreboard tile
+  63 | Tile list | .tile.scoreboard.list | A contest scoreboard listed alphabetically by team
+  64 | Tile rank | .tile.scoreboard.rank | A ranked contest scoreboard
+  65 | Tiles | .tile.scoreboard | The current contest standings.
+
 
 ## Team Clients
 

--- a/PresContest/src/META-INF/presentations.xml
+++ b/PresContest/src/META-INF/presentations.xml
@@ -35,13 +35,13 @@
       name="Single Team"
       category="ICPC"
       properties="# - controls which team to show"
-      description="Displays a team photo and name."
+      description="A team photo and name."
       class="org.icpc.tools.presentation.contest.internal.scoreboard.SingleTeamPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.message"
       name="Message"
       category="Logos and Messages"
-      description="Displays a message and contest banner."
+      description="A message and contest banner."
       properties="Your message here - enter any message"
       image="images/presentations/message.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.MessagePresentation"/>
@@ -49,28 +49,28 @@
       id="org.icpc.tools.presentation.contest.promo"
       name="Promotions"
       category="Logos and Messages"
-      description="Displays a rotating set of promotional images found in CDP/present/promo/."
+      description="A rotating set of promotional images found in CDP/present/promo/."
       image="images/presentations/promo.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.PromoPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.ccs"
       name="CCS"
       category="Logos and Messages"
-      description="Displays the primary (and optional shadow) CCS images found in CDP/present/ccs/primary.png and shadow.png."
+      description="The primary (and optional shadow) CCS images found in CDP/present/ccs/primary.png and shadow.png."
       image="images/presentations/ccs.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.CCSPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.icpc.tools"
       name="ICPC Tools"
       category="Logos and Messages"
-      description="Displays the ICPC Tools logo"
+      description="The ICPC Tools logo"
       image="images/presentations/icpcTools.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.ICPCToolsPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.single.photo"
       name="Photo and caption"
       category="ICPC"
-      description="Displays the photo at CDP/present/photo.jpg and an optional message."
+      description="The photo at CDP/present/photo.jpg and an optional message."
       properties="Your message here - enter any message"
       image="images/presentations/photo.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.SinglePhotoPresentation"/>
@@ -78,21 +78,21 @@
       id="org.icpc.tools.presentation.contest.photos"
       name="Photos"
       category="ICPC"
-      description="Displays a rotating set of photos found in CDP/present/photos/."
+      description="A rotating set of photos found in CDP/present/photos/."
       image="images/presentations/photos.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.PhotoPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.problems.colors"
       name="Problem Colours"
       category="ICPC"
-      description="Displays the problem colors"
+      description="The problem colors"
       image="images/presentations/problemColors.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.ProblemColorsPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.staff"
       name="Staff"
       category="ICPC"
-      description="Displays ICPC staff"
+      description="ICPC staff titles"
       properties="Enter partial last name or first + last name"
       image="images/presentations/staff.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.StaffPresentation"/>
@@ -100,14 +100,14 @@
       id="org.icpc.tools.presentation.contest.balloon.path"
       name="Balloon Path"
       category="ICPC"
-      description="Displays the balloons travelling to the teams"
+      description="Contest floor showing moving submissions and balloons"
       image="images/presentations/balloonPath.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.floor.BalloonFloorPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.org.logo.wall"
       name="Logo Wall"
       category="ICPC"
-      description="Shows the logos of all organizations at once"
+      description="Shows all organization logos"
       image="images/presentations/logos.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.OrgLogoWallPresentation"/>
    <presentation
@@ -143,12 +143,14 @@
       id="org.icpc.tools.presentation.contest.bill"
       name="Bill Poucher"
       category="Fun"
+      description="The venerable ICPC Executive Director."
       image="images/presentations/bill.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.BillPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.doNotTouch"
       name="Do not touch anything"
       category="Fun"
+      description="A pre-contest message from the ICPC World Finals Systems Director."
       image="images/presentations/doNotTouch.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.DoNotTouchPresentation"/>
    <presentation
@@ -164,28 +166,28 @@
       id="org.icpc.tools.presentation.contest.map.world"
       name="World"
       category="Maps"
-      description="Displays the world"
+      description="Map of the world."
       image="images/presentations/world.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.map.WorldPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.map.group"
       name="Group"
       category="Maps"
-      description="Displays groups around the world"
+      description="Shows where groups are from on a map."
       image="images/presentations/world.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.map.GroupPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.map.team"
       name="Team Intro"
       category="Maps"
-      description="Displays teams from around the world"
+      description="Steps through all teams on a map."
       image="images/presentations/world.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.map.TeamIntroPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.map.balloon"
       name="Submissions"
       category="Maps"
-      description="Shows a world map with team submissions"
+      description="A world map with team submissions coming from their location"
       image="images/presentations/worldJudge.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.map.BalloonMapPresentation"/>
      
@@ -210,7 +212,7 @@
       id="org.icpc.tools.presentation.contest.clock"
       name="Contest clock"
       category="Clock"
-      description="The contest clock."
+      description="The contest time remaining."
       image="images/presentations/clock.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.clock.ClockPresentation"/>
    <presentation
@@ -221,7 +223,7 @@
          statusOff - hide status content,
          # - countdown to number of seconds from the epoch,
          reset"
-      description="A countdown clock."
+      description="A countdown clock for start and end of a contest."
       image="images/presentations/clockCountdown.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.clock.StatusCountdownPresentation"/>
    <presentation
@@ -230,6 +232,7 @@
       category="Clock"
       properties="# - countdown to number of seconds from the epoch,
          reset"
+         description="A polar countdown clock for start and end of a contest."
       image="images/presentations/clockPolar.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.clock.PolarCountdownPresentation"/>
 
@@ -240,7 +243,7 @@
       name="Scoreboard"
       category="Scoreboard"
       properties="focusTeam:# - a team to focus on,style - set team name style,clockOn,clockOff"
-      description="Contest scoreboard."
+      description="The current contest standings."
       image="images/presentations/scoreboard.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.ScoreboardPresentation"/>
    <presentation
@@ -255,14 +258,14 @@
       name="Judge queue"
       category="Scoreboard"
       properties="style - set team name style,clockOn,clockOff"
-      description="The judgement queue. Shows all incoming submissions and what the result is."
+      description="The judgement queue. Shows all incoming submissions and the judgement."
       image="images/presentations/judgeQueue.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.JudgePresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.judge.team"
       name="Team Judgements"
       category="Scoreboard"
-      description="A team judgement queue. Shows all incoming submissions and what the result is."
+      description="A team judgement queue. Shows all incoming submissions and the judgement."
       image="images/presentations/teamJudgeQueue.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.TeamJudgePresentation"/>
    <presentation
@@ -270,7 +273,7 @@
       name="First solution"
       category="Scoreboard"
       properties="style - set team name style,clockOn,clockOff"
-      description="Tracking the first solution in the contest."
+      description="Tracks the first solution in the contest."
       image="images/presentations/firstSolution.png"
       class="org.icpc.tools.presentation.contest.internal.scoreboard.FirstSolutionPresentation"/>
    <presentation
@@ -310,6 +313,7 @@
       name="Tiles"
       category="Tile Scoreboards"
       properties="rows:,columns:,style:,clockOn,clockOff"
+      description="The current contest standings."
       image="images/presentations/tile.png"
       class="org.icpc.tools.presentation.contest.internal.tile.TileScoreboardPresentation"/>
    <presentation
@@ -317,12 +321,14 @@
       name="Tile rank"
       category="Tile Scoreboards"
       properties="rows:,columns:,style:,clockOn,clockOff"
+      description="A ranked contest scoreboard"
       image="images/presentations/tileRank.png"
       class="org.icpc.tools.presentation.contest.internal.tile.TileRankScoreboardPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.tile.team"
       name="Team scoreboard"
       category="Tile Scoreboards"
+      description="Team picture with overlayed scoreboard tile"
       properties="team:"
       class="org.icpc.tools.presentation.contest.internal.tile.TilePictureScoreboardPresentation"/>
    <presentation
@@ -330,6 +336,7 @@
       name="Tile list"
       category="Tile Scoreboards"
       properties="rows:,columns:,style:,clockOn,clockOff"
+      description="A contest scoreboard listed alphabetically by team"
       image="images/presentations/tile2.png"
       class="org.icpc.tools.presentation.contest.internal.tile.TileListScoreboardPresentation"/>
 
@@ -357,12 +364,14 @@
       id="org.icpc.tools.presentation.contest.chart.problem.summary"
       name="Problem summary"
       category="Chart"
+      description="Shows attempts, solutions, and fastest solution time for each problem."
       image="images/presentations/chartProblems.png"
       class="org.icpc.tools.presentation.contest.internal.chart.ProblemSummaryChart"/>
    <presentation
       id="org.icpc.tools.presentation.contest.chart.score"
       name="Scoreboard"
       category="Chart"
+      description="Shows position of contest leaders through the contest."
       image="images/presentations/chartScoreboard.png"
       class="org.icpc.tools.presentation.contest.internal.chart.ScoreboardChart"/>
    <presentation
@@ -409,7 +418,7 @@
       id="org.icpc.tools.presentation.contest.test.clock"
       name="Clock"
       category="Test"
-      description="The current system time."
+      description="The current system time on the presentation machine."
       image="images/presentations/testClock.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.test.TestClockPresentation"/>
    <presentation
@@ -446,7 +455,7 @@
       id="org.icpc.tools.presentation.contest.icpc.team"
       name="Desktop"
       category="Team"
-      description="The team desktop."
+      description="Team machine desktop display. Shows the team logo and name."
       class="org.icpc.tools.presentation.contest.internal.presentations.TeamDisplayPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.icpc.sync"

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -119,28 +119,34 @@ public class StandaloneLauncher {
 		System.out.println();
 
 		Trace.trace(Trace.USER, "Available presentations:");
+		Trace.trace(Trace.USER, "  #  | Name | Id  | Description");
+		Trace.trace(Trace.USER, " --: | ---- | --- | ---");
 		int count = 1;
 		String lastCategory = null;
 		for (PresentationInfo pw : presentations) {
-			StringBuilder sb = new StringBuilder();
 			String cat = pw.getCategory();
 			if (cat != null && !cat.equals(lastCategory)) {
-				if (lastCategory != null)
-					sb.append("\n");
-				sb.append("  -- " + cat + " --\n");
+				Trace.trace(Trace.USER, cat);
 				lastCategory = cat;
 			}
-			sb.append("    " + count + ". ");
+
+			StringBuilder sb = new StringBuilder("  ");
 			if (count < 10)
 				sb.append(" ");
-			sb.append(pw.getName() + " (" + pw.getId() + ")");
+			sb.append(count + " | ");
+			sb.append(pw.getName() + " | ");
+			if (pw.getId().startsWith("org.icpc.tools.presentation.contest."))
+				sb.append(pw.getId().substring(35));
+			else
+				sb.append(pw.getId());
 			if (pw.getDescription() != null) {
 				String s = pw.getDescription();
 				if (s.contains("\n"))
 					s = s.substring(0, s.indexOf("\n")) + "...";
-				sb.append("\n      " + s);
+				sb.append(" | " + s);
 			}
 			Trace.trace(Trace.USER, sb.toString());
+
 			count++;
 		}
 	}


### PR DESCRIPTION
In the past we've talked about a live list of the presentations being generated into the docs during the build, but that's a big pain. As a stopgap/step towards that, I just changed the output of the command line to markdown, which I could then just copy/paste into the readme. It's still manual, but at least it's an easy step. I was careful to keep the command output reasonably clean so that it's still as usable as possible directly from the command line.
While I was at it, I improved several presentation descriptions or made them match what was in the docs previously.