### PR TITLE
Timeline not respecting time multiplier

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
@@ -132,7 +132,7 @@ public class TimelinePresentation extends AbstractScrollingScoreboardPresentatio
 		if (state.getEnded() != null)
 			currentTime = contest.getDuration();
 		else if (state.getStarted() != null)
-			currentTime = (int) (getTimeMs() - state.getStarted());
+			currentTime = (int) ((getTimeMs() - state.getStarted()) * contest.getTimeMultiplier());
 		ct = getX(currentTime);
 		g.drawLine(ct, 0, ct, (int) (numTeams * rowHeight));
 		g.setStroke(oldStroke);


### PR DESCRIPTION
Nit: when I playback contests at 10x or 20x speed, the 'current time' line in the timeline presentation wasn't tracking. Minor fix to update it.