### PR TITLE
Fix "solved zzz problems" award.

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/TeamAwardPresentation.java
+++ b/Resolver/src/org/icpc/tools/resolver/TeamAwardPresentation.java
@@ -425,9 +425,9 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			ITeam team = contest.getTeamById(currentCache.teamId);
 			IStanding s = contest.getStanding(team);
 			if (s.getNumSolved() == 1)
-				list.add(new Award(IAward.OTHER, 0, currentCache.teamId, Messages.getString("awardSolvedOne"), false));
+				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId, Messages.getString("awardSolvedOne"), false));
 			else if (s.getNumSolved() > 1)
-				list.add(new Award(IAward.OTHER, 0, currentCache.teamId,
+				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId,
 						Messages.getString("awardSolvedMultiple").replace("{0}", s.getNumSolved() + ""), false));
 		}
 


### PR DESCRIPTION
If teams had a medal but no solution award, we show how many problems they solved.
However, we used the same award ID for all, meaning that if some teams solved X and some solved Y, it would show as X for all teams.

@deboer-tim I do wonder if we need to rename OTHER to SOLVED (and use a sovled-.* regex) to make sure it's unique if we add other awards at some point?