### PR TITLE
Add top (%) award type

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IAward.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAward.java
@@ -25,6 +25,11 @@ public interface IAward extends IContestObject {
 		public String getPattern(int id) {
 			return regEx.replace(".*", id + "");
 		}
+
+		@Override
+		public String toString() {
+			return "AwardType [" + name + "/" + regEx + "]";
+		}
 	}
 
 	AwardType WINNER = new AwardType("Winner", "winner");
@@ -34,10 +39,11 @@ public interface IAward extends IContestObject {
 	AwardType GROUP = new AwardType("Group Winner", "group-winner-.*");
 	AwardType ORGANIZATION = new AwardType("Organization Winner", "organization-winner-.*");
 	AwardType GROUP_HIGHLIGHT = new AwardType("Group Highlight", "group-highlight-.*");
+	AwardType TOP = new AwardType("Top", "top-.*");
 	AwardType OTHER = new AwardType("Other", ".*");
 
 	AwardType[] KNOWN_TYPES = new AwardType[] { WINNER, RANK, MEDAL, FIRST_TO_SOLVE, GROUP, ORGANIZATION,
-			GROUP_HIGHLIGHT, OTHER };
+			GROUP_HIGHLIGHT, TOP, OTHER };
 
 	/**
 	 * Returns the ids of the teams that this award is for.

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -376,6 +376,36 @@ public class AwardUtil {
 		return lastBronze;
 	}
 
+	public static void createTopAwards(Contest contest, int percent) {
+		Award rank = new Award(IAward.TOP, "*", null, true);
+		rank.setCount(percent);
+		createTopAwards(contest, rank);
+	}
+
+	public static void createTopAwards(Contest contest, IAward template) {
+		if (template.getCount() < 1)
+			return;
+
+		ITeam[] teams = contest.getOrderedTeams();
+		if (teams.length == 0)
+			return;
+
+		int n = teams.length;
+		if (template.getCount() < 100)
+			n = template.getCount() * teams.length / 100;
+
+		String[] teamIds = new String[n];
+		for (int i = 0; i < n; i++)
+			teamIds[i] = teams[i].getId();
+
+		String citation = template.getCitation();
+		if (citation == null || citation.trim().length() < 1)
+			citation = Messages.getString("awardTop");
+		citation = citation.replace("{0}", template.getCount() + "");
+
+		contest.add(new Award(IAward.TOP, template.getId(), teamIds, citation, true));
+	}
+
 	public static int[] getMedalCounts(IContest contest) {
 		int[] num = new int[3];
 		IAward[] awards = contest.getAwards();
@@ -434,6 +464,8 @@ public class AwardUtil {
 				createRankAwards(contest, award);
 			} else if (award.getAwardType() == IAward.FIRST_TO_SOLVE) {
 				createFirstToSolveAwards(contest, award);
+			} else if (award.getAwardType() == IAward.TOP) {
+				createTopAwards(contest, award);
 			} else if (award.getAwardType() == IAward.MEDAL) {
 				if (award.getId().contains("gold"))
 					gold = award;
@@ -457,6 +489,8 @@ public class AwardUtil {
 			// createFirstToSolveAwards(contest, awardTemplate);
 		} else if (awardTemplate.getAwardType() == IAward.WINNER) {
 			createWinnerAward(contest, awardTemplate);
+		} else if (awardTemplate.getAwardType() == IAward.TOP) {
+			createTopAwards(contest, awardTemplate);
 		}
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
@@ -20,3 +20,4 @@ awardPlace={0} place
 awardSolvedOne=Solved 1 problem
 awardSolvedMultiple=Solved {0} problems
 awardSolving={0}, and solving {1} problems in {2} minutes
+awardTop=Top {0}% of teams

--- a/Resolver/src/org/icpc/tools/resolver/awards/TemplateAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/TemplateAwardDialog.java
@@ -32,6 +32,7 @@ public class TemplateAwardDialog extends AbstractAwardDialog {
 			"{\"id\":\"silver-medal\",\"count\":4}\n" + // silver medals
 			"{\"id\":\"bronze-medal\",\"count\":4}\n" + // bronze medals
 			"{\"id\":\"first-to-solve-*\"}\n" + // first to solve awards
+			"{\"id\":\"top-25\",\"count\":25}\n" + // top 25% of teams
 			"{\"id\":\"group-winner-*\"}"; // group winners
 
 	protected Text text;
@@ -110,7 +111,7 @@ public class TemplateAwardDialog extends AbstractAwardDialog {
 
 	@Override
 	protected AwardType[] getAwardTypes() {
-		return new AwardType[] { IAward.WINNER, IAward.FIRST_TO_SOLVE, IAward.GROUP, IAward.MEDAL };
+		return new AwardType[] { IAward.WINNER, IAward.FIRST_TO_SOLVE, IAward.GROUP, IAward.MEDAL, IAward.TOP };
 	}
 
 	protected Award parseAward(JsonObject data) {


### PR DESCRIPTION
Adds an award type that can be applied via template to the top x% of all teams. e.g. adding the following to the template dialog will give the top 25% of all teams an award that says "High honours": {"id":"top-25","count":25,"citation":"High honours"}.