### PR TITLE
First pass at team (non-admin) web UI

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/details.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details.jsp
@@ -1,93 +1,49 @@
 <%@ page import="java.util.List" %>
 <%@ page import="org.icpc.tools.contest.model.*" %>
 <%@ page import="org.icpc.tools.cds.util.HttpHelper" %>
+<%@ page import="org.icpc.tools.cds.util.Role" %>
 <% request.setAttribute("title", "Details"); %>
 <%@ include file="layout/head.jsp" %>
 <% IState state = contest.getState(); %>
 <script src="${pageContext.request.contextPath}/js/contest.js"></script>
 <script src="${pageContext.request.contextPath}/js/model.js"></script>
 <script src="${pageContext.request.contextPath}/js/ui.js"></script>
+<script type="text/javascript">
+    $(document).ready(function () {
+        contest.setContestId("<%= cc.getId() %>");
+    });
+</script>
 <div class="container-fluid">
+    <% if (Role.isAdmin(request)) { %>
     <div class="row">
         <div class="col-9">
-            <div id="accordion">
-            <div class="card">
-                <div class="card-header">
-                    <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseContest">Contest</a></h4>
-                    <div class="card-tools">
-                        <button type="button" class="btn btn-tool" onclick="location.href='<%= apiRoot %>'">API</button>
-                    </div>
-                </div>
-                <div id="collapseContest" class="panel-collapse collapse in">
-                <div class="card-body p-0">
-                    <table class="table table-sm table-hover table-striped table-head-fixed">
-                        <tbody>
-                            <tr>
-                                <td><b>Name:</b></td>
-                                <td><%= HttpHelper.sanitizeHTML(contest.getName()) %></td>
-                                <td><b>Start:</b></td>
-                                <td><%= ContestUtil.formatStartTime(contest) %></td>
-                            </tr>
-                            <tr>
-                                <td><b>Duration:</b></td>
-                                <td><%= ContestUtil.formatDuration(contest.getDuration()) %></td>
-                                <td><b>Freeze duration:</b></td>
-                                <td><%= ContestUtil.formatDuration(contest.getFreezeDuration()) %></td>
-                            </tr>
-                            <tr>
-                                <td class="align-middle"><b>Logo:</b></td>
-                                <td class="table-dark" rowspan=2 id="logo"></td>
-                                <td class="align-middle"><b>Banner:</b></td>
-                                <td class="table-dark" rowspan=2 id="banner"></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                </div>
-            </div>
-            </div>
+            <%@ include file="details/contest-admin.jsp" %>
         </div>
         <div class="col-3">
             <%@ include file="details/state.jsp" %>
         </div>
     </div>
     <div class="row">
-        <div class="col-5">
-            <%@ include file="details/languages.jsp" %>
-        </div>
-        <div class="col-7">
-            <%@ include file="details/judgementTypes.jsp" %>
-        </div>
+        <div class="col-5"><%@ include file="details/languages-admin.html" %></div>
+        <div class="col-7"><%@ include file="details/judgementTypes-admin.html" %></div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <%@ include file="details/groups.jsp" %>
-        </div>
+        <div class="col-12"><%@ include file="details/groups-admin.html" %></div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <%@ include file="details/problems.jsp" %>
-        </div>
+        <div class="col-12"><%@ include file="details/problems-admin.html" %></div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <%@ include file="details/teams.jsp" %>
-        </div>
+        <div class="col-12"><%@ include file="details/teams-admin.html" %></div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <%@ include file="details/orgs.jsp" %>
-        </div>
+        <div class="col-12"><%@ include file="details/orgs-admin.html" %></div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <%@ include file="details/clarifications.jsp" %>
-        </div>
+        <div class="col-12"><%@ include file="details/clarifications-admin.html" %></div>
     </div>
     <div class="row">
-        <div class="col-12">
-            <%@ include file="details/awards.jsp" %>
-        </div>
+        <div class="col-12"><%@ include file="details/awards.jsp" %></div>
     </div>
     <div class="row">
         <div class="col-12">
@@ -134,11 +90,28 @@
             </div>
         </div>
     </div>
+    <% } else { %>
+    <div class="row">
+        <div class="col-7"><%@ include file="details/problems.html" %></div>
+        <div class="col-5"><%@ include file="details/contest.jsp" %><%@ include file="details/languages.html" %></div>
+    </div>
+    <div class="row">
+        <div class="col-7"><%@ include file="details/judgementTypes.html" %></div>
+        <div class="col-5"><%@ include file="details/groups.html" %></div>
+    </div>
+    <div class="row">
+        <div class="col-12"><%@ include file="details/teams.html" %></div>
+    </div>
+    <div class="row">
+        <div class="col-12"><%@ include file="details/orgs.html" %></div>
+    </div>
+    <div class="row">
+        <div class="col-12"><%@ include file="details/clarifications.html" %></div>
+    </div>
+    <% } %>
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function update() {
             var info = contest.getInfo();
             var logo = bestSquareLogo(info.logo, 50);

--- a/CDS/WebContent/WEB-INF/jsps/details/clarifications-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/clarifications-admin.html
@@ -18,6 +18,7 @@
                     <th>Problem</th>
                     <th>From Team</th>
                     <th>To Team</th>
+                    <th>Reply To</th>
                     <th>Text</th>
                 </tr>
             </thead>
@@ -35,13 +36,12 @@
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function clarTd(clar) {
             var problem = '';
             var time = '';
             var fromTeam = '';
             var toTeam = '';
+            var replyTo = '';
             if (clar.contest_time != null)
                 time = formatTime(parseTime(clar.contest_time));
             if (clar.problem_id != null) {
@@ -60,10 +60,12 @@
                 if (toTeam != null)
                     toTeam = toTeam.id + ' (' + toTeam.name + ')';
             }
+            if (clar.reply_to_id != null)
+            	replyTo = clar.reply_to_id;
 
             return $('<td><a href="<%= apiRoot %>/clarifications/' + clar.id + '">' + clar.id + '</a></td>' +
                 '<td align="center">' + time + '</td><td>' + problem + '</td><td>' + fromTeam + '</td>' +
-                '<td>' + toTeam + '</td><td class="pre-line">' + sanitizeHTML(clar.text) + '</td>');
+                '<td>' + toTeam + '</td><td>' + replyTo + '</td><td class="pre-line">' + sanitizeHTML(clar.text) + '</td>');
         }
 
         $.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {
@@ -72,4 +74,15 @@
         	console.log("Error loading clarifications: " + result);
         })
     })
+    
+    function submitClarification(to_team, text) {
+    	var obj = { to_team_id: to_team, text: text };
+    	console.log(obj);
+    	console.log(JSON.stringify(obj));
+    	contest.postClarification(JSON.stringify(obj), function(body) {
+    		$('#object-status').text("Posted successfully: " + body);
+    	}, function(result) {
+    		$('#object-status').text("Post failed: " + result.responseText);
+    	})
+    }
 </script>

--- a/CDS/WebContent/WEB-INF/jsps/details/clarifications.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/clarifications.html
@@ -1,0 +1,80 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseClarifications">Clarifications</a></h4>
+        <div class="card-tools">
+            <span id="clarifications-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+        </div>
+    </div>
+    <div id="collapseClarifications" class="panel-collapse collapse in">
+    <div class="card-body p-0">
+        <table id="clarifications-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th class="text-center">Time</th>
+                    <th>Problem</th>
+                    <th>From Team</th>
+                    <th>To Team</th>
+                    <th>Text</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan=6>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function clarTd(clar) {
+            var problem = '';
+            var time = '';
+            var fromTeam = '';
+            var toTeam = '';
+            if (clar.contest_time != null)
+                time = formatTime(parseTime(clar.contest_time));
+            if (clar.problem_id != null) {
+                problem = findById(contest.getProblems(), clar.problem_id);
+                if (problem != null)
+                    problem = problem.label + ' (' + problem.id + ')';
+            }
+            var teams = contest.getTeams();
+            if (clar.from_team_id != null) {
+                fromTeam = findById(teams, clar.from_team_id);
+                if (fromTeam != null)
+                    fromTeam = fromTeam.id + ' (' + fromTeam.name + ')';
+            }
+            if (clar.to_team_id != null) {
+                toTeam = findById(teams, clar.to_team_id);
+                if (toTeam != null)
+                    toTeam = toTeam.id + ' (' + toTeam.name + ')';
+            }
+
+            return $('<td align="center">' + time + '</td><td>' + problem + '</td><td>' + fromTeam + '</td>' +
+                '<td>' + toTeam + '</td><td class="pre-line">' + sanitizeHTML(clar.text) + '</td>');
+        }
+
+        $.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {
+            fillContestObjectTable("clarifications", contest.getClarifications(), clarTd)
+        }).fail(function (result) {
+        	console.log("Error loading clarifications: " + result);
+        })
+    })
+    
+    function submitClarification(to_team, text) {
+    	var obj = { to_team_id: to_team, text: text };
+    	console.log(obj);
+    	console.log(JSON.stringify(obj));
+    	contest.postClarification(JSON.stringify(obj), function(body) {
+    		$('#object-status').text("Posted successfully: " + body);
+    	}, function(result) {
+    		$('#object-status').text("Post failed: " + result.responseText);
+    	})
+    }
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/contest-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/contest-admin.jsp
@@ -1,0 +1,66 @@
+
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseContest">Contest</a></h4>
+        <div class="card-tools">
+            <button type="button" class="btn btn-tool" onclick="location.href='<%= apiRoot %>'">API</button>
+        </div>
+    </div>
+    <div id="collapseContest" class="panel-collapse collapse in">
+    <div class="card-body p-0">
+        <table class="table table-sm table-hover table-striped table-head-fixed">
+            <tbody>
+                <tr>
+                    <td><b>Name:</b></td>
+                    <td><%= HttpHelper.sanitizeHTML(contest.getName()) %></td>
+                    <td><b>Start:</b></td>
+                    <td><%= ContestUtil.formatStartTime(contest) %></td>
+                </tr>
+                <tr>
+                    <td><b>Duration:</b></td>
+                    <td><%= ContestUtil.formatDuration(contest.getDuration()) %></td>
+                    <td><b>Freeze duration:</b></td>
+                    <td><%= ContestUtil.formatDuration(contest.getFreezeDuration()) %></td>
+                </tr>
+                <tr>
+                    <td class="align-middle"><b>Logo:</b></td>
+                    <td class="table-dark" rowspan=2 id="logo"></td>
+                    <td class="align-middle"><b>Banner:</b></td>
+                    <td class="table-dark" rowspan=2 id="banner"></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function update() {
+            var info = contest.getInfo();
+            var logo = bestSquareLogo(info.logo, 50);
+            console.log(info.name + " - " + info.logo + " -> " + logo);
+            if (logo != null) {
+                var elem = document.createElement("img");
+                elem.setAttribute("src", "/api/" + logo.href);
+                elem.setAttribute("height", "40");
+                document.getElementById("logo").appendChild(elem);
+            }
+            var banner = bestLogo(info.banner, 100, 50);
+            console.log(info.name + " - " + info.banner + " -> " + banner);
+            if (banner != null) {
+                var elem = document.createElement("img");
+                elem.setAttribute("src", "/api/" + banner.href);
+                elem.setAttribute("height", "40");
+                document.getElementById("banner").appendChild(elem);
+            }
+        }
+
+        $.when(contest.loadInfo()).done(function () {
+            update()
+        }).fail(function (result) {
+            console.log("Error loading page: " + result);
+        })
+    })
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/contest.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details/contest.jsp
@@ -1,0 +1,28 @@
+
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title">Contest</h4>
+        <div class="card-tools">
+        </div>
+    </div>
+    <div class="card-body p-0">
+        <table class="table table-sm table-hover table-striped table-head-fixed">
+            <tbody>
+                <tr>
+                    <td><b>Start</b></td>
+                    <td><%= ContestUtil.formatStartTime(contest) %></td>
+                </tr>
+                <tr>
+                    <td><b>Duration</b></td>
+                    <td><%= ContestUtil.formatDuration(contest.getDuration()) %></td>
+                </tr>
+                <tr>
+                    <td><b>Freeze duration</b></td>
+                    <td><%= ContestUtil.formatDuration(contest.getFreezeDuration()) %></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</div>

--- a/CDS/WebContent/WEB-INF/jsps/details/groups-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/groups-admin.html
@@ -1,0 +1,53 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseGroups">Groups</a></h4>
+        <div class="card-tools">
+            <span id="groups-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+            <button type="button" class="btn btn-tool" onclick="location.href='<%= apiRoot %>/groups'">API</button>
+        </div>
+    </div>
+    <div id="collapseGroups" class="panel-collapse collapse in">
+    <div class="card-body p-0">
+        <table id="groups-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th>Id</th>
+                    <th>ICPC Id</th>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Hidden</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan=3>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function groupTd(group) {
+            var typ = "";
+            if (group.type != null)
+                typ = group.type;
+            var hidden = "";
+            if (group.hidden != null)
+                hidden = "true";
+            return $('<td><a href="<%= apiRoot %>/groups/' + group.id + '">' + group.id + '</td><td>' + group.icpc_id + '</td><td>'
+                + sanitizeHTML(group.name) + '</td><td>' + typ + '</td><td>' + hidden + '</td>');
+        }
+
+        $.when(contest.loadGroups()).done(function () {
+            fillContestObjectTable("groups", contest.getGroups(), groupTd)
+        }).fail(function (result) {
+        	console.log("Error loading groups: " + result);
+        });
+    });
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/groups.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/groups.html
@@ -1,49 +1,33 @@
 <div id="accordion">
 <div class="card">
     <div class="card-header">
-        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseGroups">Groups</a></h4>
+        <h4 class="card-title">Groups</h4>
         <div class="card-tools">
             <span id="groups-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
-            <button type="button" class="btn btn-tool" onclick="location.href='<%= apiRoot %>/groups'">API</button>
         </div>
     </div>
-    <div id="collapseGroups" class="panel-collapse collapse in">
     <div class="card-body p-0">
         <table id="groups-table" class="table table-sm table-hover table-striped table-head-fixed">
             <thead>
                 <tr>
-                    <th>Id</th>
-                    <th>ICPC Id</th>
                     <th>Name</th>
-                    <th>Type</th>
-                    <th>Hidden</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td colspan=3>
+                    <td>
                         <div class="spinner-border"></div>
                     </td>
                 </tr>
             </tbody>
         </table>
     </div>
-    </div>
 </div>
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function groupTd(group) {
-            var typ = "";
-            if (group.type != null)
-                typ = group.type;
-            var hidden = "";
-            if (group.hidden != null)
-                hidden = "true";
-            return $('<td><a href="<%= apiRoot %>/groups/' + group.id + '">' + group.id + '</td><td>' + group.icpc_id + '</td><td>'
-                + sanitizeHTML(group.name) + '</td><td>' + typ + '</td><td>' + hidden + '</td>');
+            return $('<td>' + sanitizeHTML(group.name) + '</td>');
         }
 
         $.when(contest.loadGroups()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/judgementTypes-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/judgementTypes-admin.html
@@ -1,0 +1,48 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseJudgementTypes">Judgement Types</a></h4>
+        <div class="card-tools">
+            <span id="judgement-types-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+            <button type="button" class="btn btn-tool"
+                onclick="location.href='<%= apiRoot %>/judgement-types'">API</button>
+        </div>
+    </div>
+    <div id="collapseJudgementTypes" class="panel-collapse collapse in">
+    <div class="card-body p-0">
+        <table id="judgement-types-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th>Id</th>
+                    <th>Name</th>
+                    <th>Penalty</th>
+                    <th>Solved</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan=3>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function judgementTypeTd(jt) {
+            var penalty = jt.penalty;
+            var solved = jt.solved;
+            return $('<td><a href="<%= apiRoot %>/judgement-types/' + jt.id + '">' + jt.id + '</td><td>' + sanitizeHTML(jt.name) + '</td><td>' + penalty + '</td><td>' + solved + '</td>');
+        }
+
+        $.when(contest.loadJudgementTypes()).done(function () {
+            fillContestObjectTable("judgement-types", contest.getJudgementTypes(), judgementTypeTd)
+        }).fail(function (result) {
+        	console.log("Error loading judgement types: " + result);
+        });
+    });
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/judgementTypes.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/judgementTypes.html
@@ -1,44 +1,41 @@
 <div id="accordion">
 <div class="card">
     <div class="card-header">
-        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseJudgementTypes">Judgement Types</a></h4>
+        <h4 class="card-title">Judgement Types</h4>
         <div class="card-tools">
             <span id="judgement-types-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
-            <button type="button" class="btn btn-tool"
-                onclick="location.href='<%= apiRoot %>/judgement-types'">API</button>
         </div>
     </div>
-    <div id="collapseJudgementTypes" class="panel-collapse collapse in">
     <div class="card-body p-0">
         <table id="judgement-types-table" class="table table-sm table-hover table-striped table-head-fixed">
             <thead>
                 <tr>
-                    <th>Id</th>
-                    <th>Name</th>
+                    <th colspan=2>Name</th>
                     <th>Penalty</th>
                     <th>Solved</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td colspan=3>
+                    <td colspan=4>
                         <div class="spinner-border"></div>
                     </td>
                 </tr>
             </tbody>
         </table>
     </div>
-    </div>
 </div>
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function judgementTypeTd(jt) {
-            var penalty = jt.penalty;
-            var solved = jt.solved;
-            return $('<td><a href="<%= apiRoot %>/judgement-types/' + jt.id + '">' + jt.id + '</td><td>' + sanitizeHTML(jt.name) + '</td><td>' + penalty + '</td><td>' + solved + '</td>');
+            var penalty = '';
+            if (jt.penalty)
+            	penalty = '<i class="fas fa-times text-danger"></i> Yes';
+            var solved = '';
+            if (jt.solved)
+            	solved = '<i class="fas fa-check text-success"></i> Yes';
+            return $('<td>' + jt.id + "</td><td>" + sanitizeHTML(jt.name) + '</td><td>' + penalty + '</td><td>' + solved + '</td>');
         }
 
         $.when(contest.loadJudgementTypes()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/languages-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/languages-admin.html
@@ -30,8 +30,6 @@
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function langTd(lang) {
             return $('<td><a href="<%= apiRoot %>/languages/' + lang.id + '">' + lang.id + '</td><td>' + sanitizeHTML(lang.name) + '</td>');
         }

--- a/CDS/WebContent/WEB-INF/jsps/details/languages.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/languages.html
@@ -1,0 +1,39 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title">Languages</h4>
+        <div class="card-tools">
+            <span id="languages-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+        </div>
+    </div>
+    <div class="card-body p-0">
+        <table id="languages-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function langTd(lang) {
+            return $('<td>' + sanitizeHTML(lang.name) + '</td>');
+        }
+
+        $.when(contest.loadLanguages()).done(function () {
+            fillContestObjectTable("languages", contest.getLanguages(), langTd)
+        }).fail(function (result) {
+        	console.log("Error loading languages: " + result);
+        });
+    });
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/orgs-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/orgs-admin.html
@@ -1,0 +1,61 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseOrganizations">Organizations</a></h4>
+        <div class="card-tools">
+            <span id="organizations-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+            <button type="button" class="btn btn-tool"
+                onclick="location.href='<%= apiRoot %>/organizations'">API</button>
+        </div>
+    </div>
+    <div id="collapseOrganizations" class="panel-collapse collapse in">
+    <div class="card-body p-0">
+        <table id="organizations-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th>Id</th>
+                    <th></th>
+                    <th>Name</th>
+                    <th>Formal Name</th>
+                    <th>Country</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan=5>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function orgTd(org) {
+            var logoSrc = '';
+            var logo = bestSquareLogo(org.logo, 20);
+            if (logo != null)
+                logoSrc = '/api/' + logo.href;
+
+            var formal_name = '';
+            if (org.formal_name != null)
+                formal_name = org.formal_name;
+
+            var country = '';
+            if (org.country != null)
+                country = org.country;
+
+            return $('<td><a href="<%= apiRoot %>/organizations/' + org.id + '">' + org.id + '</a></td><td align=middle><img src="' + logoSrc + '" height=20/></td>' +
+                '<td>' + sanitizeHTML(org.name) + '</td><td>' + sanitizeHTML(formal_name) + '</td><td>' + country + '</td>');
+        }
+
+        $.when(contest.loadOrganizations()).done(function () {
+            fillContestObjectTable("organizations", contest.getOrganizations(), orgTd);
+        }).fail(function (result) {
+        	console.log("Error loading orgs: " + result);
+        })
+    })
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/orgs.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/orgs.html
@@ -4,8 +4,6 @@
         <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseOrganizations">Organizations</a></h4>
         <div class="card-tools">
             <span id="organizations-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
-            <button type="button" class="btn btn-tool"
-                onclick="location.href='<%= apiRoot %>/organizations'">API</button>
         </div>
     </div>
     <div id="collapseOrganizations" class="panel-collapse collapse in">
@@ -13,16 +11,14 @@
         <table id="organizations-table" class="table table-sm table-hover table-striped table-head-fixed">
             <thead>
                 <tr>
-                    <th>Id</th>
                     <th></th>
                     <th>Name</th>
-                    <th>Formal Name</th>
                     <th>Country</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td colspan=5>
+                    <td colspan=3>
                         <div class="spinner-border"></div>
                     </td>
                 </tr>
@@ -34,24 +30,27 @@
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function orgTd(org) {
-            var logoSrc = '';
+        	var logoSrc = '';
             var logo = bestSquareLogo(org.logo, 20);
             if (logo != null)
                 logoSrc = '/api/' + logo.href;
+            if (logoSrc != null)
+            	logoSrc = '<img src="' + logoSrc + '" width="20" height="20"/>';
 
-            var formal_name = '';
+            var formal_name = org.name;
             if (org.formal_name != null)
-                formal_name = org.formal_name;
+                formal_name = org.formal_name + " (" + org.name + ")";
 
             var country = '';
-            if (org.country != null)
+            //let regionNames = new Intl.DisplayNames(['en'], {type: 'region'});
+            if (org.country != null) {
+            	//country = regionNames.of(org.country);
                 country = org.country;
+            }
 
-            return $('<td><a href="<%= apiRoot %>/organizations/' + org.id + '">' + org.id + '</a></td><td align=middle><img src="' + logoSrc + '" height=20/></td>' +
-                '<td>' + sanitizeHTML(org.name) + '</td><td>' + sanitizeHTML(formal_name) + '</td><td>' + country + '</td>');
+            return $('<td style="width: 20px;" align=middle>' + logoSrc + '</td>' +
+                '<td>' + sanitizeHTML(formal_name) + '</td><td>' + country + '</td>');
         }
 
         $.when(contest.loadOrganizations()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/details/problems-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/problems-admin.html
@@ -34,8 +34,6 @@
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function problemTd(problem) {
             return $('<td><a href="<%= apiRoot %>/problems/' + problem.id + '">' + problem.id + '</td><td>' + problem.label
                 + '</td><td>' + sanitizeHTML(problem.name) + '</td><td>' + problem.color + '</td><td>' + problem.rgb + '</td><td><div class="circle" style="background-color:' + problem.rgb + '"></div></td>');

--- a/CDS/WebContent/WEB-INF/jsps/details/problems.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/problems.html
@@ -1,0 +1,42 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title">Problems</h4>
+        <div class="card-tools">
+            <span id="problems-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+        </div>
+    </div>
+    <div class="card-body p-0">
+        <table id="problems-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th style="width: 30px;">Color</th>
+                    <th style="width: 30px;">Label</th>
+                    <th>Name</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan=3>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function problemTd(problem) {
+            return $('<td><div class="circle" style="background-color:' + problem.rgb + '"></div></td><td>' + problem.label
+                + '</td><td>' + sanitizeHTML(problem.name) + '</td>');
+        }
+
+        $.when(contest.loadProblems()).done(function () {
+            fillContestObjectTable("problems", contest.getProblems(), problemTd)
+        }).fail(function (result) {
+        	console.log("Error loading problems: " + result);
+        });
+    });
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/teams-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/teams-admin.html
@@ -1,0 +1,76 @@
+<div id="accordion">
+<div class="card">
+    <div class="card-header">
+        <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseTeams">Teams</a></h4>
+        <div class="card-tools">
+            <span id="teams-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+            <button type="button" class="btn btn-tool" onclick="location.href='<%= apiRoot %>/teams'">API</button>
+        </div>
+    </div>
+    <div id="collapseTeams" class="panel-collapse collapse in">
+    <div class="card-body p-0">
+        <table id="teams-table" class="table table-sm table-hover table-striped table-head-fixed">
+            <thead>
+                <tr>
+                    <th>Id</th>
+                    <th>Name</th>
+                    <th colspan=2>Organization</th>
+                    <th>Organization (formal name)</th>
+                    <th>Group</th>
+                    <th>Summary</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan=7>
+                        <div class="spinner-border"></div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    </div>
+</div>
+</div>
+<script type="text/javascript">
+    $(document).ready(function () {
+        function teamTd(team) {
+        	var name = team.display_name;
+        	if (name == null)
+        		name = team.name;
+            var org = findById(contest.getOrganizations(), team.organization_id);
+            var orgName = '';
+            var orgFormalName = '';
+            var logoSrc = '';
+            if (org != null) {
+                orgName = org.name;
+                if (org.formal_name != null)
+                    orgFormalName = org.formal_name;
+                var logo = bestSquareLogo(org.logo, 20);
+                if (logo != null)
+                    logoSrc = '/api/' + logo.href;
+            }
+            var groupNames = '';
+            var groups2 = findGroups(contest.getGroups(), team.group_ids);
+            if (groups2 != null) {
+                var first = true;
+                for (var j = 0; j < groups2.length; j++) {
+                    if (!first)
+                        groupNames += ', ';
+                    groupNames += groups2[j].name;
+                    first = false;
+                }
+            }
+
+            return $('<td><a href="<%= apiRoot %>/teams/' + team.id + '">' + team.id + '</td><td>' + sanitizeHTML(name) + '</td><td align=center><img src="' + logoSrc + '" height=20/></td><td>' + sanitizeHTML(orgName) + '</td><td>' + sanitizeHTML(orgFormalName) + '</td><td>' + sanitizeHTML(groupNames) + '</td>'
+                + '<td><a href="<%= webroot  %>/teamSummary/' + team.id + '">summary</a></td>');
+        }
+
+        $.when(contest.loadTeams(), contest.loadOrganizations(), contest.loadGroups()).done(function () {
+            fillContestObjectTable("teams", contest.getTeams(), teamTd)
+        }).fail(function (result) {
+        	console.log("Error loading teams: " + result);
+        })
+
+    })
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/details/teams.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/teams.html
@@ -4,7 +4,6 @@
         <h4 class="card-title"><a data-toggle="collapse" data-parent="#accordion" href="#collapseTeams">Teams</a></h4>
         <div class="card-tools">
             <span id="teams-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
-            <button type="button" class="btn btn-tool" onclick="location.href='<%= apiRoot %>/teams'">API</button>
         </div>
     </div>
     <div id="collapseTeams" class="panel-collapse collapse in">
@@ -12,17 +11,15 @@
         <table id="teams-table" class="table table-sm table-hover table-striped table-head-fixed">
             <thead>
                 <tr>
-                    <th>Id</th>
+                    <th colspan=2>#</th>
                     <th>Name</th>
-                    <th colspan=2>Organization</th>
-                    <th>Organization (formal name)</th>
+                    <th>Organization</th>
                     <th>Group</th>
-                    <th>Summary</th>
                 </tr>
             </thead>
             <tbody>
                 <tr>
-                    <td colspan=7>
+                    <td colspan=4>
                         <div class="spinner-border"></div>
                     </td>
                 </tr>
@@ -34,20 +31,18 @@
 </div>
 <script type="text/javascript">
     $(document).ready(function () {
-        contest.setContestId("<%= cc.getId() %>");
-
         function teamTd(team) {
         	var name = team.display_name;
         	if (name == null)
         		name = team.name;
             var org = findById(contest.getOrganizations(), team.organization_id);
             var orgName = '';
-            var orgFormalName = '';
             var logoSrc = '';
             if (org != null) {
-                orgName = org.name;
                 if (org.formal_name != null)
-                    orgFormalName = org.formal_name;
+                    orgName = org.formal_name + '(' + org.name + ')';
+                else
+                	orgName = org.name;
                 var logo = bestSquareLogo(org.logo, 20);
                 if (logo != null)
                     logoSrc = '/api/' + logo.href;
@@ -64,8 +59,7 @@
                 }
             }
 
-            return $('<td><a href="<%= apiRoot %>/teams/' + team.id + '">' + team.id + '</td><td>' + sanitizeHTML(name) + '</td><td align=center><img src="' + logoSrc + '" height=20/></td><td>' + sanitizeHTML(orgName) + '</td><td>' + sanitizeHTML(orgFormalName) + '</td><td>' + sanitizeHTML(groupNames) + '</td>'
-                + '<td><a href="<%= webroot  %>/teamSummary/' + team.id + '">summary</a></td>');
+            return $('<td>' + team.id + '</td><td align=center><img src="' + logoSrc + '" height=20/></td><td>' + sanitizeHTML(name) + '</td><td>' + sanitizeHTML(orgName) + '</td><td>' + sanitizeHTML(groupNames) + '</td>');
         }
 
         $.when(contest.loadTeams(), contest.loadOrganizations(), contest.loadGroups()).done(function () {

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -124,7 +124,7 @@
 
               <ul class="nav nav-treeview">
                 <% for (int i = 0; i < menuPages.length; i++) 
-                   if (i < 4 || Role.isAdmin(request)) { %>
+                   if ((i > 0 && i < 4) || Role.isAdmin(request)) { %>
                 <li class="nav-item">
                   <a href="${pageContext.request.contextPath}/contests/<%= cc3.getId() %><%= menuPages[i] %>"
                     class="nav-link<% if (request.getAttribute("javax.servlet.forward.request_uri").equals(webroot3 + menuPages[i])) { %> active<% } %>">


### PR DESCRIPTION
I created a team version of the UI that doesn't have API http links and 'admin-y' things like element ids. I don't _love_ this change, but I couldn't come up with a cleaner way to do this without creating copies of several files - although the UIs are close, I think you'd end up with a lot of if statements and odd logic to handle the number of columns and other differences.

Here's what I did:
- Removed the Overview page for teams in addition to the others. This is really just a 'connection details' page, so maybe it should be renamed even for admins.
- Removed the 'contest.setContestId()' from as many pages as possible and renamed them from .jsp to .html to be clear that they're now 'clean' client-side code.
- Renamed most existing /details pages to -admin and created a second copy of each for teams that removes details like API links, object ids, and some details that I don't think teams would ever need.
- Changed the layout a bit and removed the ability to collapse many of the sections.
- Removed awards, submissions, and judgements sections from the Details for teams.

I would like to have a better UI for some things (e.g. clarifications should probably be on their own page in a post-reply kind of UI vs the current table) but this is a pretty good pass at making it generally ok. There are a couple things that still aren't 'clean': the submissions page contains ids and the scoreboard page has a link to the API. I didn't touch either of these yet because both are minor, and both pages also contain server-side logic (.jsp) that ideally I'd change to client side (javascript) first.