### PR TITLE
Multiple file download

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -786,7 +786,7 @@ public class DiskContestSource extends ContestSource {
 						"organizations/" + id + "/logo{0}" };
 			if (COUNTRY_FLAG.equals(property))
 				return new String[] { reg + "organizations" + File.separator + id, "flag{0}.png",
-						"organizations/" + id + "/flag{0}" };
+						"organizations/" + id + "/country_flag{0}" };
 		} else if (type == ContestType.SUBMISSION) {
 			if (FILES.equals(property))
 				return new String[] { events + "submissions" + File.separator + id, "files.zip",


### PR DESCRIPTION
Fixes a problem where file references were set to null on objects that had multiple downloads. Cleans up the support in general by looking at local disk and syncing all files before trying to attach anything to the local contest object.
Also updates country_flag to the location that we went with in the CAF proposal.