### PR TITLE
Fix array growth from 0

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
@@ -253,11 +253,12 @@ public class ContestData implements Iterable<IContestObject> {
 			tc.cache = new IContestObject[20];
 			tc.index = new int[20];
 		} else if (tc.size == tc.cache.length) {
-			IContestObject[] temp = new IContestObject[tc.cache.length * 3 / 2];
+			int newLen = Math.max(10, tc.cache.length * 3 / 2);
+			IContestObject[] temp = new IContestObject[newLen];
 			System.arraycopy(tc.cache, 0, temp, 0, tc.cache.length);
 			tc.cache = temp;
 
-			int[] temp2 = new int[tc.index.length * 3 / 2];
+			int[] temp2 = new int[newLen];
 			System.arraycopy(tc.index, 0, temp2, 0, tc.index.length);
 			tc.index = temp2;
 		}


### PR DESCRIPTION
If the array has been reduced to size 0 then you can never add items again, so fix the minimum size.