### PR TITLE
Award Util support for PUTing awards

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -903,7 +903,7 @@ public class ContestRESTService extends HttpServlet {
 		} else {
 			try {
 				RESTContestSource restSource = (RESTContestSource) source;
-				return restSource.postClarification(obj);
+				return restSource.post(ContestType.CLARIFICATION, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY,
 						"Error submitting clarification to CCS: " + e.getMessage());
@@ -951,7 +951,7 @@ public class ContestRESTService extends HttpServlet {
 		} else {
 			try {
 				RESTContestSource restSource = (RESTContestSource) source;
-				return restSource.postAward(obj);
+				return restSource.post(ContestType.AWARD, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
 				return null;
@@ -992,7 +992,7 @@ public class ContestRESTService extends HttpServlet {
 		} else {
 			try {
 				RESTContestSource restSource = (RESTContestSource) source;
-				restSource.patchAward(obj);
+				restSource.patch(ContestType.AWARD, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
 				return;
@@ -1024,7 +1024,7 @@ public class ContestRESTService extends HttpServlet {
 		} else {
 			try {
 				RESTContestSource restSource = (RESTContestSource) source;
-				restSource.deleteAward(id);
+				restSource.delete(ContestType.AWARD, id);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
 				return;

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -403,7 +403,7 @@ public class AwardUtil {
 			citation = Messages.getString("awardTop");
 		citation = citation.replace("{0}", template.getCount() + "");
 
-		contest.add(new Award(IAward.TOP, template.getId(), teamIds, citation, true));
+		contest.add(new Award(IAward.TOP, template.getId().substring(4), teamIds, citation, true));
 	}
 
 	public static int[] getMedalCounts(IContest contest) {


### PR DESCRIPTION
Added a button to the Award UI named "Upload" that is only enabled when you're connected to a contest via REST. Clicking this button PUTs all awards to the server. This overwrites any of these award ids that exist (provided you have access) but does not affect any other award ids. As such there's a warning when you click the button and we need to decide what the options/behaviour should be long term.

To enable this I found it was more convenient to have post/patch/put/delete methods that accept a contest type + object instead of a json object. I also made the methods generic so they can accept any contest object. This means the methods can't have type-specific information, but that's covered in the spec and means we don't need separate methods for every type.

Also noticed that the top award generation was making the award id "top-top-x", so fixed that.