### PR TITLE
Don't recreate buffer strategy

### DIFF
--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -640,7 +640,6 @@ public class PresentationWindowImpl extends PresentationWindow {
 
 		if (dc.mode != Mode.FULL_SCREEN && dc.mode != Mode.FULL_SCREEN_MAX) {
 			requestFocus();
-			createBufferStrategy(2);
 			return;
 		}
 		gDevice.setFullScreenWindow(this);
@@ -662,7 +661,6 @@ public class PresentationWindowImpl extends PresentationWindow {
 		}
 
 		requestFocus();
-		createBufferStrategy(2);
 	}
 
 	@Override


### PR DESCRIPTION
Recreating the buffer strategy seems to cause issues on some OSes due to race conditions and when the peer hasn't been created. Since it was added recently and doesn't appear to be strictly necessary, I'll remove it.