### PR TITLE
Minor emoji tweaks

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/TextHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/TextHelper.java
@@ -76,7 +76,12 @@ public class TextHelper {
 
 			// detect if the font can be used to display the current character
 			int curSegment = -1;
-			if (codePoint != ZERO_WIDTH_JOINER && font.canDisplay(codePoint)) {
+			if (codePoint == ZERO_WIDTH_JOINER) {
+				// keep with last
+				curSegment = lastSegment;
+				if (curSegment == 2)
+					emojiList.add(codePoint);
+			} else if (font.canDisplay(codePoint)) {
 				curSegment = 1;
 			} else {
 				curSegment = 2;
@@ -150,7 +155,7 @@ public class TextHelper {
 		BufferedImage img = getEmoji(hex);
 		Text t = new Text();
 		// TODO should resize emojis when we scale text
-		t.img = ImageScaler.scaleImage(img, height, height);
+		t.img = ImageScaler.scaleImage(img, height - 2, height - 2);
 		t.dx = (int) xx;
 		xx += t.img.getWidth();
 		h = Math.max(h, t.img.getHeight());
@@ -170,20 +175,22 @@ public class TextHelper {
 	}
 
 	public void draw(int x, int y) {
+		FontMetrics fm = g.getFontMetrics();
 		for (Text t : list) {
 			if (t.gv != null)
 				g.drawGlyphVector(t.gv, x + t.dx, y);
 			else
-				g.drawImage(t.img, x + (int) t.dx, y - t.img.getHeight(), null);
+				g.drawImage(t.img, x + (int) t.dx, y + fm.getDescent() - t.img.getHeight() - 1, null);
 		}
 	}
 
 	public void draw(float x, float y) {
+		FontMetrics fm = g.getFontMetrics();
 		for (Text t : list) {
 			if (t.gv != null)
 				g.drawGlyphVector(t.gv, x + t.dx, y);
 			else
-				g.drawImage(t.img, (int) (x + t.dx), (int) y - t.img.getHeight(), null);
+				g.drawImage(t.img, (int) (x + t.dx), (int) y + fm.getDescent() - t.img.getHeight() - 1, null);
 		}
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
@@ -254,7 +254,8 @@ public class TeamTileHelper {
 		String s = team.getActualDisplayName();
 
 		g.setColor(Color.WHITE);
-		TextHelper text = new TextHelper(g, s + " 10", tileDim.width - tileDim.height - ww - IN_TILE_GAP * 2 - 2);
+		TextHelper text = new TextHelper(g, s,
+				tileDim.width - tileDim.height - ww - IN_TILE_GAP * 2 - 2 - fm.stringWidth(" 10"));
 		text.draw(ww + tileDim.height + IN_TILE_GAP, (tileDim.height * 7 / 10 + fm.getAscent()) / 2 - 2);
 	}
 


### PR DESCRIPTION
Fixed a regression in tile presentations, vertically centered emoji, and made the zero-width joiner stick with the current segment, since it could be used in normal text.