### PR TITLE
Inline table refresh

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
@@ -18,6 +18,7 @@
 				    <div class="card-header">
 				        <h4 class="card-title">Clarifications</h4>
 				        <div class="card-tools">
+				            <button id="clarifications-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
 				            <span id="clarifications-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
 				            <button id="clarifications-api" type="button" class="btn btn-tool">API</button>
 				        </div>
@@ -55,12 +56,17 @@
 <script type="text/javascript">
 registerContestObjectTable("clarifications");
 
-$(document).ready(function () {
-    $.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {
-        fillContestObjectTable("clarifications", contest.getClarifications())
+function clarificationsRefresh() {
+	contest.clear();
+	$.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {
+        fillContestObjectTable("clarifications", contest.getClarifications());
     }).fail(function (result) {
     	console.log("Error loading clarifications: " + result);
     })
+}
+
+$(document).ready(function () {
+	clarificationsRefresh();
 })
 
 function submitClarification(to_team, text) {

--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -18,6 +18,7 @@
 				    <div class="card-header">
 				        <h4 class="card-title">Clarifications</h4>
 				        <div class="card-tools">
+				        	<button id="clarifications-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
 				            <span id="clarifications-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
 				        </div>
 				    </div>
@@ -51,12 +52,17 @@
 <script type="text/javascript">
 registerContestObjectTable("clarifications");
 
-$(document).ready(function () {
-    $.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {
-        fillContestObjectTable("clarifications", contest.getClarifications())
+function clarificationsRefresh() {
+	contest.clear();
+	$.when(contest.loadClarifications(), contest.loadTeams(), contest.loadProblems()).done(function () {
+        fillContestObjectTable("clarifications", contest.getClarifications());
     }).fail(function (result) {
     	console.log("Error loading clarifications: " + result);
     })
+}
+
+$(document).ready(function () {
+	clarificationsRefresh();
 })
     
 function submitClarification(to_team, text) {

--- a/CDS/WebContent/WEB-INF/jsps/submissions-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions-admin.jsp
@@ -8,6 +8,7 @@
                 <div class="card-header">
                     <h3 class="card-title">Judge Queue</h3>
                     <div class="card-tools">
+                       <button id="queue-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
                        <span id="queue-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
                     </div>
                 </div>
@@ -33,6 +34,7 @@
                 <div class="card-header">
                     <h3 class="card-title">Submissions</h3>
                     <div class="card-tools">
+                       <button id="submissions-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
                        <span id="submissions-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
                        <button id="submissions-api" type="button" class="btn btn-tool">API</button>
                     </div>
@@ -86,7 +88,12 @@ contest.setContestURL("/api","<%= cc.getId() %>");
 registerContestObjectTable("queue");
 registerContestObjectTable("submissions");
 
-$(document).ready(function () {
+function queueRefresh() {
+	submissionsRefresh();
+}
+
+function submissionsRefresh() {
+	contest.clear();
 	$.when(contest.loadLanguages(), contest.loadOrganizations(), contest.loadTeams(), contest.loadProblems(), contest.loadSubmissions(), contest.loadJudgements(), contest.loadJudgementTypes()).done(function () {
     	var queue = [];
     	submissions = contest.getSubmissions();
@@ -107,6 +114,10 @@ $(document).ready(function () {
     }).fail(function (result) {
     	console.log("Error loading submissions: " + result);
     });
+}
+
+$(document).ready(function () {
+	submissionsRefresh();
 });
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/submissions.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions.jsp
@@ -8,6 +8,7 @@
                 <div class="card-header">
                     <h3 class="card-title">Judge Queue</h3>
                     <div class="card-tools">
+                       <button id="queue-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
                        <span id="queue-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
                     </div>
                 </div>
@@ -32,6 +33,7 @@
                 <div class="card-header">
                     <h3 class="card-title">Submissions</h3>
                     <div class="card-tools">
+                   	   <button id="submissions-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
                        <span id="submissions-count" data-toggle="tooltip" title="?" class="badge bg-primary">?</span>
                     </div>
                 </div>
@@ -81,7 +83,12 @@ contest.setContestURL("/api","<%= cc.getId() %>");
 registerContestObjectTable("queue");
 registerContestObjectTable("submissions");
 
-$(document).ready(function () {
+function queueRefresh() {
+	submissionsRefresh();
+}
+
+function submissionsRefresh() {
+	contest.clear();
 	$.when(contest.loadLanguages(), contest.loadOrganizations(), contest.loadTeams(), contest.loadProblems(), contest.loadSubmissions(), contest.loadJudgements(), contest.loadJudgementTypes()).done(function () {
     	var queue = [];
     	submissions = contest.getSubmissions();
@@ -102,6 +109,10 @@ $(document).ready(function () {
     }).fail(function (result) {
     	console.log("Error loading submissions: " + result);
     });
+}
+
+$(document).ready(function () {
+	submissionsRefresh();
 });
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -206,6 +206,10 @@ var contest=(function() {
 	}
 	var clear = function() {
 		startStatus = null;
+		problems = null;
+		submissions = null;
+		judgements = null;
+		clarifications = null;
 	}
 
     var post = function(type, body, ok, fail) {

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -23,6 +23,17 @@ function sortByColumn(table) {
   }
 }
 
+function refreshTable(name) {
+	console.log("Refreshing: " + name);
+	
+	// add spinner to the table (will be removed by table update) and call the refresh function
+	var table = $("#" + name + "-table");
+	table.parent().parent().append('<div id="' + 'temp" class="overlay"><i class="fas fa-2x fa-sync-alt fa-spin"></i></div>');
+	
+	var refreshFunc = new Function(name + 'Refresh()');
+	refreshFunc();
+}
+
 function registerContestObjectTable(name) {
 	if (name == null)
 		return;
@@ -36,11 +47,15 @@ function registerContestObjectTable(name) {
 	    row.append(col);
 	    $(table).append(row);
 	}
-    
+
     var x = $("#" + name + "-api");
     if (x != null)
     	x.attr("onclick", 'location.href="' + contest.getURL(name) + '"');
-    
+    	
+	var x = $("#" + name + "-refresh");
+    if (x != null)
+    	x.attr("onclick", 'refreshTable("' + name + '")');
+
     sortByColumn($('#' + name + "-table"));
 }
 
@@ -110,6 +125,8 @@ function fillContestObjectTable(name, objs) {
     }
 
 	updateContestObjectHeader(name, objs);
+	
+	$("#temp").remove();
 }
 
 var tagsToReplace = {


### PR DESCRIPTION
Added refresh icons to submissions and clarifications tables. When you click the entire card is overlayed with a spinner until the refresh is complete (which is often too quick to see for clarifications, noticeable for submissions).