### PR TITLE
Update POST, PUT, PATCH, DELETE

### DIFF
--- a/CDS/WebContent/js/cds.js
+++ b/CDS/WebContent/js/cds.js
@@ -12,8 +12,31 @@ var cds=(function() {
 		return contestURL + '/' + type + '/' + id;
 	}
 
-	var add = function(type, id, body, ok, fail) {
- 	    console.log("Adding (PUT) contest object: " + type + "/" + id + ", " + body);
+    var getMessage = function(result) {
+    	try {
+			return JSON.parse(result.responseText);
+		} catch (err) {
+			return { "code": result.status, "message":"Invalid response: " + result.responseText };
+		}
+	}
+
+	var doPost = function(type, body, ok, fail) {
+ 	    console.log("POSTing contest object: " + type + ", " + body);
+ 	    return $.ajax({
+		    url: getURL(type, null),
+		    method: 'POST',
+		    data: body,
+		    success: function(result) {
+		    	ok(result);
+		    },
+		    error: function(result) {
+			    fail(getMessage(result));
+		    }
+		});
+    }
+
+	var doPut = function(type, id, body, ok, fail) {
+ 	    console.log("PUTting contest object: " + type + "/" + id + ", " + body);
  	    return $.ajax({
 		    url: getURL(type, id),
 		    method: 'PUT',
@@ -22,13 +45,13 @@ var cds=(function() {
 		    	ok(result);
 		    },
 		    error: function(result) {
-			    fail(result);
+			    fail(getMessage(result));
 		    }
 		});
     }
 
-	var update = function(type, id, body, ok, fail) {
-        console.log("Updating (PATCH) contest object: " + type + "/" + id);
+	var doPatch = function(type, id, body, ok, fail) {
+        console.log("PATCHing contest object: " + type + "/" + id);
         return $.ajax({
 		    url: getURL(type, id),
 		    method: 'PATCH',
@@ -37,13 +60,13 @@ var cds=(function() {
 		    	ok(result);
 		    },
 		    error: function(result) {
-			    fail(result);
+			    fail(getMessage(result));
 		    }
 		});
 	}
 
-	var remove = function(type, id, ok, fail) {
-        console.log("Deleting (DELETE) contest object: " + type + "/" + id);
+	var doDelete = function(type, id, ok, fail) {
+        console.log("DELETEing contest object: " + type + "/" + id);
         return $.ajax({
 		    url: getURL(type, id),
 		    method: 'DELETE',
@@ -51,15 +74,16 @@ var cds=(function() {
 		    	ok(result);
 		    },
 		    error: function(result) {
-			    fail(result);
+			    fail(getMessage(result));
 		    }
 		});
 	}
 
 	return {
 		setContestId: setContestId,
-		add: add,
-		update: update,
-		remove: remove
+		doPost: doPost,
+		doPut: doPut,
+		doPatch: doPatch,
+		doDelete: doDelete
 	};
 })();

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -246,3 +246,16 @@ function awardsTd(award) {
     }
     return { citation: award.citation, teamsStr: teamsStr };
 }
+
+function startstatusTd(startStatus) {
+	var a = 'default';
+	var b = 'default';
+	var c = 'default';
+	if (startStatus.status == 0)
+		a = 'danger';
+	else if (startStatus.status == 1)
+		b = 'warning';
+	else if (startStatus.status == 2)
+		c = 'success';
+	return { label: startStatus.label, id: startStatus.id, a: a, b: b, c: c };
+}

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -367,7 +367,6 @@ public class ContestWebService extends HttpServlet {
 				request.getRequestDispatcher("/WEB-INF/jsps/balloon.jsp").forward(request, response);
 				return;
 			} else if (segments[1].equals("resolver")) {
-				request.setCharacterEncoding("UTF-8");
 				ResolverService.doGet(response, cc);
 				return;
 			} /* else if (segments.length == 4 && segments[1].equals("video") && segments[2].equals("map")) {

--- a/CDS/src/org/icpc/tools/cds/service/ResolverService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ResolverService.java
@@ -1,7 +1,6 @@
 package org.icpc.tools.cds.service;
 
 import java.io.IOException;
-import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +16,8 @@ import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IJudgementType;
 import org.icpc.tools.contest.model.ISubmission;
-import org.icpc.tools.contest.model.feed.JSONEncoder;
+import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
+import org.icpc.tools.contest.model.feed.JSONWriter;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.resolver.ResolutionControl;
 import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
@@ -38,20 +38,25 @@ public class ResolverService {
 	protected static boolean localControl;
 
 	protected static void doGet(HttpServletResponse response, ConfiguredContest cc) throws IOException {
-		if (control == null)
-			return;
-
 		response.setCharacterEncoding("UTF-8");
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		response.setContentType("application/json");
-		PrintWriter pw = response.getWriter();
-		JSONEncoder je = new JSONEncoder(pw);
-		je.open();
-		je.encode("pause", control.getCurrentPause());
-		je.encode("total_pauses", ResolutionUtil.getTotalPauses(steps));
-		je.encode("total_time", ResolutionUtil.getTotalTime(steps));
-		je.encode("stepping", control.isStepping());
-		je.close();
+
+		JsonObject obj = new JsonObject();
+		if (control != null) {
+			obj.put("pause", control.getCurrentPause());
+			obj.put("total_pauses", ResolutionUtil.getTotalPauses(steps));
+			obj.put("total_time", ResolutionUtil.getTotalTime(steps));
+			obj.put("stepping", control.isStepping());
+		} else {
+			obj.put("pause", -1);
+			obj.put("total_pauses", -1);
+			obj.put("total_time", -1);
+			obj.put("stepping", false);
+		}
+
+		JSONWriter pw = new JSONWriter(response.getWriter());
+		pw.writeObject(obj);
 	}
 
 	protected static void doPut(HttpServletResponse response, String command, ConfiguredContest cc) throws IOException {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -302,7 +302,6 @@ public abstract class ContestSource {
 	}
 
 	private boolean waitForContest(Ready r, int timeout) {
-		System.out.println("wait for contest");
 		long time = System.currentTimeMillis();
 		synchronized (lock) {
 			while (true) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/StartStatus.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/StartStatus.java
@@ -52,11 +52,7 @@ public class StartStatus extends ContestObject implements IStartStatus {
 			label = (String) value;
 			return true;
 		} else if (STATUS.equals(name)) {
-			try {
-				status = Integer.parseInt((String) value);
-			} catch (Exception e) {
-				// ignore
-			}
+			status = parseInt(value);
 			return true;
 		}
 


### PR DESCRIPTION
- Updated HTTP methods to match the new Contest API spec requirements.
- Updated cds.js and CDS admin page to support the same requirements.
- Added client-side support for modifying awards (but not implemented on CDS yet).
- Changed /resolver service to use JSON object encoding, fixed a bug where it wouldn't output anything if resolver hadn't been inited, and removed duplicate char encoding.
- Removed extra system.out from ContestSource (unrelated).
- Fixed bug in start status that would stop it from cloning correctly.