### PR TITLE
Switch to DateTimeFormatter

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.net.URI;
 import java.text.ParseException;
+import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -116,7 +117,7 @@ public abstract class ContestObject implements IContestObject {
 		return Double.parseDouble((String) value);
 	}
 
-	protected static Long parseTimestamp(Object value) throws ParseException {
+	protected static Long parseTimestamp(Object value) throws DateTimeParseException {
 		return Timestamp.parse((String) value);
 	}
 


### PR DESCRIPTION
PR 410 actually caused a regression handling some timestamps. To avoid making it even more complicated, I switched to using the Java 8+ API for time handling that can handle all cases.