### PR TITLE
JSON by default

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -703,14 +703,14 @@ public class DiskContestSource extends ContestSource {
 			throw e;
 		}
 		try {
-			if (contestFile.getName().endsWith("json")) {
-				NDJSONFeedParser jsonParser = new NDJSONFeedParser();
-				jsonParser.parse(contest, in);
-				parser = jsonParser;
-			} else {
+			if (contestFile.getName().endsWith("xml")) {
 				XMLFeedParser xmlParser = new XMLFeedParser();
 				xmlParser.parse(contest, in);
 				parser = xmlParser;
+			} else {
+				NDJSONFeedParser jsonParser = new NDJSONFeedParser();
+				jsonParser.parse(contest, in);
+				parser = jsonParser;
 			}
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Error reading event feed", e);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/EventFeedContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/EventFeedContestSource.java
@@ -47,11 +47,11 @@ public class EventFeedContestSource extends ContestSource {
 			throw e;
 		}
 		try {
-			if (file.getName().endsWith("json")) {
-				NDJSONFeedParser parser = new NDJSONFeedParser();
+			if (file.getName().endsWith("xml")) {
+				XMLFeedParser parser = new XMLFeedParser();
 				parser.parse(contest, in);
 			} else {
-				XMLFeedParser parser = new XMLFeedParser();
+				NDJSONFeedParser parser = new NDJSONFeedParser();
 				parser.parse(contest, in);
 			}
 		} catch (Exception e) {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -740,11 +740,11 @@ public class RESTContestSource extends DiskContestSource {
 			throw e;
 		}
 		try {
-			if (feedFile.getName().endsWith("json")) {
-				NDJSONFeedParser parser2 = new NDJSONFeedParser();
+			if (feedFile.getName().endsWith("xml")) {
+				XMLFeedParser parser2 = new XMLFeedParser();
 				parser2.parse(contest, in);
 			} else {
-				XMLFeedParser parser2 = new XMLFeedParser();
+				NDJSONFeedParser parser2 = new NDJSONFeedParser();
 				parser2.parse(contest, in);
 			}
 		} catch (Exception e) {


### PR DESCRIPTION
John hit an issue where an event feed didn't have a file extension and the code assumed it was xml. Reversing this everywhere so that JSON is the default and XML is only used when the file ends in .xml.