### PR TITLE
Minor UI tweaks and logo updates to registration page

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
@@ -30,7 +30,7 @@
 								<th>ICPC Id</th>
 								<th>Name</th>
 								<th>Type</th>
-								<th>Hidden</th>
+								<th class="text-center">Hidden</th>
 			            	</tr>
 			            </thead>
 			            <tbody></tbody>
@@ -85,10 +85,10 @@
 			        <table id="teams-table" class="table table-sm table-hover table-striped table-head-fixed">
 			            <thead>
 			                <tr>
-			                    <th>Id</th>
+			                    <th class="text-center">Id</th>
+			                    <th></th>
 			                    <th>Name</th>
-			                    <th colspan=2>Organization</th>
-			                    <th>Organization (formal name)</th>
+			                    <th>Organization</th>
 			                    <th>Group</th>
 			                    <th>Summary</th>
 			                </tr>
@@ -106,21 +106,20 @@
   <td>{{icpc_id}}</td>
   <td>{{name}}</td>
   <td>{{type}}</td>
-  <td align=center>{{#hidden}}<span class="badge badge-info"><i class="fas fa-eye-slash"></i></a>{{/hidden}}</td>
+  <td class="text-center">{{#hidden}}<span class="badge badge-info"><i class="fas fa-eye-slash"></i></a>{{/hidden}}</td>
 </script>
 <script type="text/html" id="organizations-template">
   <td><a href="{{api}}">{{id}}</a></td>
-  <td style="width: 20px;" align=middle>{{{logo}}}</td>
+  <td style="width: 20px;" class="text-center">{{#logo}}<img src="{{{logo}}}" width="20" height="20"/>{{/logo}}</td>
   <td>{{name}}</td>
   <td>{{formalName}}</td>
   <td>{{#country}}<img src="/countries/{{country}}.png" height=18/> {{country}}{{/country}}</td>
 </script>
 <script type="text/html" id="teams-template">
-  <td><a href="{{api}}">{{id}}</a></td>
+  <td class="text-right"><a href="{{api}}">{{id}}</a></td>
+  <td style="width: 20px;" class="text-center">{{#logo}}<img src="{{{logo}}}" width="20" height="20"/>{{/logo}}</td>
   <td>{{name}}</td>
-  <td style="width: 20px;" align=middle>{{{logo}}}</td>
-  <td>{{orgName}}</td>
-  <td>{{orgFormalName}}</td>
+  <td>{{orgName}}x</td>
   <td>{{groupNames}}</td>
   <td><a href="<%= webroot  %>/teamSummary/{{id}}">summary</a></td>
 </script>

--- a/CDS/WebContent/WEB-INF/jsps/registration.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration.jsp
@@ -25,7 +25,8 @@
 			        <table id="teams-table" class="table table-sm table-hover table-striped table-head-fixed">
 			            <thead>
 			                <tr>
-			                    <th colspan=2>#</th>
+			                    <th class="text-center">#</th>
+			                    <th></th>
 			                    <th>Name</th>
 			                    <th>Organization</th>
 			                    <th>Group</th>
@@ -84,21 +85,18 @@
     </div>
 </div>
 <script type="text/html" id="teams-template">
-  <td>{{id}}</td>
-  <td style="width: 20px;" align=center>{{{logo}}}</td>
+  <td class="text-right">{{id}}</td>
+  <td style="width: 20px;" class="text-center">{{#logo}}<img src="{{{logo}}}" width="20" height="20"/>{{/logo}}</td>
   <td>{{name}}</td>
   <td>{{orgName}}</td>
   <td>{{groupNames}}</td>
-</script>
-<script type="text/html" id="groups-th-template">
-  <th>Name</th>
 </script>
 <script type="text/html" id="groups-template">
   <td>{{name}}</td>
 </script>
 <script type="text/html" id="organizations-template">
-  <td style="width: 20px;" align=middle>{{{logo}}}</td>
-  <td>{{formalName}}</td>
+  <td style="width: 20px;" class="text-center">{{#logo}}<img src="{{{logo}}}" width="20" height="20"/>{{/logo}}</td>
+  <td>{{#formalName}}{{formalName}} ({{name}}){{/formalName}}{{^formalName}}{{name}}{{/formalName}}</td>
   <td>{{#country}}<img src="/countries/{{country}}.png" height=18/> {{country}}{{/country}}</td>
 </script>
 <script type="text/javascript">

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -74,8 +74,6 @@ function organizationsTd(org) {
     var logo2 = bestSquareLogo(org.logo, 20);
     if (logo2 != null)
         logoSrc = '/api/' + logo2.href;
-    if (logoSrc != null)
-    	logoSrc = '<img src="' + logoSrc + '" width="20" height="20"/>';
 
     return { name: org.name, formalName: org.formal_name, country: org.country, logo: logoSrc };
 }
@@ -89,14 +87,10 @@ function teamsTd(team) {
     var orgFormalName = '';
     var logoSrc = '';
     if (org != null) {
-        orgName = org.name;
-        if (org.formal_name != null)
-            orgFormalName = org.formal_name;
+        orgName = getOrganizationName(org);
         var logo = bestSquareLogo(org.logo, 20);
         if (logo != null)
             logoSrc = '/api/' + logo.href;
-        if (logoSrc != null)
-    		logoSrc = '<img src="' + logoSrc + '" width="20" height="20"/>';
     }
     var groupNames = '';
     var groups2 = findManyById(contest.getGroups(), team.group_ids);
@@ -110,8 +104,7 @@ function teamsTd(team) {
         }
     }
 
-    return { name: name, logo: logoSrc, orgName: orgName, orgFormalName: orgFormalName,
-    	groupNames: groupNames };
+    return { name: name, logo: logoSrc, orgName: orgName, groupNames: groupNames };
 }
 
 function queueTd(submission) {

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -28,7 +28,7 @@ function refreshTable(name) {
 	
 	// add spinner to the table (will be removed by table update) and call the refresh function
 	var table = $("#" + name + "-table");
-	table.parent().parent().append('<div id="' + 'temp" class="overlay"><i class="fas fa-2x fa-sync-alt fa-spin"></i></div>');
+	table.parent().parent().append('<div id="' + 'temp" class="overlay dark"><i class="fas fa-2x fa-sync-alt fa-spin"></i></div>');
 	
 	var refreshFunc = new Function(name + 'Refresh()');
 	refreshFunc();
@@ -51,7 +51,7 @@ function registerContestObjectTable(name) {
     var x = $("#" + name + "-api");
     if (x != null)
     	x.attr("onclick", 'location.href="' + contest.getURL(name) + '"');
-    	
+
 	var x = $("#" + name + "-refresh");
     if (x != null)
     	x.attr("onclick", 'refreshTable("' + name + '")');
@@ -191,6 +191,13 @@ function getDisplayName(team) {
 		return team.display_name;
 
 	return team.name;
+}
+
+function getOrganizationName(org) {
+	if (org.formal_name != null)
+		return org.formal_name;
+
+	return org.name;
 }
 
 function getDisplayStr(teamId) {


### PR DESCRIPTION
- Move <img> out of types and into template and make sure it looks ok when there are no logos.
- Only show one org column in teams table, not both org name and formal name.
- Minor alignment and UI fixes.
- Switch to dark overlay when reloading. Looks much better in dark mode, and only slightly worse in light mode.