### PR TITLE
Move resolver UI code where it belongs

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -116,7 +116,6 @@ public class ResolverLogic {
 
 	// which row to start single-stepping on
 	private int singleStepStartRow;
-	private int rowOffset;
 	private boolean calculateProjections;
 
 	// map from all the teamIds getting an award to the list of awards they're getting
@@ -130,11 +129,10 @@ public class ResolverLogic {
 
 	private List<PredeterminedStep> predeterminedSteps = new ArrayList<>();
 
-	public ResolverLogic(Contest contest, int singleStepStartRow, int rowOffset, boolean calculateProjections,
+	public ResolverLogic(Contest contest, int singleStepStartRow, boolean calculateProjections,
 			List<PredeterminedStep> predeterminedSteps) {
 		finalContest = filter(contest);
 		this.singleStepStartRow = singleStepStartRow;
-		this.rowOffset = rowOffset;
 		this.calculateProjections = calculateProjections;
 		this.predeterminedSteps = predeterminedSteps;
 		if (predeterminedSteps == null)
@@ -291,9 +289,8 @@ public class ResolverLogic {
 		steps.add(new PresentationStep(PresentationStep.Presentations.SCOREBOARD));
 		steps.add(new PauseStep());
 
-		// second click - scroll down to bottom (so last team is at bottom of screen),
-		// turn off the scoreboard presentation Legend, then do nothing else
-		steps.add(new ScrollStep(getScrollToCurrentRow(contest.getNumTeams() - 1, 0)));
+		// second click - scroll down to bottom (so last team is at bottom of screen)
+		steps.add(new ScrollStep(contest.getOrderedTeams().length - 1));
 		steps.add(new PauseStep());
 
 		// third click - select the team or switch to judge queue
@@ -445,7 +442,7 @@ public class ResolverLogic {
 			}
 
 			// scroll to row
-			steps.add(new ScrollStep(getScrollToCurrentRow(currentRow, singleStepStartRow)));
+			steps.add(new ScrollStep(currentRow));
 
 			// highlight team
 			boolean doneWithRow = false;
@@ -672,26 +669,6 @@ public class ResolverLogic {
 		teams = finalContest.getOrderedTeams();
 		next = teams[row - 1];
 		return numSolved == finalContest.getStanding(next).getNumSolved();
-	}
-
-	/**
-	 * Returns the row number which should be put at the TOP of the screen in order to have the
-	 * "currentRow" at the desired position on the screen. "Desired position" is normally at the
-	 * BOTTOM; in this case the returned "scroll-to row" is above the "currentRow" by a constant
-	 * based on the number of teams which should appear on one screen. A special case where "desired
-	 * position" is NOT at the bottom is when the command-line option "--offsetMedalDisplay" has
-	 * been specified; in this case the intent is to position the "currentRow" some number of rows
-	 * upward (offsetting it above the heads of Bronze Medalists on-stage).
-	 *
-	 * @return the row number which should be at the top of the screen
-	 */
-	private int getScrollToCurrentRow(int currentRow, int lastMedalRow) {
-		// TODOint offset = scoreboardPresentation.getTeamsPerScreen() - 2;
-		int offset = 12 - 3;
-		if (currentRow < lastMedalRow)
-			offset -= rowOffset;
-
-		return Math.max(0, currentRow - offset);
 	}
 
 	/**

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -531,7 +531,7 @@ public class Resolver {
 			// create the official scoreboard
 			cc.officialResults();
 
-			ResolverLogic logic = new ResolverLogic(cc, singleStepStartRow, rowOffset, show_info, predeterminedSteps);
+			ResolverLogic logic = new ResolverLogic(cc, singleStepStartRow, show_info, predeterminedSteps);
 
 			long time = System.currentTimeMillis();
 			List<ResolutionStep> subSteps = logic.resolveFrom(bill);
@@ -549,8 +549,7 @@ public class Resolver {
 			// create the official scoreboard
 			finalContest.officialResults();
 
-			ResolverLogic logic = new ResolverLogic(finalContest, singleStepStartRow, rowOffset, show_info,
-					predeterminedSteps);
+			ResolverLogic logic = new ResolverLogic(finalContest, singleStepStartRow, show_info, predeterminedSteps);
 
 			int showHour = -1;
 			if (showHour > 0) {
@@ -572,7 +571,7 @@ public class Resolver {
 
 	protected void launch(List<ResolutionStep> steps) {
 		ui = new ResolverUI(steps, show_info, new DisplayConfig(displayStr, multiDisplayStr),
-				isPresenter || client == null, screen, new ClickListener() {
+				isPresenter || client == null, rowOffset, screen, new ClickListener() {
 					@Override
 					public void clicked(int num) {
 						clicks = num;

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -101,14 +101,16 @@ public class ResolverUI {
 
 	private long lastClickTime = -1;
 	private Thread thread;
+	private int rowOffset;
 
 	public ResolverUI(List<ResolutionStep> steps, boolean showInfo, DisplayConfig displayConfig, boolean isPresenter,
-			Screen screen, ClickListener listener) {
+			int rowOffset, Screen screen, ClickListener listener) {
 		this.steps = steps;
 		this.showInfo = showInfo;
 		this.displayConfig = displayConfig;
 		this.isPresenter = isPresenter;
 		this.screen = screen;
+		this.rowOffset = rowOffset;
 		if (screen == null)
 			this.screen = Screen.MAIN;
 		this.listener = listener;
@@ -465,7 +467,8 @@ public class ResolverUI {
 			teamListPresentation.scrollIt(scroll.top);
 		} else if (step instanceof ScrollStep) {
 			ScrollStep scroll = (ScrollStep) step;
-			scoreboardPresentation.setScrollToRow(scroll.row);
+			int row = Math.max(0, scroll.row - scoreboardPresentation.getNumRows() - rowOffset + 3);
+			scoreboardPresentation.setScrollToRow(row);
 		} else if (step instanceof PresentationStep) {
 			PresentationStep pstep = (PresentationStep) step;
 			if (pstep.p == PresentationStep.Presentations.SPLASH)


### PR DESCRIPTION
The unchanged 'TODO' in ResolverLogic 689 was bugging me, so I went back and fixed it properly - how to adjust the scrolling to account for how many teams are shown onscreen just shouldn't be in the generic resolver logic. I moved this to the UI side where it can correctly adjust for any changes.