### PR TITLE
Support for Honors (score compared with a team at a given percentile)…

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IAward.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAward.java
@@ -39,11 +39,14 @@ public interface IAward extends IContestObject {
 	AwardType GROUP = new AwardType("Group Winner", "group-winner-.*");
 	AwardType ORGANIZATION = new AwardType("Organization Winner", "organization-winner-.*");
 	AwardType GROUP_HIGHLIGHT = new AwardType("Group Highlight", "group-highlight-.*");
+	AwardType SOLVED = new AwardType("Solved", "solved-.*");
 	AwardType TOP = new AwardType("Top", "top-.*");
+	AwardType HONORS = new AwardType("Honors", "honors-.*");
+	// AwardType HONORABLE_MENTION = new AwardType("Honorable Mention", "honorable-mention");
 	AwardType OTHER = new AwardType("Other", ".*");
 
 	AwardType[] KNOWN_TYPES = new AwardType[] { WINNER, RANK, MEDAL, FIRST_TO_SOLVE, GROUP, ORGANIZATION,
-			GROUP_HIGHLIGHT, TOP, OTHER };
+			GROUP_HIGHLIGHT, SOLVED, TOP, HONORS, OTHER };
 
 	/**
 	 * Returns the ids of the teams that this award is for.
@@ -60,11 +63,11 @@ public interface IAward extends IContestObject {
 	AwardType getAwardType();
 
 	/**
-	 * Return the number of awards given.
+	 * Return the awards for an award template, e.g. number of awards given.
 	 *
 	 * @return
 	 */
-	int getCount();
+	String getParameter();
 
 	/**
 	 * Return the citation for this award.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
@@ -13,12 +13,12 @@ public class Award extends ContestObject implements IAward {
 	public static final String CITATION = "citation";
 	public static final String TEAM_IDS = "team_ids";
 	public static final String SHOW = "show";
-	public static final String COUNT = "count";
+	public static final String PARAMETER = "parameter";
 
 	private String[] teamIds;
 	private boolean show = true;
 	private String citation;
-	private int count = -1;
+	private String parameter;
 
 	public Award() {
 		// create an empty award
@@ -79,8 +79,8 @@ public class Award extends ContestObject implements IAward {
 		this.citation = citation;
 	}
 
-	public void setCount(int count) {
-		this.count = count;
+	public void setParameter(String parameter) {
+		this.parameter = parameter;
 	}
 
 	@Override
@@ -93,8 +93,8 @@ public class Award extends ContestObject implements IAward {
 	}
 
 	@Override
-	public int getCount() {
-		return count;
+	public String getParameter() {
+		return parameter;
 	}
 
 	@Override
@@ -115,8 +115,8 @@ public class Award extends ContestObject implements IAward {
 		} else if (name.equals(SHOW)) {
 			show = parseBoolean(value);
 			return true;
-		} else if (name.equals(COUNT)) {
-			count = parseInt(value);
+		} else if (name.equals(PARAMETER)) {
+			parameter = (String) value;
 			return true;
 		}
 
@@ -135,8 +135,8 @@ public class Award extends ContestObject implements IAward {
 		}
 		if (show == false)
 			props.put(SHOW, show);
-		if (count >= 0)
-			props.put(COUNT, count);
+		if (parameter != null)
+			props.put(PARAMETER, parameter);
 	}
 
 	@Override
@@ -152,8 +152,8 @@ public class Award extends ContestObject implements IAward {
 		}
 		if (show == false)
 			je.encode(SHOW, show);
-		if (count >= 0)
-			je.encode(COUNT, count);
+		if (parameter != null)
+			je.encode(PARAMETER, parameter);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
@@ -21,3 +21,5 @@ awardSolvedOne=Solved 1 problem
 awardSolvedMultiple=Solved {0} problems
 awardSolving={0}, and solving {1} problems in {2} minutes
 awardTop=Top {0}% of teams
+awardHonors={0}% Honors
+awardHonorableMention=Honorable mention


### PR DESCRIPTION
… awards

Added support for awards based on a range of teams that have a score less than a given percentile. This allows us to do:
`{"id":"honors-high","parameter":"0-25", "citation":"High Honors"}`
or
`{"id":"honors-regular","parameter":"25-50", "citation":"Honors"}`
or
`{"id":"honors-mention","parameter":"50-100"}`
(citation automatically defaults to Honorable Mention)

For the record, it was seriously difficult to stick to US English here and not spell honourable correctly. ;-)