### PR TITLE
JSON error messages

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -99,7 +99,7 @@ function submitClarification() {
 	contest.postClarification(JSON.stringify(obj), function(body) {
 		$('#clar-status').text("Submitted successfully");
 	}, function(result) {
-		$('#clar-status').html("Not accepted: " + sanitizeHTML(result.responseText));
+		$('#clar-status').html("Not accepted: " + sanitizeHTML(result));
 	})
 }
 

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -267,24 +267,31 @@ class Contest {
 		this.clarifications = null;
 	}
 
-	post(type, body, ok, fail) {
+	post(type, body, success, error) {
         console.log("POSTing contest object: " + type);
         return $.ajax({
 		    url: this.getURL(type),
 		    method: 'POST',
 		    headers: { "Accept": "application/json" },
 		    data: body,
-		    success: ok,
-		    error: fail
+		    success: success,
+		    error: function(result, ajaxOptions, thrownError) {
+		       var obj = jQuery.parseJSON(result.responseText);
+		       if (obj != null && obj.message != null) {
+		          error(obj.message)
+	              return
+	           }
+		       error(result.responseText)
+		    }
 		});
 	}
 
-	postSubmission(obj, ok, fail) {
-        this.post('submissions', obj, ok, fail);
+	postSubmission(obj, success, error) {
+        this.post('submissions', obj, success, error);
 	}
 
-	postClarification(obj, ok, fail) {
-        this.post('clarifications', obj, ok, fail);
+	postClarification(obj, success, error) {
+        this.post('clarifications', obj, success, error);
 	}
 }
 

--- a/CDS/src/org/icpc/tools/cds/service/BasicAuthFilter.java
+++ b/CDS/src/org/icpc/tools/cds/service/BasicAuthFilter.java
@@ -38,6 +38,11 @@ public class BasicAuthFilter implements Filter {
 		HttpServletRequest request = (HttpServletRequest) servletRequest;
 		HttpServletResponse response = (HttpServletResponse) servletResponse;
 
+		// mark API calls
+		String uri = request.getRequestURI();
+		if (uri.startsWith("/api"))
+			request.setAttribute("CDS-api", true);
+
 		// already logged in
 		if (request.getRemoteUser() != null) {
 			filterChain.doFilter(request, response);
@@ -64,7 +69,6 @@ public class BasicAuthFilter implements Filter {
 		}
 
 		// try basic auth - but only for API
-		String uri = request.getRequestURI();
 		if (!uri.startsWith("/api/") && !uri.startsWith("/presentation/")) {
 			filterChain.doFilter(request, response);
 			return;

--- a/CDS/src/org/icpc/tools/cds/service/ErrorService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ErrorService.java
@@ -9,6 +9,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
+import org.icpc.tools.contest.model.feed.JSONWriter;
+
 @WebServlet(urlPatterns = "/error")
 public class ErrorService extends HttpServlet {
 	private static final long serialVersionUID = 1L;
@@ -22,14 +25,30 @@ public class ErrorService extends HttpServlet {
 		response.setHeader("ICPC-Tools", "CDS");
 		response.setHeader("X-Frame-Options", "sameorigin");
 
+		// if the client accepts html, return the error via html
 		String accept = request.getHeader("Accept");
-		if (accept == null || !accept.contains("html")) {
-			PrintWriter pw = response.getWriter();
-			pw.write(request.getAttribute("javax.servlet.error.message") + " (" + response.getStatus() + ")");
-			pw.flush();
+		if (accept != null && accept.contains("html")) {
+			request.getRequestDispatcher("/WEB-INF/jsps/errorPage.jsp").forward(request, response);
 			return;
 		}
 
-		request.getRequestDispatcher("/WEB-INF/jsps/errorPage.jsp").forward(request, response);
+		// if client accepts json or it's an API call, return json
+		if ((accept != null && accept.contains("json")) || request.getAttribute("CDS-api") != null) {
+			response.setContentType("application/json");
+
+			JsonObject obj = new JsonObject();
+			obj.put("code", response.getStatus());
+			obj.put("message", request.getAttribute("javax.servlet.error.message"));
+
+			JSONWriter jw = new JSONWriter(response.getWriter());
+			jw.writeObject(obj);
+			jw.flush();
+			return;
+		}
+
+		// otherwise, send plain text
+		PrintWriter pw = response.getWriter();
+		pw.write(request.getAttribute("javax.servlet.error.message") + " (" + response.getStatus() + ")");
+		pw.flush();
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -765,8 +765,22 @@ public class RESTContestSource extends DiskContestSource {
 				sb.append(s);
 				s = br.readLine();
 			}
-			if (sb.length() > 0)
+
+			if (sb.length() > 0) {
+				// try to parse as json error object first
+				try {
+					JSONParser rdr = new JSONParser(sb.toString());
+					JsonObject obj = rdr.readObject();
+					String message = obj.getString("message");
+					if (message != null && message.length() > 0)
+						return message;
+				} catch (Exception x) {
+					// ignore
+				}
+
+				// otherwise, just return the text
 				return sb.toString();
+			}
 		} catch (Exception e) {
 			// ignore
 		}
@@ -998,7 +1012,7 @@ public class RESTContestSource extends DiskContestSource {
 			conn.setRequestProperty("Content-Type", "application/json");
 
 			if (conn.getResponseCode() != 200)
-				throw new IOException(conn.getResponseCode() + ": " + conn.getResponseMessage());
+				throw new IOException(getResponseError(conn));
 
 			InputStream in = conn.getInputStream();
 			JSONParser rdr = new JSONParser(in);


### PR DESCRIPTION
Return an error message in JSON format when a call to the API fails or the client device prefers JSON, following the same template as DOMjudge. Add the same support on the client side (both CDS -> CCS and web UI -> Contest API) so that they support error messages in both json and plain text formats.