### PR TITLE
Fix unicode character sanitizing

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
+++ b/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
@@ -151,8 +151,8 @@ public class HttpHelper {
 					break;
 				default:
 					if (c < 0x0020 || c > 0x007e) {
-						String t = "000" + Integer.toHexString(c);
-						sb.append("&" + t.substring(t.length() - 4));
+						String t = Integer.toString(c);
+						sb.append("&#" + t + ";");
 					} else
 						sb.append(c);
 			}


### PR DESCRIPTION
The character for full-width left quotation mark (`“`) cannot display correct in `head.jsp h1.m-0`.

Previously it was displayed as `&201c`. Then I found the `HttpHelper.sanitizeHTML(String s)` is not implemented correct before.

A probably fix is `&#8220;`, which doesn't require the hex converting.

BTW, there are many occurrence of unsanitized HTML. (e.g. `head.jsp li.has-treeview > a:first-child > p` is directly `<%= contest3.getName() != null ? contest3.getName() : "(unnamed contest)" %>`) Is the sanitization intended?