### PR TITLE
Support for reading config from 2020 CMS

### DIFF
--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -780,6 +780,13 @@ public class ImagesGenerator {
 		Arrays.sort(orgs, new Comparator<IOrganization>() {
 			@Override
 			public int compare(IOrganization o1, IOrganization o2) {
+				try {
+					Integer i1 = Integer.parseInt(o1.getId());
+					Integer i2 = Integer.parseInt(o2.getId());
+					return Integer.compare(i1, i2);
+				} catch (Exception e) {
+					// ignore
+				}
 				return o1.getId().compareTo(o2.getId());
 			}
 		});


### PR DESCRIPTION
Am I happy with this code? No. Is it likely to require changes even in the next week? Yes. Cleanup afterwards? Are there some hardcoded bits? Absolutely.

The bulk of the change is reading directly into Contest API objects instead of the intermediate CMS objects that were there before. This means that you can import from .tsv or other formats, do any manipulation using standard mechanisms, and easily save to .tsv or .json formats. I had this part in a nice simpler commit but messed up my git history so it'll have to go in as one chunk now.