### PR TITLE
Add entry_point_* and extensions fields to language.

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/details-admin/languages.html
+++ b/CDS/WebContent/WEB-INF/jsps/details-admin/languages.html
@@ -13,7 +13,9 @@
             <thead>
                 <tr>
                     <th>Id</th>
-                    <th width=90%>Name</th>
+                    <th>Name</th>
+                    <th>Entry point</th>
+                    <th>Extensions</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -25,6 +27,13 @@
 <script type="text/html" id="languages-template">
   <td><a href="{{api}}">{{id}}</a></td>
   <td>{{name}}</td>
+  <td>
+    {{#entry_point_required}}<span class="badge badge-success"><i class="fas fa-check"></i></span> {{entry_point_name}}{{/entry_point_required}}
+    {{^entry_point_required}}<span class="badge badge-danger"><i class="fas fa-times"></i></span>{{/entry_point_required}}
+  </td>
+  <td>
+    {{extensions}}
+  </td>
 </script>
 <script type="text/javascript">
 registerContestObjectTable("languages");

--- a/CDS/WebContent/WEB-INF/jsps/details/judgementTypes.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/judgementTypes.html
@@ -23,8 +23,8 @@
 <script type="text/html" id="judgement-types-template">
   <td align=center><span class="badge {{badge}}">{{id}}</span></td>
   <td width=90%>{{name}}</td>
-  <td align=center>{{#penalty}}<span class="badge badge-danger"><i class="fas fa-times"></i></a>{{/penalty}}</td>
-  <td align=center>{{#solved}}<span class="badge badge-success"><i class="fas fa-check"></i></a>{{/solved}}</td>
+  <td align=center>{{#penalty}}<span class="badge badge-danger"><i class="fas fa-times"></i></span>{{/penalty}}</td>
+  <td align=center>{{#solved}}<span class="badge badge-success"><i class="fas fa-check"></i></span>{{/solved}}</td>
 </script>
 <script type="text/javascript">
 registerContestObjectTable("judgement-types");

--- a/CDS/WebContent/WEB-INF/jsps/details/languages.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/languages.html
@@ -11,6 +11,8 @@
             <thead>
                 <tr>
                     <th>Name</th>
+                    <th>Entry point</th>
+                    <th>Extensions</th>
                 </tr>
             </thead>
             <tbody></tbody>
@@ -20,6 +22,13 @@
 </div>
 <script type="text/html" id="languages-template">
   <td>{{name}}</td>
+  <td>
+    {{#entry_point_required}}<span class="badge badge-success"><i class="fas fa-check"></i></span> {{entry_point_name}}{{/entry_point_required}}
+    {{^entry_point_required}}<span class="badge badge-danger"><i class="fas fa-times"></i></span>{{/entry_point_required}}
+  </td>
+  <td>
+    {{extensions}}
+  </td>
 </script>
 <script type="text/javascript">
 registerContestObjectTable("languages");

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -46,7 +46,7 @@ function addColors(obj, rgb) {
 }
 
 function languagesTd(lang) {
-    return { name: lang.name };
+    return { name: lang.name, entry_point_required: lang.entry_point_required, entry_point_name: lang.entry_point_name, extensions: lang.extensions.join(', ') };
 }
 
 function judgementtypesTd(jt) {

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -30,6 +30,7 @@ import org.icpc.tools.contest.model.IContestObject.ContestType;
 import org.icpc.tools.contest.model.IContestObjectFilter;
 import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IInfo;
+import org.icpc.tools.contest.model.ILanguage;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.Scoreboard;
@@ -702,6 +703,7 @@ public class ContestRESTService extends HttpServlet {
 		String teamId = obj.getString("team_id");
 		String problemId = obj.getString("problem_id");
 		String languageId = obj.getString("language_id");
+		String entryPoint = obj.getString("entry_point");
 
 		Contest contest = cc.getContestByRole(request);
 		if (teamId != null && contest.getTeamById(teamId) == null) {
@@ -711,6 +713,12 @@ public class ContestRESTService extends HttpServlet {
 
 		if (languageId == null || contest.getLanguageById(languageId) == null) {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Unknown language");
+			return;
+		}
+
+		ILanguage language = contest.getLanguageById(languageId);
+		if (language.getEntryPointRequired() && entryPoint == null) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, language.getEntryPointName() + " required for " + language.getName());
 			return;
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/ILanguage.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ILanguage.java
@@ -10,4 +10,25 @@ public interface ILanguage extends IContestObject {
 	 * @return the name
 	 */
 	String getName();
+
+	/**
+	 * Returns whether this language requires an entrypoint.
+	 *
+	 * @return whether an entry point is required
+	 */
+	boolean getEntryPointRequired();
+
+	/**
+	 * Returns the entry point name for this language, if any.
+	 *
+	 * @return the entry point or null
+	 */
+	String getEntryPointName();
+
+	/**
+	 * Returns the extensions for this language
+	 *
+	 * @return the extensions
+	 */
+	String[] getExtensions();
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Language.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Language.java
@@ -6,11 +6,18 @@ import java.util.Map;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.ILanguage;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
+import org.icpc.tools.contest.model.feed.JSONParser;
 
 public class Language extends ContestObject implements ILanguage {
 	private static final String NAME = "name";
+	private static final String ENTRY_POINT_REQUIRED = "entry_point_required";
+	private static final String ENTRY_POINT_NAME = "entry_point_name";
+	private static final String EXTENSIONS = "extensions";
 
 	private String name;
+	private boolean entryPointRequired;
+	private String entryPointName;
+	private String[] extensions;
 
 	@Override
 	public ContestType getType() {
@@ -23,10 +30,38 @@ public class Language extends ContestObject implements ILanguage {
 	}
 
 	@Override
+	public boolean getEntryPointRequired() {
+		return entryPointRequired;
+	}
+
+	@Override
+	public String getEntryPointName() {
+		return entryPointRequired ? entryPointName : null;
+	}
+
+	@Override
+	public String[] getExtensions() {
+		return extensions;
+	}
+
+	@Override
 	protected boolean addImpl(String name2, Object value) throws Exception {
-		if (NAME.equals(name2)) {
-			name = (String) value;
-			return true;
+		switch (name2) {
+			case NAME:
+				name = (String) value;
+				return true;
+			case ENTRY_POINT_REQUIRED:
+				entryPointRequired = parseBoolean(value);
+				return true;
+			case ENTRY_POINT_NAME:
+				entryPointName = (String) value;
+				return true;
+			case EXTENSIONS:
+				Object[] ob = JSONParser.getOrReadArray(value);
+				extensions = new String[ob.length];
+				for (int i = 0; i < ob.length; i++)
+					extensions[i] = (String) ob[i];
+				return true;
 		}
 
 		return false;
@@ -36,12 +71,30 @@ public class Language extends ContestObject implements ILanguage {
 	protected void getPropertiesImpl(Map<String, Object> props) {
 		super.getPropertiesImpl(props);
 		props.put(NAME, name);
+		props.put(ENTRY_POINT_REQUIRED, entryPointRequired);
+		if (entryPointName != null) {
+			props.put(ENTRY_POINT_NAME, entryPointName);
+		}
+		if (extensions != null) {
+			if (extensions.length == 0)
+				props.put(EXTENSIONS, "[]");
+			else
+				props.put(EXTENSIONS, "[\"" + String.join("\",\"", extensions) + "\"]");
+		}
 	}
 
 	@Override
 	public void writeBody(JSONEncoder je) {
 		je.encode(ID, id);
 		je.encode(NAME, name);
+		je.encode(ENTRY_POINT_REQUIRED, entryPointRequired);
+		je.encode(ENTRY_POINT_NAME, entryPointName);
+		if (extensions != null) {
+			if (extensions.length == 0)
+				je.encodePrimitive(EXTENSIONS, "[]");
+			else
+				je.encodePrimitive(EXTENSIONS, "[\"" + String.join("\",\"", extensions) + "\"]");
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Tested with a recent DOMjudge commit that contains this feature.

Screenshots:
<img width="656" alt="image" src="https://user-images.githubusercontent.com/550145/113424450-76c47800-93d0-11eb-8705-5710c5d6a2a0.png">
<img width="632" alt="image" src="https://user-images.githubusercontent.com/550145/113424468-7f1cb300-93d0-11eb-9284-03bbe33c76a4.png">
