### PR TITLE
Error if no teams or problems

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -541,6 +541,17 @@ public class Resolver {
 				Trace.trace(Trace.INFO, "Resolved for problems labels " + cc.getNumProblems());
 			}
 
+			// error if no teams
+			if (cc.getTeams().length == 0) {
+				Trace.trace(Trace.ERROR, "Contest has no teams, exiting.");
+				System.exit(2);
+			}
+
+			if (cc.getProblems().length == 0) {
+				Trace.trace(Trace.ERROR, "Contest has no problems, exiting.");
+				System.exit(2);
+			}
+
 			if (!hasAwards) {
 				Trace.trace(Trace.USER, "Generating awards");
 				AwardUtil.createDefaultAwards(cc);


### PR DESCRIPTION
If there are no teams or no problems (possible in any broken feed, but more likely after using --groups or --problems with an incorrect id) the resolver should give an error and exit. Otherwise, it'll cause exceptions later.