### PR TITLE
Initial Commentary presentation

### DIFF
--- a/PresContest/src/META-INF/presentations.xml
+++ b/PresContest/src/META-INF/presentations.xml
@@ -124,6 +124,12 @@
       description="Slides the logos of all organizations"
       image="images/presentations/logos.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.OrgLogoSlidePresentation"/>
+   <presentation
+      id="org.icpc.tools.presentation.contest.commentary"
+      name="Commentary"
+      category="ICPC"
+      description="Displays contest commentary."
+      class="org.icpc.tools.presentation.contest.internal.presentations.CommentaryPresentation"/>
 
    <!-- Fun -->
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/nls/Messages.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/nls/Messages.java
@@ -29,6 +29,7 @@ public class Messages {
 	public static String titleLeaderboard;
 	public static String titleGroupLeaderboard;
 	public static String titleGroupLeaderboardSubs;
+	public static String titleCommentary;
 
 	static {
 		NLS.initMessages(Messages.class);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/nls/Messages.properties
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/nls/Messages.properties
@@ -24,3 +24,4 @@ titleJudgeQueue=Judge Queue
 titleLeaderboard=Current Medal Contenders
 titleGroupLeaderboard=Leaders
 titleGroupLeaderboardSubs={0} Leaders
+titleCommentary=Commentary

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/CommentaryPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/CommentaryPresentation.java
@@ -1,0 +1,249 @@
+package org.icpc.tools.presentation.contest.internal.presentations;
+
+import java.awt.AlphaComposite;
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.icpc.tools.contest.model.ICommentary;
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IContestListener;
+import org.icpc.tools.presentation.contest.internal.Animator;
+import org.icpc.tools.presentation.contest.internal.Animator.Movement;
+import org.icpc.tools.presentation.contest.internal.ICPCFont;
+import org.icpc.tools.presentation.contest.internal.nls.Messages;
+
+/**
+ * Shows incoming commentary.
+ */
+public class CommentaryPresentation extends TitledPresentation {
+	private static final long TIME_TO_KEEP_SOLVED = 11000;
+	private static final long TIME_TO_KEEP_FAILED = 8000;
+	private static final long TIME_TO_KEEP_RECENT = 14000;
+	private static final long TIME_TO_FADE_RECENT = 2000;
+	private static final long LINES_PER_SCREEN = 20;
+
+	private static final Movement COMMENTARY_MOVEMENT = new Movement(5, 9);
+
+	enum Action {
+		MOVE_UP, MOVE_DOWN, MOVE_OUT
+	}
+
+	protected class RecentCommentary {
+		public ICommentary commentary;
+		protected BufferedImage img;
+		protected Animator anim;
+		protected long fullAge;
+		protected long actionAge;
+
+		protected Action action;
+
+		@Override
+		public String toString() {
+			return "Commentary: " + commentary.getId();
+		}
+	}
+
+	protected List<RecentCommentary> comments = new ArrayList<>();
+	protected long timeToKeepFailed = TIME_TO_KEEP_FAILED;
+	protected long timeToKeepSolved = TIME_TO_KEEP_SOLVED;
+	protected Font titleFont;
+	protected Font textFont;
+
+	protected IContestListener listener = (contest, obj, d) -> {
+		if (obj instanceof ICommentary)
+			handleCommentary((ICommentary) obj);
+	};
+
+	@Override
+	public void init() {
+		super.init();
+
+		getContest().addListener(listener);
+
+		final float dpi = 96;
+		float size = (int) (height * 72.0 * 0.028 / dpi);
+		titleFont = ICPCFont.getMasterFont().deriveFont(Font.BOLD, size * 2.2f);
+		textFont = ICPCFont.getMasterFont().deriveFont(Font.PLAIN, size * 1.25f);
+	}
+
+	@Override
+	public void dispose() {
+		super.dispose();
+
+		getContest().removeListener(listener);
+	}
+
+	@Override
+	public void aboutToShow() {
+		super.aboutToShow();
+
+		synchronized (comments) {
+			comments.clear();
+
+			IContest contest = getContest();
+			ICommentary[] comm2 = contest.getCommentary();
+			for (ICommentary commentary : comm2) {
+				handleCommentary(commentary);
+			}
+		}
+		updateTargets(true);
+	}
+
+	protected void handleCommentary(ICommentary commentary) {
+		// check for existing record first
+		synchronized (comments) {
+			for (RecentCommentary comm : comments) {
+				if (comm.commentary.getId().equals(commentary.getId())) {
+					comm.commentary = commentary;
+					return;
+				}
+			}
+			createRecentCommentary(commentary);
+		}
+	}
+
+	protected RecentCommentary createRecentCommentary(ICommentary commentary) {
+		synchronized (comments) {
+			RecentCommentary comm = new RecentCommentary();
+			comm.commentary = commentary;
+			double initalX = 0;
+			if (comments.size() > 0)
+				initalX = Math.min(comments.get(comments.size() - 1).anim.getValue() + 1, LINES_PER_SCREEN * 2);
+			comm.anim = new Animator(Math.max(initalX, LINES_PER_SCREEN + 2), COMMENTARY_MOVEMENT);
+
+			// create image
+			int h = (int) (height / LINES_PER_SCREEN);
+			comm.img = new BufferedImage(width, h, BufferedImage.TYPE_INT_ARGB);
+			Graphics2D g = comm.img.createGraphics();
+			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+
+			g.setColor(Color.WHITE);
+			g.setFont(textFont);
+			g.drawString(commentary.getMessage(), 0, h - 4);
+
+			g.dispose();
+
+			comments.add(comm);
+
+			updateTargets(false);
+			return comm;
+		}
+	}
+
+	@Override
+	public void incrementTimeMs(long dt) {
+		updateRecords(dt);
+		updateTargets(false);
+		super.incrementTimeMs(dt);
+	}
+
+	@Override
+	protected String getTitle() {
+		return Messages.titleCommentary;
+	}
+
+	@Override
+	protected void paintImpl(Graphics2D g) {
+		RecentCommentary[] submissions2 = null;
+		synchronized (comments) {
+			submissions2 = comments.toArray(new RecentCommentary[0]);
+		}
+
+		g.setFont(textFont);
+		for (RecentCommentary comm : submissions2) {
+			double yy = comm.anim.getValue() * height / LINES_PER_SCREEN;
+			if (yy < height - headerHeight) {
+				Graphics2D g2 = (Graphics2D) g.create();
+				g2.translate(0, (int) yy);
+				if (comm.action == Action.MOVE_DOWN) {
+					float tr = (float) Math.min(1.0,
+							Math.max(0.1, 1.0 - (comm.actionAge - timeToKeepFailed * 0.75) * 2.0 / timeToKeepFailed));
+					g2.setComposite(AlphaComposite.SrcOver.derive(tr));
+				} else if (comm.action == Action.MOVE_OUT) {
+					float tr = (float) (1.0 - comm.actionAge / (double) TIME_TO_FADE_RECENT);
+					g2.setComposite(AlphaComposite.SrcOver.derive(tr));
+				}
+				paintCommentary(g2, comm);
+				g2.dispose();
+			}
+		}
+	}
+
+	protected void paintCommentary(Graphics2D g, RecentCommentary comm) {
+		g.drawImage(comm.img, 0, 0, null);
+	}
+
+	protected void updateTargets(boolean force) {
+		if (comments == null)
+			return;
+
+		int count = 0;
+		// IContest contest = getContest();
+		synchronized (comments) {
+			for (RecentCommentary comment : comments) {
+				double target = 0;
+				target = count;
+				if (comment.action == Action.MOVE_UP && (comment.actionAge > timeToKeepSolved))
+					target = -LINES_PER_SCREEN;
+				else if (comment.action == Action.MOVE_DOWN && comment.actionAge > timeToKeepFailed)
+					target = LINES_PER_SCREEN * 2;
+				else if (comment.action == Action.MOVE_OUT && comment.actionAge > TIME_TO_FADE_RECENT / 3) {
+					// don't move count
+				} else if (count < LINES_PER_SCREEN * 2)
+					count++;
+
+				if (force)
+					comment.anim.reset(target);
+				else
+					comment.anim.setTarget(target);
+			}
+		}
+	}
+
+	protected void updateRecords(long dt) {
+		List<RecentCommentary> remove = new ArrayList<>();
+
+		// IContest contest = getContest();
+		synchronized (comments) {
+			for (RecentCommentary comment : comments) {
+				comment.anim.incrementTimeMs(dt);
+				comment.fullAge += dt;
+
+				if (comment.action == null) {
+					if (comment.fullAge > TIME_TO_KEEP_RECENT)
+						comment.action = Action.MOVE_OUT;
+
+					/*if (contest.getState().isFrozen() && contest.getState().isRunning()) {
+						if (comment.fullAge > TIME_TO_KEEP_RECENT)
+							comment.action = Action.MOVE_OUT;
+					} else {
+						if (contest.isJudged(comment.commentary)) {
+							if (contest.isSolved(comment.commentary))
+								comment.action = Action.MOVE_UP;
+							else
+								comment.action = Action.MOVE_DOWN;
+						}
+					}*/
+				} else
+					comment.actionAge += dt;
+
+				if (comment.action == Action.MOVE_UP && comment.anim.getValue() < -1)
+					remove.add(comment);
+				else if (comment.action == Action.MOVE_DOWN && comment.anim.getValue() > LINES_PER_SCREEN)
+					remove.add(comment);
+				else if (comment.action == Action.MOVE_OUT && comment.actionAge > TIME_TO_FADE_RECENT)
+					remove.add(comment);
+			}
+
+			for (RecentCommentary s : remove)
+				comments.remove(s);
+		}
+	}
+}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TitledPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TitledPresentation.java
@@ -1,0 +1,172 @@
+package org.icpc.tools.presentation.contest.internal.presentations;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.Transparency;
+import java.awt.image.BufferedImage;
+
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
+import org.icpc.tools.presentation.contest.internal.ICPCColors;
+import org.icpc.tools.presentation.contest.internal.ICPCFont;
+
+/**
+ * Abstract presentation with a title area and contest time.
+ */
+public abstract class TitledPresentation extends AbstractICPCPresentation {
+	protected static final int TRANSITION_TIME = 2000;
+	protected static final int BORDER = 8;
+	protected static final int CLOCK_MARGIN = 2;
+
+	private Font titleFont;
+	private Font clockFont;
+
+	protected int titleHeight = 20;
+	protected int headerHeight = 20;
+	private BufferedImage headerImg;
+	private boolean showClock = true;
+
+	protected void setup() {
+		final float dpi = 96;
+		float size = (int) (height * 72.0 * 0.028 / dpi);
+		titleFont = ICPCFont.getMasterFont().deriveFont(Font.BOLD, size * 2.2f);
+		clockFont = ICPCFont.getMasterFont().deriveFont(Font.BOLD, size * 1.25f);
+
+		headerImg = createHeaderImage();
+	}
+
+	@Override
+	public void setSize(Dimension d) {
+		super.setSize(d);
+
+		headerImg = null;
+
+		if (d.width == 0 || d.height == 0)
+			return;
+
+		setup();
+	}
+
+	protected boolean isInStartTransition() {
+		if (getPreviousPresentation() != null && getRepeatTimeMs() < TRANSITION_TIME)
+			return true;
+		return false;
+	}
+
+	protected boolean isInEndTransition() {
+		if (getNextPresentation() != null && getRepeatTimeMs() > getRepeat() - TRANSITION_TIME)
+			return true;
+		return false;
+	}
+
+	protected boolean isInTransition() {
+		return isInStartTransition() || isInEndTransition();
+	}
+
+	/**
+	 * Helper method. Returns a number between 0 and 1 if the current time is between 0 and the
+	 * transition time respectively, and 1 and 0 if the time is between the transition and the
+	 * end/repeat time respectively.
+	 *
+	 * @return a number between 0 and 1
+	 */
+	protected double getTransitionTime() {
+		long repeat = getRepeat();
+		long repeatTimeMs = getRepeatTimeMs();
+		if (repeatTimeMs < TRANSITION_TIME)
+			return repeatTimeMs / (double) TRANSITION_TIME;
+		else if (repeatTimeMs > repeat - TRANSITION_TIME)
+			return (repeat - repeatTimeMs) / (double) TRANSITION_TIME;
+
+		return 1.0;
+	}
+
+	protected void paintHeader(Graphics2D g) {
+		int h = 0;
+		if (isInTransition())
+			h = (int) (getTransitionTime() * headerHeight) - headerHeight;
+		g.drawImage(headerImg, 0, h + titleHeight, null);
+
+		if (showClock) {
+			if (getContest().getState().isFrozen())
+				g.setColor(ICPCColors.YELLOW);
+			else
+				g.setColor(Color.WHITE);
+			g.setFont(clockFont);
+			FontMetrics fm = g.getFontMetrics();
+			String s = getContestTime();
+			if (s != null)
+				g.drawString(s, width / 12 - fm.stringWidth(s) / 2, fm.getAscent() + CLOCK_MARGIN);
+
+			s = getRemainingTime();
+			if (s != null)
+				g.drawString(s, width * 11 / 12 - fm.stringWidth(s) / 2, fm.getAscent() + CLOCK_MARGIN);
+		}
+	}
+
+	protected BufferedImage createHeaderImage() {
+		BufferedImage img = new BufferedImage(width, headerHeight, Transparency.OPAQUE);
+		Graphics2D g = (Graphics2D) img.getGraphics();
+		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+
+		drawHeader(g);
+
+		g.dispose();
+		return img;
+	}
+
+	protected void drawHeader(Graphics2D g) {
+		g.setColor(Color.black);
+		g.fillRect(0, 0, width, headerHeight + 2);
+
+		g.setColor(Color.white);
+		g.drawLine(0, headerHeight - 1, width, headerHeight - 1);
+	}
+
+	protected String getTitle() {
+		return null;
+	}
+
+	@Override
+	public void paint(Graphics2D g) {
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+
+		paintHeader(g);
+
+		String s = getTitle();
+		if (s != null) {
+			g.setColor(Color.WHITE);
+			g.setFont(titleFont);
+			FontMetrics fm = g.getFontMetrics();
+			g.drawString(s, (width - fm.stringWidth(s)) / 2, fm.getAscent());
+		}
+
+		IContest c = getContest();
+		if (c == null || c.getNumTeams() == 0)
+			return;
+
+		Graphics2D g2 = (Graphics2D) g.create();
+		g2.translate(0, headerHeight + titleHeight);
+		g2.setClip(0, 0, width, height - headerHeight - titleHeight);
+		paintImpl(g2);
+		g2.dispose();
+	}
+
+	protected abstract void paintImpl(Graphics2D g);
+
+	@Override
+	public void setProperty(String value) {
+		if (value.startsWith("clockOn"))
+			showClock = true;
+		else if (value.startsWith("clockOff"))
+			showClock = false;
+	}
+}


### PR DESCRIPTION
This is an initial commentary presentation as requested by Fredrik. This pass is functional and similar to a judge queue - commentary slides up from the bottom when they occurs, then fade away after a while - but is very vanilla. The messages are shown as-is, no formatting of teams or problems, text is not wrapped, etc. I'll follow up with visual improvements later.