### PR TITLE
SVG support for CDS (API)

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -718,7 +718,8 @@ public class ContestRESTService extends HttpServlet {
 
 		ILanguage language = contest.getLanguageById(languageId);
 		if (language.getEntryPointRequired() && entryPoint == null) {
-			response.sendError(HttpServletResponse.SC_BAD_REQUEST, language.getEntryPointName() + " required for " + language.getName());
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+					language.getEntryPointName() + " required for " + language.getName());
 			return;
 		}
 
@@ -776,7 +777,7 @@ public class ContestRESTService extends HttpServlet {
 		// cache accepted submission file locally to avoid asking CCS for it later
 		if (source instanceof DiskContestSource) {
 			DiskContestSource dsource = (DiskContestSource) source;
-			File f = dsource.getNewFile(ContestType.SUBMISSION, sId, "files");
+			File f = dsource.getNewFile(ContestType.SUBMISSION, sId, "files", null);
 			if (!f.getParentFile().exists())
 				f.getParentFile().mkdirs();
 			Object[] files = (Object[]) obj.get("files");

--- a/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
+++ b/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
@@ -70,6 +70,8 @@ public class HttpHelper {
 			response.setContentType("text/plain");
 		else if (name.endsWith(".png"))
 			response.setContentType("image/png");
+		else if (name.endsWith(".svg"))
+			response.setContentType("image/svg+xml");
 
 		response.setContentLength((int) f.length());
 		response.setDateHeader("Last-Modified", lastModified);

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -186,14 +186,16 @@ public class PlaybackContest extends Contest {
 		}
 
 		// more complex matching
-		// for now, only download new images that have a different width & height than local images
+		// for now, only download new images that have a different width & height or mime type than
+		// local images
 		for (FileReference sourceFile : sourceFiles) {
 			if (sourceFile.height <= 0 || sourceFile.width <= 0)
 				continue;
 
 			boolean found = false;
 			for (FileReference currentRef : localFiles) {
-				if (currentRef.height == sourceFile.height && currentRef.width == sourceFile.width) {
+				if (currentRef.height == sourceFile.height && currentRef.width == sourceFile.width
+						&& (currentRef.mime == null || currentRef.mime.equals(sourceFile.mime))) {
 					found = true;
 					continue;
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -420,7 +420,7 @@ public class RESTContestSource extends DiskContestSource {
 		if (obj == null)
 			return null;
 
-		File file = super.getNewFile(obj.getType(), obj.getId(), property);
+		File file = super.getNewFile(obj.getType(), obj.getId(), property, ref.mime);
 		if (file == null)
 			return null;
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/SVGParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/SVGParser.java
@@ -1,0 +1,60 @@
+package org.icpc.tools.contest.model.feed;
+
+import java.awt.Dimension;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.StringTokenizer;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+/**
+ * Helper class to read an SVG file and grab the (integer) viewBox width and height.
+ */
+public class SVGParser {
+	public static Dimension parse(File file) throws IOException {
+		if (file == null)
+			return null;
+
+		InputStream in = null;
+		try {
+			in = new FileInputStream(file);
+			XMLInputFactory inputFactory = XMLInputFactory.newInstance();
+			inputFactory.setProperty(XMLInputFactory.IS_VALIDATING, false);
+			inputFactory.setProperty(XMLInputFactory.IS_REPLACING_ENTITY_REFERENCES, false);
+			XMLEventReader reader = inputFactory.createXMLEventReader(in);
+
+			while (reader.hasNext()) {
+				XMLEvent event = reader.nextEvent();
+				if (event.isStartElement()) {
+					StartElement element = (StartElement) event;
+					String name = element.getName().getLocalPart();
+					if ("svg".equals(name)) {
+						String viewBox = element.getAttributeByName(new QName("viewBox")).getValue();
+						StringTokenizer st = new StringTokenizer(viewBox);
+						st.nextToken(); // x
+						st.nextToken(); // y
+						Double w = Double.parseDouble(st.nextToken());
+						Double h = Double.parseDouble(st.nextToken());
+						return new Dimension(w.intValue(), h.intValue());
+					}
+				}
+			}
+		} catch (Exception e) {
+			throw new IOException("Error reading xml", e);
+		} finally {
+			if (in != null)
+				try {
+					in.close();
+				} catch (Exception e) {
+					// ignore
+				}
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
API support for SVG images, as well as multiple file types per property (e.g. logos could be in png, jpg, or both). Notes:
- Formalized FilePatterns into a helper class that handles the standard differences between resources.
- Added svg mime type to file references and download header.
- Now use mime type when trying to pick local file name for files downloaded from CCS.
- Added SVG helper class to read the viewBox size out of SVG files.