### PR TITLE
Fix regression in timestamp parsing

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/Timestamp.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/Timestamp.java
@@ -16,7 +16,7 @@ public class Timestamp {
 	// 2014-06-25T11:22:05.034Z
 	public static final DateTimeFormatter TIME_FORMAT;
 	static {
-		TIME_FORMAT = DateTimeFormatter.ofPattern("[yyyy-MM-dd]'T'[HH:mm:ss][.SSS][z][XXX][X]");
+		TIME_FORMAT = DateTimeFormatter.ofPattern("[yyyy-MM-dd]'T'[HH:mm:ss][HH:mm:s][.SSS][.S][z][XXX][X]");
 	}
 
 	public static long parseOld(String value) {
@@ -65,14 +65,16 @@ public class Timestamp {
 	/*public static void main(String[] args) {
 		String[] s = new String[] { "2014-06-25T11:22:05.034Z", "2014-06-25T11:22:05.034-02",
 				"2014-06-25T11:22:05.034+09", "2014-06-25T11:22:05.034-09:00", "2014-06-25T11:22:05.034-09:30",
-				"2014-06-25T11:22:05-09:00", "2014-06-25T11:22:05-09:30" };
+				"2014-06-25T11:22:05-09:00", "2014-06-25T11:22:05-09:30", "2014-06-25T11:22:05.034+01:00",
+				"2014-06-25T11:22:05.034+01", "2021-09-02T08:51:37.2-04:00", "2020-02-21T09:57:0.000-0500",
+				"2021-06-12T07:54:58.8-04:00" };
 		for (String o : s) {
 			try {
 				long num = parse(o);
 				System.out.println(o + " -> " + num);
 				System.out.println(format(num));
-				num = parse(format(num));
-				System.out.println(format(num));
+				long num2 = parse(format(num));
+				System.out.println(format(num2));
 			} catch (Exception e) {
 				e.printStackTrace();
 			}


### PR DESCRIPTION
Found some timestamps in older feeds that don't match the spec but the CDS was previously able to parse fine - single digit seconds or ms. Added these to the test and expanded the pattern to support.