### PR TITLE
Steps toward improved team support

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -123,7 +123,8 @@
               </a>
 
               <ul class="nav nav-treeview">
-                <% for (int i = 0; i < menuPages.length; i++) { %>
+                <% for (int i = 0; i < menuPages.length; i++) 
+                   if (i < 4 || Role.isAdmin(request)) { %>
                 <li class="nav-item">
                   <a href="${pageContext.request.contextPath}/contests/<%= cc3.getId() %><%= menuPages[i] %>"
                     class="nav-link<% if (request.getAttribute("javax.servlet.forward.request_uri").equals(webroot3 + menuPages[i])) { %> active<% } %>">
@@ -137,6 +138,7 @@
             </li>
             <% } } %>
             
+            <% if (Role.isPresAdmin(request)) { %>
             <li class="nav-item">
               <a href="${pageContext.request.contextPath}/presentation/admin/web"
                 class="nav-link<% if (request.getAttribute("javax.servlet.forward.request_uri").toString().contains("presentation/admin/web")) { %> active<% } %>">
@@ -144,7 +146,9 @@
                 <p>Presentation Admin</p>
               </a>
             </li>
+            <% } %>
 
+            <% if (Role.isAdmin(request)) { %>
             <li class="nav-item has-treeview menu-<% if (request.getAttribute("javax.servlet.forward.request_uri").toString().contains("/video/control/")) { %>open<% } else { %>closed<% } %>">
               <a href="#" class="nav-link">
                 <i class="nav-icon fas fa-video"></i>
@@ -166,6 +170,7 @@
                 <% } %>
               </ul>
             </li>
+            <% } %>
 
             <li class="nav-item">
               <a href="${pageContext.request.contextPath}/about"

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -287,6 +287,30 @@ var contest=(function() {
 		});
 	}
 
+    var post = function(type, body, ok, fail) {
+        console.log("Posting (POST) contest object: " + type);
+        return $.ajax({
+		    url: urlPrefix + type,
+		    method: 'POST',
+		    headers: { "Accept": "application/json" },
+		    data: body,
+		    success: function(body) {
+		    	ok(body);
+		    },
+		    error: function(result) {
+			    fail(result);
+		    }
+		});
+	}
+
+	var postSubmission = function(obj, ok, fail) {
+        post('submissions', obj, ok, fail);
+	}
+
+	var postClarification = function(obj, ok, fail) {
+        post('clarifications', obj, ok, fail);
+	}
+
 	return {
 		setContestId: setContestId,
 		loadInfo: loadInfo,
@@ -315,6 +339,8 @@ var contest=(function() {
 		clear: clear,
 		add: add,
 		update: update,
-		remove: remove
+		remove: remove,
+		postSubmission: postSubmission,
+		postClarification: postClarification
 	};
 })();

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -53,7 +53,9 @@ function fillContestObjectTable(name, objs, tdGen) {
 var tagsToReplace = {
     '&': '&amp;',
     '<': '&lt;',
-    '>': '&gt;'
+    '>': '&gt;',
+    '\n': '<br/>',
+    '\r': ''
 };
 
 function replaceTag(tag) {
@@ -63,7 +65,7 @@ function replaceTag(tag) {
 function sanitizeHTML(str) {
 	if (str == null)
 		return "";
-	return str.replace(/[&<>]/g, replaceTag);
+	return str.replace(/[&<>\n\r]/g, replaceTag);
 }
 
 function formatTime(time2) {	

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -955,14 +955,21 @@ public class ConfiguredContest {
 	public static String getRole(HttpServletRequest request) {
 		if (Role.isAdmin(request))
 			return "admin";
+		else if (Role.isPresAdmin(request))
+			return "pres-admin";
 		else if (Role.isBlue(request))
 			return "blue";
 		else if (Role.isTrusted(request))
 			return "trusted";
 		else if (Role.isBalloon(request))
 			return "balloon";
-		else if (Role.isTeam(request))
+		else if (Role.isTeam(request)) {
+			String teamId = CDSConfig.getInstance().getTeamIdFromUser(request.getRemoteUser());
+			if (teamId != null)
+				return "team " + teamId;
+
 			return "team";
+		}
 		return "public";
 	}
 


### PR DESCRIPTION
Fixed a few indirect items:
- Admin-only navigation options (e.g. pres admin, video support) are now hidden until you log in as an admin.
- Basic post support for submissions and clarifications added to JS API (but not exposed on web).
- Fix to ui.js - noticed that clarifications were not being converted to well-formed html.
- Fixed missing pres-admin role and added team id to the output for team role (shows up at top-right on web).