### PR TITLE
setStatus() when not modified

### DIFF
--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationFilesServlet.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationFilesServlet.java
@@ -47,7 +47,7 @@ public class PresentationFilesServlet extends HttpServlet {
 		try {
 			long ifModifiedSince = request.getDateHeader("If-Modified-Since");
 			if (ifModifiedSince != -1 && ifModifiedSince >= lastModified) {
-				response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+				response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 				return;
 			}
 		} catch (Exception e) {

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -196,6 +196,9 @@ public class ContestWebService extends HttpServlet {
 			} else if (segments[1].equals("scoreboard")) {
 				request.getRequestDispatcher("/WEB-INF/jsps/scoreboard.jsp").forward(request, response);
 				return;
+			} else if (segments[1].equals("commentary")) {
+				request.getRequestDispatcher("/WEB-INF/jsps/commentary.jsp").forward(request, response);
+				return;
 			} else if (segments[1].equals("contestCompare")) {
 				try {
 					Contest contestA = cc.getContestByRole(request);

--- a/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
+++ b/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
@@ -39,7 +39,7 @@ public class HttpHelper {
 		try {
 			long ifModifiedSince = request.getDateHeader("If-Modified-Since");
 			if (ifModifiedSince != -1 && ifModifiedSince >= lastModified) {
-				response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+				response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 				return;
 			}
 		} catch (Exception e) {
@@ -54,7 +54,7 @@ public class HttpHelper {
 				while (ifNoneMatch.hasMoreElements()) {
 					String val = ifNoneMatch.nextElement();
 					if (current.equals(val)) {
-						response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+						response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 						return;
 					}
 				}
@@ -87,6 +87,7 @@ public class HttpHelper {
 		}
 
 		bin.close();
+		out.flush();
 	}
 
 	/**

--- a/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
+++ b/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
@@ -264,7 +264,7 @@ public class ReactionVideoRecorder {
 			try {
 				long ifModifiedSince = request.getDateHeader("If-Modified-Since");
 				if (ifModifiedSince != -1 && ifModifiedSince >= lastModified) {
-					response.sendError(HttpServletResponse.SC_NOT_MODIFIED);
+					response.setStatus(HttpServletResponse.SC_NOT_MODIFIED);
 					return;
 				}
 			} catch (Exception e) {


### PR DESCRIPTION
I noticed that Safari wasn't always loading org images. In the Web Inspector is looks like it's never getting a response, but on the server side you can see a setError(SC_NOT_MODIFIED) getting sent back. I didn't hook up a proxy to confirm, but this incorrectly includes the error page response in the body (like a 404) and I think that's what's messing up Safari. With this fix I've run several times and Safari is loading images correctly.