### PR TITLE
Local feed + REST contest source

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -72,7 +72,7 @@ public abstract class ContestSource {
 			if (f.isDirectory())
 				return new DiskContestSource(f);
 
-			return new EventFeedContestSource(source);
+			return new RESTContestSource(f, arg1, arg2);
 		}
 
 		throw new IOException("Could not parse or resolve contest source");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -108,7 +108,7 @@ public class DiskContestSource extends ContestSource {
 
 		public FilePattern(IContestObject.ContestType type, String id, String property, String folder,
 				String[] fileExtensions) {
-			if (type == ContestType.CONTEST) {
+			if (type == null) {
 				this.folder = folder;
 				this.url = property;
 			} else {


### PR DESCRIPTION
There are currently 3 ways to load a contest (6 if you count XML vs JSON...): 1) HTTP URL/REST (with absolute or relative file references), 2) Disk/CDP/CAF (with local resources), and 3) directly from feed file (with no references, since this is mostly historic).
This switches the third method to use the REST contest source from the first, which means that if there are absolute file references in the feed then it should be able to download and use those. Relative URLs still won't work, since the behaviour is undefined and wouldn't match the CAF.
Also using this commit to slip in the one line change in DiskContestSource that was missing from previous commit.