### PR TITLE
Move scoreboard and submissions pages toward client-side logic

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/details/teams-admin.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/teams-admin.html
@@ -51,7 +51,7 @@
                     logoSrc = '/api/' + logo.href;
             }
             var groupNames = '';
-            var groups2 = findGroups(contest.getGroups(), team.group_ids);
+            var groups2 = findManyById(contest.getGroups(), team.group_ids);
             if (groups2 != null) {
                 var first = true;
                 for (var j = 0; j < groups2.length; j++) {

--- a/CDS/WebContent/WEB-INF/jsps/details/teams.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/teams.html
@@ -48,7 +48,7 @@
                     logoSrc = '/api/' + logo.href;
             }
             var groupNames = '';
-            var groups2 = findGroups(contest.getGroups(), team.group_ids);
+            var groups2 = findManyById(contest.getGroups(), team.group_ids);
             if (groups2 != null) {
                 var first = true;
                 for (var j = 0; j < groups2.length; j++) {

--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -1,6 +1,4 @@
 <%@ page import="org.icpc.tools.cds.util.Role" %>
-<%@ page import="org.icpc.tools.cds.CDSConfig" %>
-<%@ page import="org.icpc.tools.contest.model.IProblem" %>
 <% request.setAttribute("title", "Scoreboard"); %>
 <%@ include file="layout/head.jsp" %>
 <div class="container-fluid">
@@ -24,35 +22,14 @@
 
                         <a href="<%= webroot%>/scoreboardCompare/compare2src">source</a>
                     </p>
-
                     <% } %>
 
                     <table id="score-table" class="table table-sm table-hover table-striped table-head-fixed">
                         <thead>
-                            <tr>
-                                <th class="text-right">Rank</th>
-                                <th></th>
-                                <th>Team</th>
-                                <th>Organization</th>
-                                <% int numProblems = contest.getNumProblems();
-                        for (int j = 0; j < numProblems; j++) {
-                            IProblem p = contest.getProblems()[j]; %>
-
-                                <th class="text-center">
-                                    <%= p.getLabel() %>
-                                    <div class="circle" style="background-color: <%= p.getRGB() %>"></div>
-                                </th>
-                                <% } %>
-
-                                <th class="text-right">Solved</th>
-                                <th class="text-right">Time</th>
-                            </tr>
                         </thead>
                         <tbody>
                             <tr>
-                                <td colspan="<%= 6 + numProblems %>">
-                                    <div class="spinner-border"></div>
-                                </td>
+                                <td><div class="spinner-border"></div></td>
                             </tr>
                         </tbody>
                     </table>
@@ -67,6 +44,21 @@
 <script type="text/javascript">
     $(document).ready(function () {
         contest.setContestId("<%= cc.getId() %>");
+
+        function createTableHeader() {
+            $("#score-table thead").find("tr").remove();
+            var row = $('<tr></tr>');
+            row.append($('<th class="text-right">Rank</th><th></th><th>Team</th><th>Organization</th>'));
+       
+            problems = contest.getProblems();
+            for (var i = 0; i < problems.length; i++) {
+            	row.append($('<th class="text-center">' + problems[i].label + 
+                   ' <div class="circle" style="background-color: ' + problems[i].rgb + '"></div></th>'));
+            }
+
+            row.append($('<th class="text-right">Solved</th><th class="text-right">Time</th>'));
+            $('#score-table thead').append(row);
+        }
 
         function fillTable() {
             $("#score-table tbody").find("tr").remove();
@@ -131,7 +123,8 @@
         sortByColumn($('#score-table'));
 
         $.when(contest.loadOrganizations(), contest.loadTeams(), contest.loadProblems(), contest.loadScoreboard()).done(function () {
-            fillTable()
+        	createTableHeader();
+            fillTable();
         }).fail(function (result) {
         	console.log("Error loading scoreboard: " + result);
         })

--- a/CDS/WebContent/WEB-INF/jsps/submissions.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions.jsp
@@ -1,4 +1,3 @@
-<%@page import="org.icpc.tools.contest.model.*" %>
 <%@page import="java.util.List" %>
 <% request.setAttribute("title", "Submissions"); %>
 <%@ include file="layout/head.jsp" %>
@@ -8,100 +7,12 @@
             <div class="card">
                 <div class="card-header">
                     <h3 class="card-title">Judge Queue</h3>
+                    <div class="card-tools">
+                       <span id="queue-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+                    </div>
                 </div>
                 <div class="card-body p-0">
-                    <table class="table table-sm table-hover table-striped table-head-fixed">
-                        <thead>
-                            <tr>
-                                <th>Id</th>
-                                <th class="text-center">Time</th>
-                                <th>Problem</th>
-                                <th>Language</th>
-                                <th>Team</th>
-                                <th>Organization</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-
-                    <% ISubmission[] subs = contest.getSubmissions();
-                    int numJudging = 0;
-                    for (int i = 0; i < subs.length; i++) {
-                        String id = subs[i].getTeamId();
-                        String teamStr = "";
-                        String orgStr = "";
-                        if (id != null) {
-                            ITeam team = contest.getTeamById(id);
-                            if (team != null) {
-                                teamStr = id + ": " + team.getActualDisplayName();
-                                IOrganization org = contest.getOrganizationById(team.getOrganizationId());
-                                if (org != null)
-                                    orgStr = org.getName();
-                            }
-                        }
-
-                        id = subs[i].getId();
-                        boolean judged = false;
-                        if (id != null) {
-                            IJudgement[] jud = contest.getJudgementsBySubmissionId(id);
-                            if (jud != null) {
-                                for (IJudgement j : jud) {
-                                    if (j.getJudgementTypeId() != null)
-                                        judged = true;
-                                }
-                            }
-                        }
-                        if (judged)
-                            continue;
-                        numJudging++;
-
-                        String langStr = "";
-                        id = subs[i].getLanguageId();
-                        if (id != null) {
-                            ILanguage lang = contest.getLanguageById(id);
-                            if (lang != null)
-                                langStr = lang.getName();
-                        }
-
-                        String probStr = "";
-                        id = subs[i].getProblemId();
-                        if (id != null) {
-                            IProblem prob = contest.getProblemById(id);
-                            if (prob != null)
-                                probStr = id + " (" + prob.getLabel() + ")";
-                        } %>
-                            <tr>
-                                <td><a href="<%= apiRoot %>/submissions/<%= subs[i].getId() %>">
-                                        <%= subs[i].getId() %>
-                                    </a></td>
-                                <td class="text-center">
-                                    <%= ContestUtil.formatTime(subs[i].getContestTime()) %>
-                                </td>
-                                <td>
-                                    <%= probStr %>
-                                </td>
-                                <td>
-                                    <%= langStr %>
-                                </td>
-                                <td>
-                                    <%= teamStr %>
-                                </td>
-                                <td>
-                                    <%= orgStr %>
-                                </td>
-                            </tr>
-                            <% } %>
-                        </tbody>
-                    </table>
-                    <p class="indent"><%= numJudging %> pending judgements</p>
-                </div>
-            </div>
-
-            <div class="card">
-                <div class="card-header">
-                    <h3 class="card-title">Submissions</h3>
-                </div>
-                <div class="card-body p-0">
-                    <table class="table table-sm table-hover table-striped table-head-fixed">
+                    <table id="queue-table" class="table table-sm table-hover table-striped table-head-fixed">
                         <thead>
                             <tr>
                                 <th>Id</th>
@@ -114,112 +25,42 @@
                             </tr>
                         </thead>
                         <tbody>
-                    <% for (ISubmission sub : subs) {
-                    String id = sub.getTeamId();
-                    String teamStr = "";
-                    String orgStr = "";
-                    if (id != null) {
-                        ITeam team = contest.getTeamById(id);
-                        if (team != null) {
-                            teamStr = id + ": " + team.getActualDisplayName();
-                            IOrganization org = contest.getOrganizationById(team.getOrganizationId());
-                            if (org != null)
-                                orgStr = org.getName();
-                        } else
-                            teamStr = "<font color=\"red\">" + id + "</font>";
-                    }
+                           <tr>
+                              <td colspan=7>
+                                 <div class="spinner-border"></div>
+                              </td>
+                           </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
 
-                    id = sub.getId();
-                    String judgeStr = "";
-                    String judgeClass = "";
-                    if (id != null) {
-                        IJudgement[] jud = contest.getJudgementsBySubmissionId(id);
-                        if (jud != null) {
-                            for (IJudgement j : jud) {
-                                IJudgementType jt = contest.getJudgementTypeById(j.getJudgementTypeId());
-                                if (jt != null) {
-                                    judgeStr += jt.getName();
-                                    if (contest.isFirstToSolve(sub))
-                                        judgeClass = "bg-success";
-                                    else if (jt.isSolved())
-                                        judgeClass = "table-success";
-                                    else if (jt.isPenalty())
-                                        judgeClass = "table-danger";
-                                } else {
-                                    judgeClass = "table-warning";
-                                    judgeStr += "...";
-                                }
-                                judgeStr += " (<a href=\"" + apiRoot + "/judgements/" + j.getId() + "\">" + j.getId() + "</a>) ";
-                       /*IRun[] runs = contest.getRunsByJudgementId(j.getId());
-                       if (runs != null) {
-                          //judgeStr += runs.length;
-                          for (IRun r : runs) {
-                             judgeStr += "<a href=\""+ apiRoot + "/runs/" + r.getId() + "\">" +r.getId() + "</a> ";
-                          }
-                       }
-                       judgeStr += "]";*/
-                            }
-                        }
-                    }
-
-                    String langStr = "";
-                    id = sub.getLanguageId();
-                    if (id != null) {
-                        ILanguage lang = contest.getLanguageById(id);
-                        if (lang != null)
-                            langStr = lang.getName();
-                        else
-                            langStr = "<span class=\"text-danger\">" + id + "</span>";
-                    }
-
-                    String probStr = "";
-                    id = sub.getProblemId();
-                    if (id != null) {
-                        IProblem prob = contest.getProblemById(id);
-                        if (prob != null)
-                            probStr = id + " (" + prob.getLabel() + ")";
-                        else
-                            probStr = "<span class=\"text-danger\">" + id + "</span>";
-                    }
-
-                    List<String> valList = sub.validate(contest);
-                    String val = null;
-                    if (valList != null && !valList.isEmpty()) {
-                        val = "";
-                        for (String s : valList)
-                            val += s + "\n";
-                    } %>
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Submissions</h3>
+                    <div class="card-tools">
+                       <span id="submissions-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
+                    </div>
+                </div>
+                <div class="card-body p-0">
+                    <table id="submissions-table" class="table table-sm table-hover table-striped table-head-fixed">
+                        <thead>
                             <tr>
-                                <td>
-                                    <a href="<%= apiRoot %>/submissions/<%= sub.getId() %>">
-                                        <%= sub.getId() %>
-                                    </a>
-                                    <% if (val != null) { %>
-                                    <span class="text-danger">
-                                        <%= val %>
-                                    </span>
-                                    <% } %>
-                                </td>
-                                <td class="text-center">
-                                    <%= ContestUtil.formatTime(sub.getContestTime()) %>
-                                </td>
-                                <td>
-                                    <%= probStr %>
-                                </td>
-                                <td>
-                                    <%= langStr %>
-                                </td>
-                                <td>
-                                    <%= teamStr %>
-                                </td>
-                                <td>
-                                    <%= orgStr %>
-                                </td>
-                                <td class="<%= judgeClass %>">
-                                    <%= judgeStr %>
-                                </td>
+                                <th>Id</th>
+                                <th class="text-center">Time</th>
+                                <th>Problem</th>
+                                <th>Language</th>
+                                <th>Team</th>
+                                <th>Organization</th>
+                                <th>Judgements</th>
                             </tr>
-                            <% } %>
+                        </thead>
+                        <tbody>
+                           <tr>
+                              <td colspan=7>
+                                 <div class="spinner-border"></div>
+                              </td>
+                           </tr>
                         </tbody>
                     </table>
                 </div>
@@ -227,4 +68,95 @@
         </div>
     </div>
 </div>
+<script src="${pageContext.request.contextPath}/js/model.js"></script>
+<script src="${pageContext.request.contextPath}/js/contest.js"></script>
+<script src="${pageContext.request.contextPath}/js/ui.js"></script>
+<script type="text/javascript">
+    $(document).ready(function () {
+    	contest.setContestId("<%= cc.getId() %>");
+
+        function submissionTd(submission) {
+        	var time = '';
+        	var problem = '';
+        	var lang = '';
+        	var team = '';
+        	var org = '';
+        	var judge = '';
+        	var judgeClass = '';
+        	if (submission.contest_time != null)
+                time = formatTime(parseTime(submission.contest_time));
+        	if (submission.problem_id != null) {
+                problem = findById(contest.getProblems(), submission.problem_id);
+                if (problem != null)
+                    problem = problem.label + ' (' + problem.id + ')';
+            }
+        	if (submission.language_id != null) {
+                lang = findById(contest.getLanguages(), submission.language_id);
+                if (lang != null)
+                	lang = lang.name;
+            }
+        	if (submission.team_id != null) {
+        		team = submission.team_id;
+                var team2 = findById(contest.getTeams(), submission.team_id);
+                if (team2.organization_id != null) {
+                	org = findById(contest.getOrganizations(), team2.organization_id);
+                    if (org != null)
+                        org = org.name;
+                }
+                if (team2 != null)
+                	team = team2.display_name;
+                	if (team == null)
+                		team = team2.name;
+                	team = team2.id + ": " + team;
+            }
+        	var judgements = findManyBySubmissionId(contest.getJudgements(), submission.id);
+        	if (judgements != null && judgements.length > 0) {
+                var first = true;
+                for (var j = 0; j < judgements.length; j++) {
+                    if (!first)
+                    	judge += ', ';
+                    var jt = findById(contest.getJudgementTypes(), judgements[j].judgement_type_id);
+                    if (jt != null) {
+                        judge += jt.name;
+                        if (jt.solved) {
+                        	if (isFirstToSolve(contest,submission))
+                        		judgeClass = "bg-success";
+                        	else
+                            	judgeClass = "table-success";
+                        } else if (jt.penalty)
+                            judgeClass = "table-danger";
+                    } else {
+                        judgeClass = "table-warning";
+                        judge += "...";
+                    }
+                    judge += ' (<a href="<%= apiRoot %>/judgements/' + judgements[j].id + '">' + judgements[j].id + '</a>)';
+                    first = false;
+                }
+            }
+            return $('<td><a href="<%= apiRoot %>/submissions/' + submission.id + '">' + submission.id + '</td><td>' + time + '</td><td>'
+                + problem + '</td><td>' + lang + '</td><td>' + team + '</td><td>' + org + '</td><td class="' + judgeClass + '">' + judge + '</td>');
+        }
+
+        $.when(contest.loadLanguages(), contest.loadOrganizations(), contest.loadTeams(), contest.loadProblems(), contest.loadSubmissions(), contest.loadJudgements(), contest.loadJudgementTypes()).done(function () {
+        	var queue = [];
+        	submissions = contest.getSubmissions();
+            for (var i = 0; i < submissions.length; i++) {
+               var judgements = findManyBySubmissionId(contest.getJudgements(), submissions[i].id);
+               var hasJudgement = false;
+               if (judgements != null) {
+            	  for (var j = 0; j < judgements.length; j++) {
+            		 if (judgements[j].judgement_type_id != null)
+            			 hasJudgement = true;
+            	  }
+               }
+               if (!hasJudgement)
+                  queue.push(submissions[i]);
+            }
+        	fillContestObjectTable("queue", queue, submissionTd);
+        	fillContestObjectTable("submissions", submissions, submissionTd);
+        }).fail(function (result) {
+        	console.log("Error loading groups: " + result);
+        });
+    });
+</script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -6,6 +6,8 @@ var contest=(function() {
 	var languages;
 	var judgementTypes;
 	var problems;
+	var submissions;
+	var judgements;
 	var clarifications;
 	var awards;
 	var startStatus;
@@ -136,6 +138,38 @@ var contest=(function() {
 		}
 	}
 
+    var loadSubmissions = function() {
+		console.log("Loading submissions: " + submissions);
+		var deferred = new $.Deferred();
+		if (submissions != null) {
+			deferred.resolve();
+			return deferred;
+		} else {
+			return $.ajax({
+			  url: urlPrefix + 'submissions',
+			  success: function(result) {
+				  submissions = result;
+			  }
+			});
+		}
+	}
+
+	var loadJudgements = function() {
+		console.log("Loading judgements: " + judgements);
+		var deferred = new $.Deferred();
+		if (judgements != null) {
+			deferred.resolve();
+			return deferred;
+		} else {
+			return $.ajax({
+			  url: urlPrefix + 'judgements',
+			  success: function(result) {
+				  judgements = result;
+			  }
+			});
+		}
+	}
+
 	var loadClarifications = function() {
 		console.log("Loading clarifications: " + clarifications);
 		var deferred = new $.Deferred();
@@ -211,6 +245,12 @@ var contest=(function() {
 	}
 	var getProblems = function() {
 		return problems;
+	}
+	var getSubmissions = function() {
+		return submissions;
+	}
+	var getJudgements = function() {
+		return judgements;
 	}
 	var getClarifications = function() {
 		return clarifications;
@@ -320,6 +360,8 @@ var contest=(function() {
 		loadJudgementTypes: loadJudgementTypes,
 		loadTeams: loadTeams,
 		loadProblems: loadProblems,
+		loadSubmissions: loadSubmissions,
+		loadJudgements: loadJudgements,
 		loadClarifications: loadClarifications,
 		loadAwards: loadAwards,
 		loadStartStatus: loadStartStatus,
@@ -331,6 +373,8 @@ var contest=(function() {
 		getGroups: getGroups,
 		getOrganizations: getOrganizations,
 		getTeams: getTeams,
+		getSubmissions: getSubmissions,
+		getJudgements: getJudgements,
 		getClarifications: getClarifications,
 		getAwards: getAwards,
 		getStartStatus: getStartStatus,

--- a/CDS/WebContent/js/model.js
+++ b/CDS/WebContent/js/model.js
@@ -1,4 +1,4 @@
-function findById(arr,id) {
+function findById(arr, id) {
   if (arr == null || id == null)
     return null;
 
@@ -9,18 +9,30 @@ function findById(arr,id) {
   return null;
 }
 
-function findGroups(groups, ids) {
-  if (groups == null || ids == null || ids.length == 0)
+function findManyById(arr, ids) {
+  if (arr == null || ids == null || ids.length == 0)
     return null;
 
-  var grs = [];
+  var list = [];
   for (var j = 0; j < ids.length; j++) {
-    for (var i = 0; i < groups.length; i++) {
-      if (ids[j] == groups[i].id)
-        grs.push(groups[i]);
+    for (var i = 0; i < arr.length; i++) {
+      if (ids[j] == arr[i].id)
+        list.push(arr[i]);
     }
   }
-  return grs;
+  return list;
+}
+
+function findManyBySubmissionId(arr, id) {
+  if (arr == null || id == null)
+    return null;
+
+  var list = [];
+  for (var i = 0; i < arr.length; i++) {
+    if (arr[i].submission_id == id)
+      list.push(arr[i]);
+  }
+  return list;
 }
 
 function bestSquareLogo(logos, size) {
@@ -84,25 +96,38 @@ function bestLogo(logos, width, height) {
 function parseTime(contestTime) {
 	match = contestTime.match("-?([0-9]+):([0-9]{2}):([0-9]{2})(\\.[0-9]{3})?");
 
-	h = parseInt(match[0]);
-	m = parseInt(match[1]);
-	s = parseInt(match[2]);	
+	h = parseInt(match[1]);
+	m = parseInt(match[2]);
+	s = parseInt(match[3]);	
 	ms = 0;
-	if (match.length == 4)
-		ms = parseInt(match[3].substring(1));
+	if (match.length == 5)
+		ms = parseInt(match[4].substring(1));
 
 	ret = h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
 	if (contestTime.startsWith("-"))
-	  return -ret;
-	
+	  return -ret
+
 	return ret;
-} 
+}
 
-var isInt = (function() {
-	  var re = /^[+-]?\d+$/;
-	  var re2 = /\.0+$/;
-
-	  return function(n) {
-	    return re.test((''+ n).replace(re2,''));
-	  }
-	}());
+function isFirstToSolve(contest, submission) {
+   problem_id = submission.problem_id;
+   submissions = contest.getSubmissions();
+   for (var i = 0; i < submissions.length; i++) {
+      if (parseTime(submissions[i].contest_time) >= 0 && submissions[i].problem_id == problem_id) {
+         // TODO: should we check if this is a public team too?
+         var judgements = findManyBySubmissionId(contest.getJudgements(), submissions[i].id);
+         if (judgements != null && judgements.length > 0) {
+            var jt = findById(contest.getJudgementTypes(), judgements[judgements.length - 1].judgement_type_id);
+            if (jt != null) {
+               if (jt.solved) {
+                  if (submission == submissions[i])
+                     return true;
+                  return false;
+               }
+            }
+         }
+      }
+   }
+   return false;
+}

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -73,12 +73,12 @@ function formatTime(time2) {
 		return "0s";
 
 	var sb = [];
-	time = time2 / 1000;
-
-	if (time < 0) {
+	if (time2 < 0) {
 		sb.push("-");
-		time = -time;
+		time2 = -time2;
 	}
+	time = Math.floor(time2 / 1000);
+
 	days = Math.floor(time / 86400.0);
 	if (days > 0)
 		sb.push(days + "d");


### PR DESCRIPTION
Changed the Scoreboard (just problem header) and Submissions page (both judge queue and list of submissions) from server-side (jsp) to client-side (javascript) logic. This doesn't make either page completely 'clean', but it moves the bulk of the logic over. This will make it easier later to dynamically refresh parts of the page or reuse the pages when pointing at another Contest API server.

Minimal UI differences, and where there are it's more consistent with other pages (e.g. there was a footer on the judge queue that said how many there are, now it uses the card-tool at the top-right like everything in the Details page).

I didn't specifically test performance, but this page has always been slightly slower than other pages (due to sheer complexity compared to other pages) and even without optimizing the contest model or building lookup tables it appears to be performing fine even on large contests.

- Added submissions and judgements to contest.js.
- Changed findGroups() more generic findManyById() and fixed references in teams pages.
- Added findManyBySubmissionId() and isFirstToSolve() to model.
- Found and fixed problems with negative contest time in both parsing (model.js) and formatting (ui.js).