### PR TITLE
Hidden teams and award null teamIds

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
@@ -86,6 +86,7 @@
 			                    <th>Name</th>
 			                    <th>Organization</th>
 			                    <th>Group</th>
+			                    <th class="text-center">Hidden</th>
 			                    <th>Summary</th>
 			                </tr>
 			            </thead>
@@ -117,6 +118,7 @@
   <td>{{name}}</td>
   <td>{{orgName}}</td>
   <td>{{groupNames}}</td>
+  <td class="text-center">{{#hidden}}<span class="badge badge-info"><i class="fas fa-eye-slash"></i></a>{{/hidden}}</td>
   <td><a href="<%= webroot  %>/teamSummary/{{id}}">summary</a></td>
 </script>
 <script type="text/javascript">

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -119,8 +119,11 @@ function teamsTd(team) {
             first = false;
         }
     }
+    var hidden = "";
+    if (team.hidden != null)
+        hidden = "true";
 
-    return { id: team.id, name: name, logo: logoSrc, orgName: orgName, groupNames: groupNames };
+    return { id: team.id, name: name, logo: logoSrc, orgName: orgName, groupNames: groupNames, hidden: hidden };
 }
 
 function queueTd(submission) {

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -288,23 +288,25 @@ public class PlaybackContest extends Contest {
 				}
 
 				String[] teamIds = a.getTeamIds();
-				int count = 0;
-				for (String teamId : teamIds) {
-					ITeam team = getTeamById(teamId);
-					if (team != null)
-						count++;
-				}
-				if (count == 0)
-					return;
-
-				if (count != teamIds.length) {
-					List<String> ids = new ArrayList<String>(count);
+				if (teamIds != null) {
+					int count = 0;
 					for (String teamId : teamIds) {
 						ITeam team = getTeamById(teamId);
 						if (team != null)
-							ids.add(teamId);
+							count++;
 					}
-					a.setTeamIds(ids.toArray(new String[count]));
+					if (count == 0)
+						return;
+
+					if (count != teamIds.length) {
+						List<String> ids = new ArrayList<String>(count);
+						for (String teamId : teamIds) {
+							ITeam team = getTeamById(teamId);
+							if (team != null)
+								ids.add(teamId);
+						}
+						a.setTeamIds(ids.toArray(new String[count]));
+					}
 				}
 			}
 		}

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -14,6 +14,7 @@ import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IContestObject.ContestType;
+import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
@@ -342,6 +343,14 @@ public class PlaybackContest extends Contest {
 				team.setAudio(new FileReferenceList(audioRef));
 			} else
 				team.setAudio(null);
+
+			if (team.getGroupIds() != null) {
+				for (String gId : team.getGroupIds()) {
+					IGroup g = getGroupById(gId);
+					if (g != null && g.isHidden())
+						team.add("hidden", "true");
+				}
+			}
 		}
 
 		if (obj instanceof Submission) {

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
@@ -119,4 +119,11 @@ public interface ITeam extends IContestObject, IPosition {
 	 * @return the audio stream
 	 */
 	String getAudioURL();
+
+	/**
+	 * Returns <code>true</code> if the team is hidden.
+	 *
+	 * @return <code>true</code> if the team is hidden, <code>false</code> otherwise
+	 */
+	boolean isHidden();
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedWriter.java
@@ -258,8 +258,9 @@ public class XMLFeedWriter {
 				write("show", "true");
 			else
 				write("show", "false");
-			for (String t : a.getTeamIds())
-				write("teamId", t);
+			if (a.getTeamIds() != null)
+				for (String t : a.getTeamIds())
+					write("teamId", t);
 			writeEnd(XMLFeedParser.AWARD);
 		} else if (obj instanceof Finalized) {
 			Finalized f = (Finalized) obj;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
@@ -100,10 +100,14 @@ public class Award extends ContestObject implements IAward {
 	@Override
 	protected boolean addImpl(String name, Object value) throws Exception {
 		if (TEAM_IDS.equals(name)) {
-			Object[] ob = JSONParser.getOrReadArray(value);
-			teamIds = new String[ob.length];
-			for (int i = 0; i < ob.length; i++)
-				teamIds[i] = (String) ob[i];
+			if (value == null || "null".equals(value))
+				teamIds = null;
+			else {
+				Object[] ob = JSONParser.getOrReadArray(value);
+				teamIds = new String[ob.length];
+				for (int i = 0; i < ob.length; i++)
+					teamIds[i] = (String) ob[i];
+			}
 			return true;
 		} else if (name.equals(CITATION)) {
 			citation = (String) value;
@@ -122,13 +126,13 @@ public class Award extends ContestObject implements IAward {
 	@Override
 	protected void getPropertiesImpl(Map<String, Object> props) {
 		super.getPropertiesImpl(props);
+		props.put(CITATION, citation);
 		if (teamIds != null) {
 			if (teamIds.length == 0)
 				props.put(TEAM_IDS, "[]");
 			else
 				props.put(TEAM_IDS, "[\"" + String.join("\",\"", teamIds) + "\"]");
 		}
-		props.put(CITATION, citation);
 		if (show == false)
 			props.put(SHOW, show);
 		if (count >= 0)
@@ -159,7 +163,7 @@ public class Award extends ContestObject implements IAward {
 		if (citation == null || citation.isEmpty())
 			errors.add("Citation missing");
 
-		if (teamIds != null || teamIds.length > 0) {
+		if (teamIds != null && teamIds.length > 0) {
 			for (String tId : teamIds) {
 				if (c.getTeamById(tId) == null)
 					errors.add("Invalid team " + tId);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1017,6 +1017,9 @@ public class Contest implements IContest {
 		if (team == null)
 			return false;
 
+		if (team.isHidden())
+			return true;
+
 		String[] groupIds = team.getGroupIds();
 		if (groupIds == null || groupIds.length == 0)
 			return false;
@@ -1676,22 +1679,24 @@ public class Contest implements IContest {
 
 		for (IAward award : getAwards()) {
 			String[] awardTeamIds = award.getTeamIds();
-			int found = 0;
-			for (String teamId : awardTeamIds) {
-				if (teamId != null && teamIds.contains(teamId))
-					found++;
-			}
-			if (found > 0) {
-				if (awardTeamIds.length != found) {
-					String[] newTeamIds = new String[awardTeamIds.length - found];
-					found = 0;
-					for (String teamId : awardTeamIds) {
-						if (teamId != null && !teamIds.contains(teamId))
-							newTeamIds[found++] = teamId;
-					}
-					((Award) award).setTeamIds(newTeamIds);
-				} else
-					remove.add(award);
+			if (awardTeamIds != null) {
+				int found = 0;
+				for (String teamId : awardTeamIds) {
+					if (teamId != null && teamIds.contains(teamId))
+						found++;
+				}
+				if (found > 0) {
+					if (awardTeamIds.length != found) {
+						String[] newTeamIds = new String[awardTeamIds.length - found];
+						found = 0;
+						for (String teamId : awardTeamIds) {
+							if (teamId != null && !teamIds.contains(teamId))
+								newTeamIds[found++] = teamId;
+						}
+						((Award) award).setTeamIds(newTeamIds);
+					} else
+						remove.add(award);
+				}
 			}
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -31,6 +31,7 @@ public class Team extends ContestObject implements ITeam {
 	private static final String AUDIO = "audio";
 	private static final String KEY_LOG = "key_log";
 	private static final String TOOL_DATA = "tool_data";
+	private static final String HIDDEN = "hidden";
 
 	private String name;
 	private String displayName;
@@ -48,6 +49,7 @@ public class Team extends ContestObject implements ITeam {
 	private FileReferenceList backup;
 	private FileReferenceList keylog;
 	private FileReferenceList tooldata;
+	private boolean isHidden;
 
 	@Override
 	public ContestType getType() {
@@ -224,6 +226,11 @@ public class Team extends ContestObject implements ITeam {
 	}
 
 	@Override
+	public boolean isHidden() {
+		return isHidden;
+	}
+
+	@Override
 	public Object resolveFileReference(String url) {
 		return FileReferenceList.resolve(url, photo, video, backup, desktop, webcam, audio, keylog, tooldata);
 	}
@@ -313,6 +320,10 @@ public class Team extends ContestObject implements ITeam {
 				audio = new FileReferenceList(value);
 				return true;
 			}
+			case HIDDEN: {
+				isHidden = parseBoolean(value);
+				return true;
+			}
 		}
 
 		return false;
@@ -338,6 +349,7 @@ public class Team extends ContestObject implements ITeam {
 		t.x = x;
 		t.y = y;
 		t.rotation = rotation;
+		t.isHidden = isHidden;
 		return t;
 	}
 
@@ -369,6 +381,8 @@ public class Team extends ContestObject implements ITeam {
 				attrs.add("\"" + ROTATION + "\":" + round(rotation));
 			props.put(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
+		if (isHidden)
+			props.put(HIDDEN, "true");
 	}
 
 	@Override
@@ -404,6 +418,8 @@ public class Team extends ContestObject implements ITeam {
 				attrs.add("\"" + ROTATION + "\":" + round(rotation));
 			je.encodePrimitive(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
+		if (isHidden)
+			je.encode(HIDDEN, true);
 	}
 
 	private static double round(double d) {

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -145,11 +145,13 @@ public class ResolverLogic {
 			IAward[] awards2 = finalContest.getAwards();
 			for (IAward a : awards2) {
 				if (a.getAwardType() == IAward.MEDAL) {
-					for (String id : a.getTeamIds()) {
-						ITeam team = finalContest.getTeamById(id);
-						if (team != null) {
-							int row = finalContest.getOrderOf(team);
-							this.singleStepStartRow = Math.max(row, this.singleStepStartRow);
+					if (a.getTeamIds() != null) {
+						for (String id : a.getTeamIds()) {
+							ITeam team = finalContest.getTeamById(id);
+							if (team != null) {
+								int row = finalContest.getOrderOf(team);
+								this.singleStepStartRow = Math.max(row, this.singleStepStartRow);
+							}
 						}
 					}
 				}
@@ -173,13 +175,15 @@ public class ResolverLogic {
 		AwardUtil.sortAwards(contest, contestAwards);
 		for (IAward award : contestAwards) {
 			String[] teamIds = award.getTeamIds();
-			for (String teamId : teamIds) {
-				List<IAward> aw = awards.get(teamId);
-				if (aw == null) {
-					aw = new ArrayList<>();
-					awards.put(teamId, aw);
+			if (teamIds != null) {
+				for (String teamId : teamIds) {
+					List<IAward> aw = awards.get(teamId);
+					if (aw == null) {
+						aw = new ArrayList<>();
+						awards.put(teamId, aw);
+					}
+					aw.add(award);
 				}
-				aw.add(award);
 			}
 		}
 
@@ -408,7 +412,6 @@ public class ResolverLogic {
 	}
 
 	private void resolveEverything(boolean bill) {
-		int currentRow = contest.getNumTeams() - 1;
 		// boolean singleStep = false;
 
 		Timing timing = null;
@@ -432,6 +435,7 @@ public class ResolverLogic {
 		SubmissionInfo runInfo = getNextResolve();
 		projectStandings(runInfo);
 
+		int currentRow = contest.getOrderedTeams().length - 1;
 		while (currentRow >= 0) {
 			Trace.trace(Trace.INFO, "Resolving row: " + currentRow);
 

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -366,8 +366,10 @@ public class AwardUtil {
 				if (a.getAwardType() == IAward.MEDAL && a.getId().contains("bronze")) {
 					lastBronze = 0;
 					String[] teamIds = a.getTeamIds();
-					for (String tId : teamIds) {
-						lastBronze = Math.max(lastBronze, contest.getOrderOf(contest.getTeamById(tId)) + 1);
+					if (teamIds != null) {
+						for (String tId : teamIds) {
+							lastBronze = Math.max(lastBronze, contest.getOrderOf(contest.getTeamById(tId)) + 1);
+						}
 					}
 				}
 		}
@@ -380,12 +382,14 @@ public class AwardUtil {
 		if (awards != null) {
 			for (IAward a : awards)
 				if (a.getAwardType() == IAward.MEDAL) {
-					if (a.getId().contains("gold"))
-						num[0] = a.getTeamIds().length;
-					else if (a.getId().contains("silver"))
-						num[1] = a.getTeamIds().length;
-					else if (a.getId().contains("bronze"))
-						num[2] = a.getTeamIds().length;
+					if (a.getTeamIds() != null) {
+						if (a.getId().contains("gold"))
+							num[0] = a.getTeamIds().length;
+						else if (a.getId().contains("silver"))
+							num[1] = a.getTeamIds().length;
+						else if (a.getId().contains("bronze"))
+							num[2] = a.getTeamIds().length;
+					}
 				}
 		}
 		return num;
@@ -520,13 +524,15 @@ public class AwardUtil {
 		Map<String, List<IAward>> map = new HashMap<>();
 		for (IAward award : awards) {
 			String[] teamIds = award.getTeamIds();
-			for (String teamId : teamIds) {
-				List<IAward> aw = map.get(teamId);
-				if (aw == null) {
-					aw = new ArrayList<>();
-					map.put(teamId, aw);
+			if (teamIds != null) {
+				for (String teamId : teamIds) {
+					List<IAward> aw = map.get(teamId);
+					if (aw == null) {
+						aw = new ArrayList<>();
+						map.put(teamId, aw);
+					}
+					aw.add(award);
 				}
-				aw.add(award);
 			}
 		}
 

--- a/Resolver/src/org/icpc/tools/resolver/TeamAwardPresentation.java
+++ b/Resolver/src/org/icpc/tools/resolver/TeamAwardPresentation.java
@@ -108,9 +108,11 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 						c.teamId = as.teamId;
 
 						for (IAward a : as.awards) {
-							for (String tId : a.getTeamIds()) {
-								if (tId.equals(c.teamId))
-									c.awards.add(a);
+							if (a.getTeamIds() != null) {
+								for (String tId : a.getTeamIds()) {
+									if (tId.equals(c.teamId))
+										c.awards.add(a);
+								}
 							}
 						}
 
@@ -425,7 +427,8 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			ITeam team = contest.getTeamById(currentCache.teamId);
 			IStanding s = contest.getStanding(team);
 			if (s.getNumSolved() == 1)
-				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId, Messages.getString("awardSolvedOne"), false));
+				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId,
+						Messages.getString("awardSolvedOne"), false));
 			else if (s.getNumSolved() > 1)
 				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId,
 						Messages.getString("awardSolvedMultiple").replace("{0}", s.getNumSolved() + ""), false));

--- a/Resolver/src/org/icpc/tools/resolver/awards/AbstractAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AbstractAwardDialog.java
@@ -89,13 +89,15 @@ public abstract class AbstractAwardDialog extends Dialog {
 			for (AwardType type : types)
 				if (type == null || type.equals(award.getAwardType())) {
 					String[] teamIds = award.getTeamIds();
-					for (String teamId : teamIds) {
-						ITeam team = previewContest.getTeamById(teamId);
-						IStanding standing = previewContest.getStanding(team);
+					if (teamIds != null) {
+						for (String teamId : teamIds) {
+							ITeam team = previewContest.getTeamById(teamId);
+							IStanding standing = previewContest.getStanding(team);
 
-						TableItem ti = new TableItem(previewTable, SWT.NONE);
-						ti.setText(new String[] { standing.getRank(), team.getId(), team.getActualDisplayName(),
-								award.getCitation() });
+							TableItem ti = new TableItem(previewTable, SWT.NONE);
+							ti.setText(new String[] { standing.getRank(), team.getId(), team.getActualDisplayName(),
+									award.getCitation() });
+						}
 					}
 				}
 		}

--- a/Resolver/src/org/icpc/tools/resolver/awards/EditAwardsDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/EditAwardsDialog.java
@@ -52,10 +52,12 @@ public class EditAwardsDialog extends Dialog {
 
 		for (IAward aw : previewContest.getAwards()) {
 			String[] teamIds = aw.getTeamIds();
-			for (String teamId : teamIds) {
-				if (teamId.equals(team.getId())) {
-					originalAwards.add(aw);
-					awards.add(aw);
+			if (teamIds != null) {
+				for (String teamId : teamIds) {
+					if (teamId.equals(team.getId())) {
+						originalAwards.add(aw);
+						awards.add(aw);
+					}
 				}
 			}
 		}
@@ -275,11 +277,16 @@ public class EditAwardsDialog extends Dialog {
 	}
 
 	private boolean isMultiTeamAwardSelected() {
+		if (selectedAward.getTeamIds() == null)
+			return false;
 		return selectedAward.getTeamIds().length > 1;
 	}
 
 	private void removeTeamFromAward() {
 		String[] teamIds = selectedAward.getTeamIds();
+		if (teamIds == null)
+			return;
+
 		String[] newTeamIds = new String[teamIds.length - 1];
 		int count = 0;
 		for (int i = 0; i < teamIds.length; i++) {
@@ -314,10 +321,12 @@ public class EditAwardsDialog extends Dialog {
 			for (IAward a : awards) {
 				TableItem ti = new TableItem(awardTable, SWT.NONE);
 				String name = a.getAwardType().getName();
-				if (a.getTeamIds().length == 2)
-					name += " (shared with 1 other team)";
-				else if (a.getTeamIds().length > 2)
-					name += " (shared with " + (a.getTeamIds().length - 1) + " other teams)";
+				if (a.getTeamIds() != null) {
+					if (a.getTeamIds().length == 2)
+						name += " (shared with 1 other team)";
+					else if (a.getTeamIds().length > 2)
+						name += " (shared with " + (a.getTeamIds().length - 1) + " other teams)";
+				}
 				ti.setText(name);
 				ti.setData(a);
 			}


### PR DESCRIPTION
This change handles two spec updates (because I'm lazy and they touched a couple of the same files):
- Teams can be hidden (will eventually replace group hidden flag)
- Award teamIds can be null (to signify the award hasn't been assigned yet)

Notes:
- If a team belongs to a hidden group then the CDS will automatically flag the team as hidden as well (in PlaybackContest), but nothing else does automatic conversion/migration. We should have a discussion on a future CLICS call to decide if any other compatibility is required. All of the ICPC tools use Contest.isTeamHidden() to check for hidden groups and this was updated to support hidden teams, so these tools shouldn't require any other changes.
- Column added to admin registration page to show hidden teams on the CDS.
- Null checks added to award teamIds to avoid any places that could cause NPE, but nothing else has been done to support this scenario.