### PR TITLE
Add contest time to web pages

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
@@ -77,5 +77,7 @@ function submitClarification(to_team, text) {
 		$('#object-status').text("Post failed: " + result.responseText);
 	})
 }
+
+updateContestClock(contest, "contest-time");
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -73,4 +73,6 @@ function submitClarification(to_team, text) {
 		$('#object-status').text("Post failed: " + result.responseText);
 	})
 }
+
+updateContestClock(contest, "contest-time");
 </script>

--- a/CDS/WebContent/WEB-INF/jsps/details-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details-admin.jsp
@@ -69,5 +69,6 @@ contest = new Contest("/api", "<%= cc.getId() %>");
         	console.log("Error loading runs: " + result);
         })
     })
+    updateContestClock(contest, "contest-time");
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/details.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details.jsp
@@ -9,6 +9,7 @@
 <script src="${pageContext.request.contextPath}/js/mustache.min.js"></script>
 <script type="text/javascript">
 contest = new Contest("/api", "<%= cc.getId() %>");
+updateContestClock(contest, "contest-time");
 </script>
 <div class="container-fluid">
     <div class="row">

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -219,6 +219,9 @@
                    contestName = contest.getName() + " "; %>
               <h1 class="m-0"><%= HttpHelper.sanitizeHTML(contestName) %><%= request.getAttribute("title") %></h1>
             </div><!-- /.col -->
+            <div class="col-sm-2">
+            	<div id="contest-time" class="text-right"></div>
+            </div>
           </div><!-- /.row -->
         </div><!-- /.container-fluid -->
       </div>

--- a/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
@@ -136,5 +136,7 @@ $(document).ready(function () {
     	console.log("Error loading teams: " + result);
     })
 })
+
+updateContestClock(contest, "contest-time");
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/registration.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration.jsp
@@ -112,5 +112,7 @@ $(document).ready(function () {
     	console.log("Error loading teams: " + result);
     })
 })
+
+updateContestClock(contest, "contest-time");
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -146,6 +146,8 @@ $(document).ready(function () {
     }).fail(function (result) {
     	console.log("Error loading scoreboard: " + result);
     })
+    
+    updateContestClock(contest, "contest-time");
 })
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/submissions-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions-admin.jsp
@@ -119,5 +119,7 @@ function submissionsRefresh() {
 $(document).ready(function () {
 	submissionsRefresh();
 });
+
+updateContestClock(contest, "contest-time");
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/submissions.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions.jsp
@@ -114,5 +114,7 @@ function submissionsRefresh() {
 $(document).ready(function () {
 	submissionsRefresh();
 });
+
+updateContestClock(contest, "contest-time");
 </script>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -23,6 +23,11 @@ function sortByColumn(table) {
   }
 }
 
+function toHtml(templateName, obj) {
+  var template = $('#' + templateName).html();
+  return Mustache.render(template, obj);
+}
+
 function refreshTable(name) {
 	console.log("Refreshing: " + name);
 	
@@ -68,11 +73,6 @@ function updateContestObjectHeader(name, objs) {
     	x.attr("title", objs.length);
     	x.html(objs.length);
     }
-}
-
-function toHtml(templateName, obj) {
-  var template = $('#' + templateName).html();
-  return Mustache.render(template, obj);
 }
 
 function fillContestObjectTable(name, objs) {
@@ -179,6 +179,40 @@ function formatTime(time2) {
 	return sb.join("");
 }
 
+function formatContestTime(time) {
+	if (time == null)
+		return "";
+
+	if (time >= 0 && time < 1000)
+		return "0";
+
+	var sb = [];
+	if (time < 0) {
+		sb.push("-");
+		time = -time;
+	}
+	time2 = Math.floor(time / 1000);
+
+	days = Math.floor(time2 / 86400.0);
+	if (days > 0)
+		sb.push(days + "d ");
+
+	sb.push(Math.floor(time2 / 3600.0) % 24);
+
+	sb.push(':');
+	mins = Math.floor(time2 / 60.0) % 60;
+	if (mins < 10)
+		sb.push('0');
+	sb.push(mins);
+
+	sb.push(':');
+	secs = time2 % 60;
+	if (secs < 10)
+		sb.push('0');
+	sb.push(secs);
+	return sb.join("");
+}
+
 function formatTimestamp(time2) {
 	if (time2 == null)
 		return "";
@@ -209,4 +243,8 @@ function getDisplayStr(teamId) {
 		return teamId + ': ' + getDisplayName(team);
 	
 	return teamId + ': (not found)';
+}
+
+function updateContestClock(contest, id) {
+    setInterval(() => { $("#" + id).html(contest.getContestTime()) }, 300);
 }

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -421,6 +421,7 @@ public class ContestRESTService extends HttpServlet {
 		request.setCharacterEncoding("UTF-8");
 		response.setCharacterEncoding("UTF-8");
 		response.setHeader("ICPC-Tools", "CDS");
+		response.setHeader("ICPC-Time", System.currentTimeMillis() + "");
 
 		String method = request.getMethod();
 		if (method.equals("PATCH"))


### PR DESCRIPTION
This change adds the current contest time to the top right of all the main screens: details, registration, submissions, clarifications, and scoreboard.
- The round trip time of every contest http call is halved, compared against the server's current time in the response, and the last 3 of these are kept as an average to determine the client time offset.
- The server's time comparison uses a CDS-specific 'ICPC-Time' header (ms accuracy), or falls back to the standard Date header (~second accuracy).
- The text handles when the start time is not scheduled, countdown is in progress or paused, normal contest time, and contest over.
- The CDS time multiplier is supported to show the correct clock when playing back contests at higher speeds.
- The one thing that is *not* handled yet are server-side changes like stopping the countdown.