### PR TITLE
REST connection cleanup

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,13 +58,8 @@ public abstract class ContestSource {
 		if (source == null)
 			throw new IOException("No contest source");
 
-		try {
-			URL url = new URL(source);
-			if ("http".equals(url.getProtocol()) || "https".equals(url.getProtocol()))
-				return new RESTContestSource(url, arg1, arg2);
-		} catch (Exception e) {
-			// could not parse as a url, ignore
-		}
+		if (source.startsWith("http"))
+			return new RESTContestSource(source, arg1, arg2);
 
 		File f = new File(source);
 		if (f.exists()) {


### PR DESCRIPTION
I wasn't planning on going this far, but one thing led to another...
- I started by trying to clean the code and avoid potential errors when pointing at an event feed file with absolute URLs.
- I did some general cleanup along the way - removing a couple unused methods, and making some private to make sure nobody is using/then can be inlined or removed as well.
- Changed every connection to go through the common createConnection() method - all URLs are either contest API (base URL relative) or simple contest sub-paths.
- Contest URLs were always cleaned to strip a trailing slash before, but Kattis has a redirect to include the slash. Now that's valid, and avoids an extra redirect on every API call.
- I noticed that you used to create the connection with a potentially bad URL and then clients may call validate() later, which in turn might decide to autocorrect the URL. It also might not tell the user, and baseURL might already be set. Now the URL is auto-corrected on creation.
- Better redirect following and error handling when auto-detecting. Better error messages returned in some cases.