### PR TITLE
Show resolver version in splash, move selection up one

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -687,7 +687,7 @@ public class ResolverLogic {
 	 */
 	private int getScrollToCurrentRow(int currentRow, int lastMedalRow) {
 		// TODOint offset = scoreboardPresentation.getTeamsPerScreen() - 2;
-		int offset = 12 - 2;
+		int offset = 12 - 3;
 		if (currentRow < lastMedalRow)
 			offset -= rowOffset;
 

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -824,16 +824,19 @@ public class PresentationWindowImpl extends PresentationWindow {
 				}
 			}
 			int hh = 0;
+			Dimension d = getSize();
 			if (logo != null) {
-				Dimension d = getSize();
 				hh = d.height / 2;
 				g.drawImage(logo, (d.width - hh) / 2, (d.height - hh) / 2 - 15, hh, hh, null);
 			}
 			g.setColor(Color.WHITE);
 			FontMetrics fm = g.getFontMetrics();
 			String s = "No presentation assigned";
-			Dimension d = getSize();
 			g.drawString(s, (d.width - fm.stringWidth(s)) / 2, (d.height) * 7 / 8);
+
+			g.setColor(Color.DARK_GRAY);
+			s = Trace.getVersion();
+			g.drawString(s, (d.width - fm.stringWidth(s)) / 2, d.height - 20);
 		}
 		if (showFPS) {
 			g.setColor(Color.WHITE);

--- a/Resolver/src/org/icpc/tools/resolver/SplashPresentation.java
+++ b/Resolver/src/org/icpc/tools/resolver/SplashPresentation.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 
 import javax.imageio.ImageIO;
 
+import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
@@ -198,5 +199,11 @@ public class SplashPresentation extends AbstractICPCPresentation {
 
 		g.setFont(smallFont);
 		g.drawString(conceptOrg, col1 - fm2.stringWidth(conceptOrg), h);
+
+		g.setColor(Color.DARK_GRAY);
+		g.setFont(smallFont);
+		fm = g.getFontMetrics();
+		s = Messages.getString(Trace.getVersion());
+		g.drawString(s, width - BORDER - fm.stringWidth(s), height - BORDER);
 	}
 }


### PR DESCRIPTION
Requested at finals 2019:
- Adding the version to the resolver splash screen. You can find this in the logs, but easier to be able to see if you're on the latest onscreen. Also added to the 'no presentation' client screen.
- Move the 'selected row' up by one so it's not quite so close to the bottom of the screen.