### PR TITLE
Fix missing app icons

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
@@ -65,6 +65,7 @@ import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.util.ArgumentParser;
 import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
+import org.icpc.tools.contest.model.util.Taskbar;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 
@@ -996,6 +997,8 @@ public class BalloonUtility {
 		});
 
 		Display.setAppName("Balloon Utility");
+		Taskbar.setTaskbarImage(BalloonUtility.class.getResourceAsStream("/images/balloonIcon.png"));
+
 		Display display = new Display();
 		final Shell shell = new Shell(display);
 		Image image = new Image(display, BalloonUtility.class.getResourceAsStream("/images/balloonIcon.png"));

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -15,7 +15,6 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
-import java.awt.Image;
 import java.awt.Label;
 import java.awt.Panel;
 import java.awt.Rectangle;
@@ -30,7 +29,6 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
-import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -61,6 +59,7 @@ import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.util.ArgumentParser;
 import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
+import org.icpc.tools.contest.model.util.Taskbar;
 
 import uk.co.caprica.vlcj.factory.MediaPlayerFactory;
 import uk.co.caprica.vlcj.player.base.MediaPlayer;
@@ -888,7 +887,7 @@ public class CoachView extends Panel {
 		try {
 			BufferedImage image = ImageIO.read(CoachView.class.getClassLoader().getResource("images/coachViewIcon.png"));
 			frame.setIconImage(image);
-			setTaskbarImage(image);
+			Taskbar.setTaskbarImage(image);
 		} catch (Exception e) {
 			// could not set icon
 		}
@@ -979,35 +978,6 @@ public class CoachView extends Panel {
 			device.setDisplayMode(bestMode);
 
 		requestFocus();
-	}
-
-	private static void setTaskbarImage(Image iconImage) {
-		// call java.awt.Taskbar.getTaskbar().setIconImage() (Java 9+) or
-		// for Mac Java 8 call com.apple.eawt.Application.getApplication().setDockIconImage()
-		// without direct dependencies
-		try {
-			Class<?> c = Class.forName("java.awt.Taskbar");
-			Method m = c.getDeclaredMethod("getTaskbar");
-			Object o = m.invoke(null);
-			m = c.getDeclaredMethod("setIconImage", Image.class);
-			m.invoke(o, iconImage);
-			return;
-		} catch (Exception e) {
-			// ignore
-		}
-
-		if (!System.getProperty("os.name").contains("Mac"))
-			return;
-
-		try {
-			Class<?> c = Class.forName("com.apple.eawt.Application");
-			Method m = c.getDeclaredMethod("getApplication");
-			Object o = m.invoke(null);
-			m = c.getDeclaredMethod("setDockIconImage", Image.class);
-			m.invoke(o, iconImage);
-		} catch (Exception e) {
-			// ignore
-		}
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/util/Taskbar.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/Taskbar.java
@@ -1,0 +1,50 @@
+package org.icpc.tools.contest.model.util;
+
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+import javax.imageio.ImageIO;
+
+public class Taskbar {
+	public static void setTaskbarImage(InputStream in) {
+		try {
+			BufferedImage image = ImageIO.read(in);
+			if (image != null)
+				Taskbar.setTaskbarImage(image);
+		} catch (IOException e) {
+			// could not set icon
+		}
+	}
+
+	public static void setTaskbarImage(Image iconImage) {
+		// call java.awt.Taskbar.getTaskbar().setIconImage() (Java 9+) or
+		// for Mac Java 8 call com.apple.eawt.Application.getApplication().setDockIconImage()
+		// without direct dependencies
+		try {
+			Class<?> c = Class.forName("java.awt.Taskbar");
+			Method m = c.getDeclaredMethod("getTaskbar");
+			Object o = m.invoke(null);
+			m = c.getDeclaredMethod("setIconImage", Image.class);
+			m.invoke(o, iconImage);
+			return;
+		} catch (Exception e) {
+			// ignore
+		}
+
+		if (!System.getProperty("os.name").contains("Mac"))
+			return;
+
+		try {
+			Class<?> c = Class.forName("com.apple.eawt.Application");
+			Method m = c.getDeclaredMethod("getApplication");
+			Object o = m.invoke(null);
+			m = c.getDeclaredMethod("setDockIconImage", Image.class);
+			m.invoke(o, iconImage);
+		} catch (Exception e) {
+			// ignore
+		}
+	}
+}

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
@@ -18,6 +18,7 @@ import org.icpc.tools.contest.model.feed.CDSUtil;
 import org.icpc.tools.contest.model.util.ArgumentParser;
 import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
 import org.icpc.tools.contest.model.util.ArgumentParser.Source;
+import org.icpc.tools.contest.model.util.Taskbar;
 
 public class Admin {
 	public static void main(String[] args) {
@@ -68,6 +69,8 @@ public class Admin {
 		View v = new View(url, source.user, source.password);
 
 		Display.setAppName("Presentation Admin");
+		Taskbar.setTaskbarImage(Admin.class.getClassLoader().getResourceAsStream("images/adminIcon.png"));
+
 		final Display display = new Display();
 		ImageResource.initializeImageRegistry(v.getClass(), display);
 		PresentationHelper.setDisplay(display);

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -21,7 +21,6 @@ import java.awt.Toolkit;
 import java.awt.Transparency;
 import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
-import java.lang.reflect.Method;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +32,7 @@ import java.util.concurrent.locks.LockSupport;
 import javax.imageio.ImageIO;
 
 import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.util.Taskbar;
 import org.icpc.tools.presentation.core.DisplayConfig;
 import org.icpc.tools.presentation.core.DisplayConfig.Mode;
 import org.icpc.tools.presentation.core.Presentation;
@@ -246,7 +246,7 @@ public class PresentationWindowImpl extends PresentationWindow {
 		super(title);
 
 		setIconImage(iconImage);
-		setTaskbarImage(iconImage);
+		Taskbar.setTaskbarImage(iconImage);
 
 		nanoTimeDelta = System.currentTimeMillis() * 1000000L - System.nanoTime();
 
@@ -914,34 +914,5 @@ public class PresentationWindowImpl extends PresentationWindow {
 	@Override
 	public void update(Graphics g) {
 		paint(g);
-	}
-
-	private static void setTaskbarImage(Image iconImage) {
-		// call java.awt.Taskbar.getTaskbar().setIconImage() (Java 9+) or
-		// for Mac Java 8 call com.apple.eawt.Application.getApplication().setDockIconImage()
-		// without direct dependencies
-		try {
-			Class<?> c = Class.forName("java.awt.Taskbar");
-			Method m = c.getDeclaredMethod("getTaskbar");
-			Object o = m.invoke(null);
-			m = c.getDeclaredMethod("setIconImage", Image.class);
-			m.invoke(o, iconImage);
-			return;
-		} catch (Exception e) {
-			// ignore
-		}
-
-		if (!System.getProperty("os.name").contains("Mac"))
-			return;
-
-		try {
-			Class<?> c = Class.forName("com.apple.eawt.Application");
-			Method m = c.getDeclaredMethod("getApplication");
-			Object o = m.invoke(null);
-			m = c.getDeclaredMethod("setDockIconImage", Image.class);
-			m.invoke(o, iconImage);
-		} catch (Exception e) {
-			// ignore
-		}
 	}
 }

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -1,13 +1,11 @@
 package org.icpc.tools.resolver;
 
-import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.PrintWriter;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +31,7 @@ import org.icpc.tools.contest.model.resolver.ResolverLogic.PredeterminedStep;
 import org.icpc.tools.contest.model.util.ArgumentParser;
 import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
 import org.icpc.tools.contest.model.util.AwardUtil;
+import org.icpc.tools.contest.model.util.Taskbar;
 import org.icpc.tools.contest.model.util.TeamDisplay;
 import org.icpc.tools.presentation.contest.internal.PresentationClient;
 import org.icpc.tools.presentation.core.DisplayConfig;
@@ -150,35 +149,6 @@ public class Resolver {
 		System.out.println("     i      - Toggle additional info");
 	}
 
-	private static void setTaskbarImage(Image iconImage) {
-		// call java.awt.Taskbar.getTaskbar().setIconImage() (Java 9+) or
-		// for Mac Java 8 call com.apple.eawt.Application.getApplication().setDockIconImage()
-		// without direct dependencies
-		try {
-			Class<?> c = Class.forName("java.awt.Taskbar");
-			Method m = c.getDeclaredMethod("getTaskbar");
-			Object o = m.invoke(null);
-			m = c.getDeclaredMethod("setIconImage", Image.class);
-			m.invoke(o, iconImage);
-			return;
-		} catch (Exception e) {
-			// ignore
-		}
-
-		if (!System.getProperty("os.name").contains("Mac"))
-			return;
-
-		try {
-			Class<?> c = Class.forName("com.apple.eawt.Application");
-			Method m = c.getDeclaredMethod("getApplication");
-			Object o = m.invoke(null);
-			m = c.getDeclaredMethod("setDockIconImage", Image.class);
-			m.invoke(o, iconImage);
-		} catch (Exception e) {
-			// ignore
-		}
-	}
-
 	public static void main(String[] args) {
 		String log = "resolver";
 		List<String> argList = Arrays.asList(args);
@@ -214,7 +184,7 @@ public class Resolver {
 		} catch (Exception e) {
 			// could not set title or icon
 		}
-		setTaskbarImage(iconImage);
+		Taskbar.setTaskbarImage(iconImage);
 
 		for (ContestSource cs : contestSource)
 			cs.outputValidation();

--- a/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
@@ -45,6 +45,7 @@ import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.util.AwardUtil;
+import org.icpc.tools.contest.model.util.Taskbar;
 
 public class AwardUI {
 	private static final String PREF_ID = "org.icpc.tools.award";
@@ -669,6 +670,8 @@ public class AwardUI {
 		}
 
 		Display.setAppName("Award Utility");
+		Taskbar.setTaskbarImage(AwardUI.class.getResourceAsStream("/images/resolverIcon.png"));
+
 		Display display = new Display();
 
 		final Shell shell = new Shell(display);


### PR DESCRIPTION
Application icons (e.g. on the dock on Mac) were missing for SWT apps. Not sure if it's a regression or how, but fixed this by using the same code that was being used for AWT apps. Made a common method in ContestModel - even though it's not the 'correct' place, it's one place where all apps can use it from.