### PR TITLE
Add support for AdminLTE 3.1 dark mode

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -21,6 +21,7 @@
 <script src="${pageContext.request.contextPath}/js/jquery.min.js"></script>
 <script src="${pageContext.request.contextPath}/js/bootstrap.bundle.min.js"></script>
 <script src="${pageContext.request.contextPath}/js/adminlte.min.js"></script>
+<script src="${pageContext.request.contextPath}/js/theme.js"></script>
 
 <head>
   <meta charset="utf-8"/>
@@ -65,6 +66,23 @@
 
       <!-- Right navbar links -->
       <ul class="navbar-nav ml-auto">
+        <li class="nav-item dropdown theme-menu">
+          <a class="nav-link" data-toggle="dropdown" href="#">
+            <i class="fas fa-user"></i>&nbsp;&nbsp;
+            Theme
+          </a>
+          <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
+            <a class="dropdown-item" href="#" data-theme="auto">
+              <i class="fas fa-check fa-fw"></i>&nbsp;&nbsp;Use device theme
+            </a>
+            <a class="dropdown-item" href="#" data-theme="light">
+              <i class="fas fa-fw"></i>&nbsp;&nbsp;Light theme
+            </a>
+            <a class="dropdown-item" href="#" data-theme="dark">
+              <i class="fas fa-fw"></i>&nbsp;&nbsp;Dark theme
+            </a>
+          </div>
+        </li>
         <% if (request.getRemoteUser() == null) { %>
           <li class="nav-item dropdown">
             <a class="nav-link" href="${pageContext.request.contextPath}/login">
@@ -117,7 +135,7 @@
                 String webroot3 = request.getContextPath() + "/contests/" + cc3.getId(); %>
 
             <li class="nav-item has-treeview menu-<% if (cc == cc3) { %>open<% } else { %>closed<% } %>">
-              <a href="#" class="nav-link">
+              <a href="#" class="nav-link <% if (cc == cc3) { %>active<% } %>">
                 <i class="nav-icon fas fa-tachometer-alt"></i>
                 <p>
                   <%= contest3.getName() != null ? contest3.getName() : "(unnamed contest)" %>
@@ -153,7 +171,7 @@
 
             <% if (Role.isAdmin(request)) { %>
             <li class="nav-item has-treeview menu-<% if (request.getAttribute("javax.servlet.forward.request_uri").toString().contains("/video/control/")) { %>open<% } else { %>closed<% } %>">
-              <a href="#" class="nav-link">
+              <a href="#" class="nav-link <% if (request.getAttribute("javax.servlet.forward.request_uri").toString().contains("/video/control/")) { %>active<% } %>">
                 <i class="nav-icon fas fa-video"></i>
                 <p>
                   Video
@@ -199,7 +217,7 @@
               <% String contestName = "";
                if (contest != null && contest.getName() != null)
                    contestName = contest.getName() + " "; %>
-              <h1 class="m-0 text-dark"><%= HttpHelper.sanitizeHTML(contestName) %><%= request.getAttribute("title") %></h1>
+              <h1 class="m-0"><%= HttpHelper.sanitizeHTML(contestName) %><%= request.getAttribute("title") %></h1>
             </div><!-- /.col -->
           </div><!-- /.row -->
         </div><!-- /.container-fluid -->

--- a/CDS/WebContent/WEB-INF/jsps/login.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/login.jsp
@@ -11,6 +11,11 @@
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/adminlte.min.css"/>
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/cds.css"/>
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/source-sans-pro.css"/>
+
+  <script src="${pageContext.request.contextPath}/js/jquery.min.js"></script>
+  <script src="${pageContext.request.contextPath}/js/bootstrap.bundle.min.js"></script>
+  <script src="${pageContext.request.contextPath}/js/adminlte.min.js"></script>
+  <script src="${pageContext.request.contextPath}/js/theme.js"></script>
 </head>
 <body class="hold-transition login-page">
 <div class="login-box">
@@ -60,10 +65,6 @@
   </div>
 </div>
 <!-- /.login-box -->
-
-<script src="${pageContext.request.contextPath}/js/jquery.min.js"></script>
-<script src="${pageContext.request.contextPath}/js/bootstrap.bundle.min.js"></script>
-<script src="${pageContext.request.contextPath}/js/adminlte.min.js"></script>
 
 </body>
 </html>

--- a/CDS/WebContent/WEB-INF/jsps/welcome.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/welcome.jsp
@@ -22,26 +22,23 @@
                     if (state == null)
                         state = new State();
                     String headerClass = "bg-info";
-                    String textClass = "text-white";
                     if (state.getFinalized() != null) {
                         headerClass = "";
-                        textClass = "text-dark";
                     } else if (state.getEnded() != null)
                         headerClass = "bg-danger";
                     else if (state.getFrozen() != null) {
                         headerClass = "bg-warning";
-                        textClass = "text-dark";
                     } else if (state.getStarted() != null)
                         headerClass = "bg-success";
             %>
       <div class="card mb-4">
         <% String webRootH = "/contests/" + cch.getId();
            String apiRootH = "/api/contests/" + cch.getId(); %>
-        <div class="card-header <%= headerClass %> <%= textClass %>">
+        <div class="card-header <%= headerClass %> default-text-color">
           <a href="<%= webRootH %>">
-            <h2 class="card-title <%= textClass %>"><%= contestH.getActualFormalName() != null ? HttpHelper.sanitizeHTML(contestH.getActualFormalName()) : "(unnamed contest)" %></h2>
+            <h2 class="card-title default-text-color"><%= contestH.getActualFormalName() != null ? HttpHelper.sanitizeHTML(contestH.getActualFormalName()) : "(unnamed contest)" %></h2>
           </a>
-          <div class="card-tools"><a href="<%= apiRootH %>" class="<%= textClass %>">/<%= cch.getId() %></a></div>
+          <div class="card-tools"><a href="<%= apiRootH %>" class="default-text-color">/<%= cch.getId() %></a></div>
         </div>
         <div class="card-body <%= headerClass %>">
           <table class="table table-sm table-fullwidth">
@@ -65,7 +62,7 @@
               <tr>
                 <td colspan="3">
                   <% if (state.isRunning()) { %>
-                  <% if (state.isFrozen()) { %><a class="<%= textClass %>" href="<%= webRootH %>/freeze">Scoreboard frozen</a>. <% } %>
+                  <% if (state.isFrozen()) { %><a class="default-text-color" href="<%= webRootH %>/freeze">Scoreboard frozen</a>. <% } %>
                   Started at <%= ContestUtil.formatStartTime(contestH) %>
                   <% } else if (state.getFinalized() != null) { %>
                   Finalized. Started at <%= ContestUtil.formatStartTime(contestH) %>
@@ -91,14 +88,14 @@
               </tr>
               <tr>
                 <td colspan="3"><a href="<%= webRootH %>/details"
-                    class="<%= textClass %>"><%= contestH.getNumProblems() %> problems, <%= contestH.getNumTeams() %> teams</a>
+                    class="default-text-color"><%= contestH.getNumProblems() %> problems, <%= contestH.getNumTeams() %> teams</a>
                   <span class="float-right"><a href="<%= webRootH %>/scoreboard"
-                      class="<%= textClass %>">Scoreboard</a></span></td>
+                      class="default-text-color">Scoreboard</a></span></td>
               </tr>
               <tr>
                 <td colspan="3"><a href="<%= webRootH %>/submissions"
-                    class="<%= textClass %>"><%= contestH.getNumSubmissions() %> submissions</a>
-                  <span class="float-right"><a href="<%= webRootH %>/admin" class="<%= textClass %>">Admin</a></span>
+                    class="default-text-color"><%= contestH.getNumSubmissions() %> submissions</a>
+                  <span class="float-right"><a href="<%= webRootH %>/admin" class="default-text-color">Admin</a></span>
                 </td>
               </tr>
             </thead>

--- a/CDS/WebContent/css/cds.css
+++ b/CDS/WebContent/css/cds.css
@@ -9,3 +9,22 @@ body {
 	margin: 10px;
 	margin-left: 20px;
 }
+
+.default-text-color {
+    color: #343a40;
+}
+
+body.dark-mode .default-text-color {
+    color: #fff;
+}
+
+/* Some elements don't really offer a good dark mode element by default, so we create our own */
+body.dark-mode .table-success {
+    background-color: #00795b !important;
+}
+body.dark-mode .table-danger {
+    background-color: #e74c3c !important;
+}
+body.dark-mode .table-warning {
+    background-color: #f39c12 !important;
+}

--- a/CDS/WebContent/js/theme.js
+++ b/CDS/WebContent/js/theme.js
@@ -1,0 +1,48 @@
+// Theme switching support
+var localStorageThemeKey = 'cds_theme';
+
+function loadTheme() {
+    var theme = 'auto';
+    var actualTheme;
+    if (window.localStorage.getItem(localStorageThemeKey)) {
+        theme = window.localStorage.getItem(localStorageThemeKey);
+    }
+
+    if (theme === 'auto') {
+        actualTheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+    } else {
+        actualTheme = theme;
+    }
+
+    if (actualTheme === 'dark') {
+        $('body').addClass('dark-mode');
+        $('nav.main-header').addClass('navbar-dark').removeClass('navbar-white navbar-light');
+    } else {
+        $('body').removeClass('dark-mode');
+        $('nav.main-header').removeClass('navbar-dark').addClass('navbar-white navbar-light');
+    }
+
+    $('[data-theme]').find('i.fas').removeClass('fa-check');
+    $('[data-theme=' + theme + '] i.fas').addClass('fa-check');
+}
+
+$(function() {
+    $('[data-theme]').click(function() {
+        window.localStorage.setItem(localStorageThemeKey, $(this).data('theme'));
+        loadTheme();
+    });
+
+    if (!window.localStorage) {
+        $('.theme-menu').hide();
+    } else {
+        // Load the currently configured theme
+        loadTheme();
+    }
+});
+
+// If the browser supports switching themes, update the theme based on the browser setting
+if (window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+        loadTheme();
+    });
+}

--- a/website/themes/icpctools/layouts/_default/baseof.html
+++ b/website/themes/icpctools/layouts/_default/baseof.html
@@ -10,6 +10,11 @@
     <link rel="stylesheet" href="/plugins/fontawesome-free/css/all.min.css">
     <link rel="stylesheet" href="/css/adminlte.min.css">
     <link rel="stylesheet" href="/css/icpctools.css">
+    
+    <script src="/plugins/jquery/jquery.min.js"></script>
+    <script src="/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="/js/adminlte.min.js"></script>
+    <script src="/js/theme.js"></script>
 
     {{ hugo.Generator }}
 
@@ -32,7 +37,7 @@
                 <div class="container-fluid">
                     <div class="row mb-2">
                         <div class="col-md-12">
-                            <h1 class="m-0 text-dark">{{ .Params.Title }}</h1>
+                            <h1 class="m-0">{{ .Params.Title }}</h1>
                         </div>
                     </div>
                 </div>
@@ -50,9 +55,5 @@
     </div>
 
     {{ partial "footer.html" . }}
-
-    <script src="/plugins/jquery/jquery.min.js"></script>
-    <script src="/plugins/bootstrap/js/bootstrap.bundle.min.js"></script>
-    <script src="/js/adminlte.min.js"></script>
 </body>
 </html>

--- a/website/themes/icpctools/static/js/theme.js
+++ b/website/themes/icpctools/static/js/theme.js
@@ -1,0 +1,21 @@
+function loadTheme() {
+    var theme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light';
+    if (theme === 'dark') {
+        $('body').addClass('dark-mode');
+        $('nav.main-header').addClass('navbar-dark').removeClass('navbar-white navbar-light');
+    } else {
+        $('body').removeClass('dark-mode');
+        $('nav.main-header').removeClass('navbar-dark').addClass('navbar-white navbar-light');
+    }
+}
+
+$(function() {
+    loadTheme();
+});
+
+// If the browser supports switching themes, update the theme based on the browser setting
+if (window.matchMedia) {
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', function() {
+        loadTheme();
+    });
+}


### PR DESCRIPTION
Since @meisterT likes screenshots:
<img width="407" alt="Screen Shot 2021-03-22 at 19 45 25" src="https://user-images.githubusercontent.com/550145/112042164-7f52be00-8b47-11eb-8c7a-bfd463c7694a.png">
<img width="1794" alt="Screen Shot 2021-03-22 at 19 45 38" src="https://user-images.githubusercontent.com/550145/112042167-8083eb00-8b47-11eb-8d1e-84ec47f335cc.png">
<img width="1539" alt="Screen Shot 2021-03-22 at 19 45 47" src="https://user-images.githubusercontent.com/550145/112042171-811c8180-8b47-11eb-8a18-c8eb1e943f54.png">

I also updated the website to have a dark layout, but there you can not switch; it will use the browser setting ([if your browser supports it](https://caniuse.com/?search=prefers-color-scheme)).

On the CDS it uses the browser based setting as default, but you can change it if you want. It will store it in the local settings, meaning it will persist for the current host indefinitely (unless you clear your local storage).

At first I had the theme menu as a submenu of the user menu, but that was not very logical I think. And we have more than enough space.