### PR TITLE
Client arg help and ubuntu fix

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
@@ -135,7 +135,7 @@ public class ArgumentParser {
 		return cs;
 	}
 
-	private static Source parseSource(List<Object> args) {
+	private static Source parseSource(List<Object> args, OptionParser parser) {
 		Source source = null;
 		try {
 			if (args.size() == 3) {
@@ -144,10 +144,14 @@ public class ArgumentParser {
 			} else if (args.size() == 1) {
 				expectOptions("Contest source", args, "url:string");
 				source = parseMultiSource((String) args.get(0), null, null);
-			} else
+			} else {
 				Trace.trace(Trace.ERROR, "Invalid contest source");
+				parser.showHelp();
+				System.exit(1);
+			}
 		} catch (IOException e) {
 			Trace.trace(Trace.ERROR, "Invalid contest source: " + e.getMessage());
+			parser.showHelp();
 			System.exit(1);
 		}
 
@@ -158,7 +162,7 @@ public class ArgumentParser {
 			throws IllegalArgumentException {
 		if (option == null) {
 			if (!list.isEmpty())
-				return parseSource(list);
+				return parseSource(list, parser);
 
 			throw new IllegalArgumentException("Options without argument");
 		}
@@ -185,7 +189,11 @@ public class ArgumentParser {
 	 * @throws IllegalArgumentException
 	 */
 	public static ContestSource parse(String[] args, OptionParser parser) throws IllegalArgumentException {
-		return parseMulti(args, parser)[0];
+		ContestSource[] sources = parseMulti(args, parser);
+		if (sources == null || sources.length < 1)
+			return null;
+
+		return sources[0];
 	}
 
 	private static ContestSource[] convertMulti(Source source) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -85,6 +85,11 @@ public class ClientLauncher {
 			}
 		});
 
+		if (contestSource == null) {
+			showHelp();
+			return;
+		}
+
 		RESTContestSource cdsSource = RESTContestSource.ensureCDS(contestSource);
 		cdsSource.outputValidation();
 		cdsSource.checkForUpdates("presentations-");
@@ -123,7 +128,7 @@ public class ClientLauncher {
 				}
 			}
 		});
-		client.connect();
+		client.connect(false);
 	}
 
 	protected static void createWindow(final PresentationClient client, final boolean sendthumbnails, boolean showFPS) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -69,7 +69,7 @@ public class StandaloneLauncher {
 		});
 
 		if (source == null) {
-			Trace.trace(Trace.ERROR, "Must provide a contest source");
+			showHelp(presentations);
 			return;
 		}
 

--- a/PresCore/src/org/icpc/tools/client/core/BasicClient.java
+++ b/PresCore/src/org/icpc/tools/client/core/BasicClient.java
@@ -583,7 +583,7 @@ public class BasicClient {
 	}
 
 	public void connect() {
-		connect(false);
+		connect(true);
 	}
 
 	public void connect(boolean daemon) {

--- a/PresCore/src/org/icpc/tools/client/core/BasicClient.java
+++ b/PresCore/src/org/icpc/tools/client/core/BasicClient.java
@@ -583,6 +583,10 @@ public class BasicClient {
 	}
 
 	public void connect() {
+		connect(false);
+	}
+
+	public void connect(boolean daemon) {
 		Thread connectionThread = new Thread("Client connection thread") {
 			// try to connect right away, then add some incremental back-off
 			private int[] DELAY = new int[] { 2, 5, 20 };
@@ -609,7 +613,7 @@ public class BasicClient {
 		};
 
 		connectionThread.setPriority(Thread.NORM_PRIORITY + 1);
-		connectionThread.setDaemon(true);
+		connectionThread.setDaemon(daemon);
 		connectionThread.start();
 	}
 


### PR DESCRIPTION
This change does three things (because I'm lazy):
- Fixes an NPE regression when you don't specify any args to the tools.
- Outputs the help when you don't specify a contest or have an incorrect number of args.
- Switches the presentation client back to using a daemon thread, because ubuntu (see issue #323).