### PR TITLE
Fix Timestamp parse in frontend

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/Timestamp.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/Timestamp.java
@@ -11,18 +11,18 @@ public class Timestamp {
 	// parser for old spec times like: 1265335256.480
 	private static final Pattern OLD_TIME_PATTERN = Pattern.compile("([0-9]+)(\\.([0-9]{1,}))?");
 
-	// parser for times like: 2014-06-25T11:22:05.034+01
+	// parser for times like: 2014-06-25T11:22:05.034+01:00
 	private static final ThreadLocal<DateFormat> TIME_FORMAT = new ThreadLocal<DateFormat>() {
 		@Override
 		protected DateFormat initialValue() {
-			return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+			return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 		}
 	};
-	// parser for times like: 2014-06-25T11:22:05+01
+	// parser for times like: 2014-06-25T11:22:05+01:00
 	private static final ThreadLocal<DateFormat> TIME_FORMAT2 = new ThreadLocal<DateFormat>() {
 		@Override
 		protected DateFormat initialValue() {
-			return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
+			return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
 		}
 	};
 


### PR DESCRIPTION
Currently, the timestamp string produced by CDS api is like `2014-06-25T11:22:05.034+01`.

However, in some browsers, this string cannot be parsed as Date, both in Firefox and Chrome.

![firefox](https://user-images.githubusercontent.com/10959348/120892368-8b2b2800-c640-11eb-8a69-b420f6fd5801.png)

![chrome](https://user-images.githubusercontent.com/10959348/120892392-a39b4280-c640-11eb-98fe-aeba797e7230.png)

If we extend the format be like `+01:00` it would work.

In Contest API standard, it said `timestamp` should be `yyyy-mm-ddThh:mm:ss(.uuu)?[+-]zz(:mm)?`. I think this change would be ok.