### PR TITLE
Fix markdown table

### DIFF
--- a/PresContest/README.md
+++ b/PresContest/README.md
@@ -277,7 +277,7 @@ and notes on their operation. (Note that the numbers will be different, and some
 presentations are only useful when used in conjunction with the Presentation Admin.)
 
 Available presentations:
-  #  | Name | Id  | Description
+|  # | Name | Id  | Description
  --: | ---- | --- | ---
 Beta
    1 | Better Fireworks | .better.fireworks

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -119,7 +119,7 @@ public class StandaloneLauncher {
 		System.out.println();
 
 		Trace.trace(Trace.USER, "Available presentations:");
-		Trace.trace(Trace.USER, "  #  | Name | Id  | Description");
+		Trace.trace(Trace.USER, "|  # | Name | Id  | Description");
 		Trace.trace(Trace.USER, " --: | ---- | --- | ---");
 		int count = 1;
 		String lastCategory = null;


### PR DESCRIPTION
The VS Code markdown support != github markdown, and with the previous commit the table doesn't parse correctly either in readme or pdf. This one character change appears to fix the github markdown, hopefully the pdf conversion as well.