### PR TITLE
Welcome page switch from server-side to client-side logic

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -14,6 +14,7 @@
     }
     String[] menuPages = {"", "/details", "/registration", "/clarifications", "/submissions", "/scoreboard", "/commentary", "/admin", "/video/status", "/reports"};
     String[] menuTitles = {"Overview", "Details", "Registration", "Clarifications", "Submissions", "Scoreboard", "Commentary", "Admin", "Video", "Reports"};
+    String[] menuIcons = {"fa-globe", "fa-info", "fa-users", "fa-comments", "fa-share", "fa-trophy", "fa-comments", "fa-user-cog", "fa-video", "fa-file-alt"};
 %>
 <!DOCTYPE html>
 
@@ -149,7 +150,7 @@
                 <li class="nav-item">
                   <a href="${pageContext.request.contextPath}/contests/<%= cc3.getId() %><%= menuPages[i] %>"
                     class="nav-link<% if (request.getAttribute("javax.servlet.forward.request_uri").equals(webroot3 + menuPages[i])) { %> active<% } %>">
-                    <i class="far fa-circle nav-icon"></i>
+                    <i class="far <%= menuIcons[i] %> nav-icon"></i>
                     <p><%= menuTitles[i] %></p>
                   </a>
                 </li>

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -217,6 +217,9 @@ function formatTimestamp(time2) {
 	if (time2 == null)
 		return "";
 	var d = new Date(time2);
+	var now = new Date();
+	if (d.getDate() == now.getDate() && d.getMonth() == now.getMonth() && d.getYear() == now.getYear())
+		return d.toLocaleTimeString();
 	return d.toDateString() + " " + d.toLocaleTimeString();
 }
 

--- a/CDS/src/org/icpc/tools/cds/service/BasicAuthFilter.java
+++ b/CDS/src/org/icpc/tools/cds/service/BasicAuthFilter.java
@@ -72,14 +72,15 @@ public class BasicAuthFilter implements Filter {
 
 		String authHeader = request.getHeader(AUTHORIZATION_HEADER);
 		if (authHeader == null || !authHeader.startsWith(BASIC_PREFIX)) {
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "BASIC authentication is required");
+			// unauthorized, but let them through for public API
+			filterChain.doFilter(request, response);
 			return;
 		}
 
 		String authValue = authHeader.substring(BASIC_PREFIX.length());
 		String userAndPassword = new String(Base64.getDecoder().decode(authValue));
 		if (!userAndPassword.contains(":")) {
-			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "BASIC authentication is required");
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid BASIC authentication");
 			return;
 		}
 

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -14,8 +14,6 @@ import java.net.URL;
 import javax.imageio.ImageIO;
 import javax.servlet.ServletException;
 import javax.servlet.ServletResponse;
-import javax.servlet.annotation.HttpConstraint;
-import javax.servlet.annotation.ServletSecurity;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -46,8 +44,6 @@ import org.icpc.tools.contest.model.util.ScoreboardData;
 import org.icpc.tools.contest.model.util.ScoreboardUtil;
 
 @WebServlet(urlPatterns = { "/contests", "/contests/*" }, asyncSupported = true)
-@ServletSecurity(@HttpConstraint(transportGuarantee = ServletSecurity.TransportGuarantee.CONFIDENTIAL, rolesAllowed = {
-		Role.ADMIN, Role.BLUE, Role.BALLOON, Role.TRUSTED, Role.TEAM, Role.PUBLIC }))
 public class ContestWebService extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
Switches the welcome page from JSPs to jQuery/Bootstrap. In some ways this just replaces some ugly server-side logic with less-ugly javascript (I had some trouble getting the format to look reasonable), but it is a fair bit less ugly, and easier to improve for future UI improvements, automatic refreshing, etc.

Details:
- Adds public support to Contest API by changing the auth filter (the model was already there, just exposes it). Prior to this anyone not logged in could see the welcome page but not access the equivalent API.
- Adds Contests class to contest.js in order to load the base URL and support multiple contests on one page.
- Adds a helper method to contest to allows clients to get the contest scheduled/paused/started state easier. Could be cleaned up in the future, but it works for now.
- Fixes a couple issues where welcome page leaked admin info like an 'incorrect' number of teams (includes jury members) since the client now uses the Contest API directly.
- Improved design of the welcome page: contest logos are shown, dates that are today are simplified (ui.js), better layout, fancy boxes showing the number of problems, teams, and submissions, simplified card colour changes (yellow for about to start, green for running, default otherwise).
- Adds icons to the left navigation.

Pic for Tobi!
<img width="1356" alt="Screen Shot 2021-04-08 at 2 39 41 PM" src="https://user-images.githubusercontent.com/19958075/114080273-35711400-9879-11eb-914d-6bc65fbe3a72.png">
