### PR TITLE
Start to standardize --bill

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IAward.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAward.java
@@ -32,6 +32,15 @@ public interface IAward extends IContestObject {
 		}
 	}
 
+	// An optional attribute that controls how to display the award in the resolver.
+	// The default 'detail' (or null/missing display mode) will stop to show the team photo and
+	// details.
+	// 'Pause' will pause but then move on.
+	// 'List' will stop to show a list, but only after all teams have been resolved.
+	public enum DisplayMode {
+		DETAIL, PAUSE, LIST
+	}
+
 	AwardType WINNER = new AwardType("Winner", "winner");
 	AwardType RANK = new AwardType("Rank", "rank-.*");
 	AwardType MEDAL = new AwardType("Medal", ".*-medal");
@@ -77,10 +86,9 @@ public interface IAward extends IContestObject {
 	String getCitation();
 
 	/**
-	 * Returns <code>true</code> if the award should be recognized by showing on a separate screen
-	 * with the teams photo or other graphics, and <code>false</code> otherwise.
+	 * Returns the resolver display mode.
 	 *
 	 * @return
 	 */
-	boolean showAward();
+	DisplayMode getDisplayMode();
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/XMLFeedWriter.java
@@ -254,10 +254,8 @@ public class XMLFeedWriter {
 			writeStart(XMLFeedParser.AWARD);
 			write("id", a.getId());
 			write("citation", a.getCitation());
-			if (a.showAward())
-				write("show", "true");
-			else
-				write("show", "false");
+			if (a.getDisplayMode() != null)
+				write("display_mode", a.getDisplayMode().name().toLowerCase());
 			if (a.getTeamIds() != null)
 				for (String t : a.getTeamIds())
 					write("teamId", t);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
@@ -13,10 +13,11 @@ public class Award extends ContestObject implements IAward {
 	public static final String CITATION = "citation";
 	public static final String TEAM_IDS = "team_ids";
 	public static final String SHOW = "show";
+	public static final String DISPLAY_MODE = "display_mode";
 	public static final String PARAMETER = "parameter";
 
 	private String[] teamIds;
-	private boolean show = true;
+	private DisplayMode mode;
 	private String citation;
 	private String parameter;
 
@@ -24,27 +25,31 @@ public class Award extends ContestObject implements IAward {
 		// create an empty award
 	}
 
-	public Award(AwardType type, String teamId, String citation, boolean show) {
-		this(type.getPattern(""), new String[] { teamId }, citation, show);
+	public Award(AwardType type, String teamId, String citation) {
+		this(type.getPattern(""), new String[] { teamId }, citation);
 	}
 
-	public Award(AwardType type, int id, String teamId, String citation, boolean show) {
-		this(type.getPattern(id + ""), new String[] { teamId }, citation, show);
+	public Award(AwardType type, String id, String[] teamIds, String citation) {
+		this(type.getPattern(id), teamIds, citation);
 	}
 
-	public Award(AwardType type, int id, String[] teamIds, String citation, boolean show) {
-		this(type.getPattern(id + ""), teamIds, citation, show);
+	private Award(String id, String[] teamIds, String citation) {
+		this(id, teamIds, citation, null);
 	}
 
-	public Award(AwardType type, String id, String[] teamIds, String citation, boolean show) {
-		this(type.getPattern(id), teamIds, citation, show);
+	public Award(AwardType type, String teamId, String citation, DisplayMode mode) {
+		this(type.getPattern(""), new String[] { teamId }, citation, mode);
 	}
 
-	private Award(String id, String[] teamIds, String citation, boolean show) {
+	public Award(AwardType type, String id, String[] teamIds, String citation, DisplayMode mode) {
+		this(type.getPattern(id), teamIds, citation, mode);
+	}
+
+	private Award(String id, String[] teamIds, String citation, DisplayMode mode) {
 		super(id);
 		this.teamIds = teamIds;
 		this.citation = citation;
-		this.show = show;
+		this.mode = mode;
 	}
 
 	@Override
@@ -84,12 +89,14 @@ public class Award extends ContestObject implements IAward {
 	}
 
 	@Override
-	public boolean showAward() {
-		return show;
+	public DisplayMode getDisplayMode() {
+		if (mode == null)
+			return DisplayMode.DETAIL;
+		return mode;
 	}
 
-	public void setShowAward(boolean b) {
-		this.show = b;
+	public void setDisplayMode(DisplayMode s) {
+		this.mode = s;
 	}
 
 	@Override
@@ -113,7 +120,18 @@ public class Award extends ContestObject implements IAward {
 			citation = (String) value;
 			return true;
 		} else if (name.equals(SHOW)) {
-			show = parseBoolean(value);
+			if (parseBoolean(value))
+				mode = DisplayMode.DETAIL;
+			else
+				mode = DisplayMode.PAUSE;
+		} else if (name.equals(DISPLAY_MODE)) {
+			if ("detail".equals(value))
+				mode = DisplayMode.DETAIL;
+			else if ("pause".equals(value))
+				mode = DisplayMode.PAUSE;
+			else if ("list".equals(value))
+				mode = DisplayMode.LIST;
+
 			return true;
 		} else if (name.equals(PARAMETER)) {
 			parameter = (String) value;
@@ -133,8 +151,8 @@ public class Award extends ContestObject implements IAward {
 			else
 				props.put(TEAM_IDS, "[\"" + String.join("\",\"", teamIds) + "\"]");
 		}
-		if (show == false)
-			props.put(SHOW, show);
+		if (mode != null && mode != DisplayMode.DETAIL)
+			props.put(DISPLAY_MODE, mode.name().toLowerCase());
 		if (parameter != null)
 			props.put(PARAMETER, parameter);
 	}
@@ -150,8 +168,8 @@ public class Award extends ContestObject implements IAward {
 			else
 				je.encodePrimitive(TEAM_IDS, "[\"" + String.join("\",\"", teamIds) + "\"]");
 		}
-		if (show == false)
-			je.encode(SHOW, show);
+		if (mode != null && mode != DisplayMode.DETAIL)
+			je.encode(DISPLAY_MODE, mode.name().toLowerCase());
 		if (parameter != null)
 			je.encode(PARAMETER, parameter);
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -9,6 +9,7 @@ import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IAward.AwardType;
+import org.icpc.tools.contest.model.IAward.DisplayMode;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IProblem;
@@ -62,13 +63,13 @@ public class AwardUtil {
 				} else
 					beforeFreeze = true;
 
-				boolean show = false;
+				DisplayMode mode = null;
 				if ((beforeFreeze && showBeforeFreeze) || (afterFreeze && showAfterFreeze))
-					show = true;
+					mode = DisplayMode.DETAIL;
 
 				String citation = Messages.getString("awardFTS").replace("{0}", p.getLabel());
 				contest.add(
-						new Award(IAward.FIRST_TO_SOLVE, s.getProblemId(), new String[] { team.getId() }, citation, show));
+						new Award(IAward.FIRST_TO_SOLVE, s.getProblemId(), new String[] { team.getId() }, citation, mode));
 			}
 		}
 	}
@@ -115,7 +116,7 @@ public class AwardUtil {
 	}
 
 	public static void createGroupAwards(Contest contest, int numPerGroup) {
-		Award group = new Award(IAward.GROUP, "*", null, null, true);
+		Award group = new Award(IAward.GROUP, "*", null, (String) null);
 		group.setParameter(numPerGroup + "");
 		createGroupAwards(contest, group);
 	}
@@ -138,7 +139,7 @@ public class AwardUtil {
 				if (group.isHidden())
 					continue;
 
-				Award groupAward = new Award(IAward.GROUP, group.getId(), null, null, true);
+				Award groupAward = new Award(IAward.GROUP, group.getId(), null, (String) null);
 				// groupAward.setCount("1");
 				contest.add(groupAward);
 				assignGroup(contest, groupAward, numPerGroup);
@@ -172,14 +173,14 @@ public class AwardUtil {
 				} else
 					beforeFreeze = true;
 
-				boolean show = false;
+				DisplayMode mode = DisplayMode.PAUSE;
 				if ((beforeFreeze && showBeforeFreeze) || (afterFreeze && showAfterFreeze))
-					show = true;
+					mode = null;
 
 				a.setTeamIds(new String[] { team.getId() });
 				if (a.getCitation() == null)
 					a.setCitation(Messages.getString("awardFTS").replace("{0}", p.getLabel()));
-				a.setShowAward(show);
+				a.setDisplayMode(mode);
 			}
 		}
 	}
@@ -187,7 +188,7 @@ public class AwardUtil {
 	public static void createFirstToSolveAwards(Contest contest, IAward template) {
 		if (template.getId().equals("first-to-solve-*")) {
 			for (IProblem problem : contest.getProblems()) {
-				Award ftsAward = new Award(IAward.FIRST_TO_SOLVE, problem.getId(), null, null, true);
+				Award ftsAward = new Award(IAward.FIRST_TO_SOLVE, problem.getId(), null, (String) null);
 				contest.add(ftsAward);
 				assignFirstToSolve(contest, ftsAward);
 			}
@@ -197,7 +198,7 @@ public class AwardUtil {
 	}
 
 	public static void createGroupHighlightAwards(Contest contest, String groupId2, int numToHighlight, String citation,
-			boolean show) {
+			DisplayMode show) {
 		IGroup group = contest.getGroupById(groupId2);
 		if (group == null)
 			return;
@@ -226,7 +227,7 @@ public class AwardUtil {
 			return;
 
 		ITeam team = teams[0];
-		contest.add(new Award(IAward.WINNER, team.getId(), citation, true));
+		contest.add(new Award(IAward.WINNER, team.getId(), citation));
 	}
 
 	public static void createWinnerAward(Contest contest, IAward awardTemplate) {
@@ -237,11 +238,11 @@ public class AwardUtil {
 		String citation = awardTemplate.getCitation();
 		if (citation == null)
 			citation = Messages.getString("awardWorldChampion");
-		contest.add(new Award(IAward.WINNER, teams[0].getId(), citation, true));
+		contest.add(new Award(IAward.WINNER, teams[0].getId(), citation));
 	}
 
 	public static void createRankAwards(Contest contest, int num) {
-		Award rank = new Award(IAward.RANK, "*", null, true);
+		Award rank = new Award(IAward.RANK, "*", null);
 		rank.setParameter(num + "");
 		createRankAwards(contest, rank);
 	}
@@ -264,14 +265,15 @@ public class AwardUtil {
 
 		for (int i = 0; i < n; i++) {
 			ITeam team = teams[i];
+			String[] teamIds = new String[] { team.getId() };
 			IStanding standing = contest.getStanding(team);
 			try {
 				int rank = Integer.parseInt(standing.getRank());
-				contest.add(new Award(IAward.RANK, i + 1, team.getId(),
-						Messages.getString("awardPlace").replace("{0}", getPlaceString(rank)), true));
+				contest.add(new Award(IAward.RANK, (i + 1) + "", teamIds,
+						Messages.getString("awardPlace").replace("{0}", getPlaceString(rank))));
 			} catch (Exception e) {
-				contest.add(new Award(IAward.RANK, i + 1, team.getId(),
-						Messages.getString("awardPlace").replace("{0}", standing.getRank()), true));
+				contest.add(new Award(IAward.RANK, (i + 1) + "", teamIds,
+						Messages.getString("awardPlace").replace("{0}", standing.getRank())));
 			}
 		}
 	}
@@ -312,7 +314,7 @@ public class AwardUtil {
 			int count = 0;
 			while (nextAwardNum < numGold2 && nextAwardNum < teams.length)
 				teamIds[count++] = teams[nextAwardNum++].getId();
-			contest.add(new Award(IAward.MEDAL, "gold", teamIds, Messages.getString("awardMedalGold"), true));
+			contest.add(new Award(IAward.MEDAL, "gold", teamIds, Messages.getString("awardMedalGold")));
 		}
 
 		// silver medals
@@ -321,7 +323,7 @@ public class AwardUtil {
 			int count = 0;
 			while (nextAwardNum < numGold2 + numSilver2 && nextAwardNum < teams.length)
 				teamIds[count++] = teams[nextAwardNum++].getId();
-			contest.add(new Award(IAward.MEDAL, "silver", teamIds, Messages.getString("awardMedalSilver"), true));
+			contest.add(new Award(IAward.MEDAL, "silver", teamIds, Messages.getString("awardMedalSilver")));
 		}
 
 		// bronze medals
@@ -330,7 +332,7 @@ public class AwardUtil {
 			int count = 0;
 			while (nextAwardNum < numGold2 + numSilver2 + numBronze2 && nextAwardNum < teams.length)
 				teamIds[count++] = teams[nextAwardNum++].getId();
-			contest.add(new Award(IAward.MEDAL, "bronze", teamIds, Messages.getString("awardMedalBronze"), true));
+			contest.add(new Award(IAward.MEDAL, "bronze", teamIds, Messages.getString("awardMedalBronze")));
 		}
 	}
 
@@ -399,7 +401,7 @@ public class AwardUtil {
 	}
 
 	public static void createTopAwards(Contest contest, int percent) {
-		Award rank = new Award(IAward.TOP, "*", null, true);
+		Award rank = new Award(IAward.TOP, "*", null);
 		rank.setParameter(percent + "");
 		createTopAwards(contest, rank);
 	}
@@ -431,11 +433,11 @@ public class AwardUtil {
 			citation = Messages.getString("awardTop");
 		citation = citation.replace("{0}", percent + "");
 
-		contest.add(new Award(IAward.TOP, template.getId().substring(4), teamIds, citation, true));
+		contest.add(new Award(IAward.TOP, template.getId().substring(4), teamIds, citation));
 	}
 
 	public static void createHonorsAwards(Contest contest, int percentile) {
-		Award rank = new Award(IAward.HONORS, "*", null, true);
+		Award rank = new Award(IAward.HONORS, "*", null);
 		rank.setParameter(percentile + "");
 		createTopAwards(contest, rank);
 	}
@@ -500,7 +502,7 @@ public class AwardUtil {
 				citation = Messages.getString("awardHonors");
 		}
 
-		contest.add(new Award(IAward.HONORS, template.getId().substring(7), teamIds, citation, true));
+		contest.add(new Award(IAward.HONORS, template.getId().substring(7), teamIds, citation));
 	}
 
 	public static int[] getMedalCounts(IContest contest) {
@@ -531,19 +533,19 @@ public class AwardUtil {
 	}
 
 	public static void createWorldFinalsAwards(Contest contest, int b) {
-		Award gold = new Award(IAward.MEDAL, "gold", null, null, true);
+		Award gold = new Award(IAward.MEDAL, "gold", null, (String) null);
 		gold.setParameter("4");
-		Award silver = new Award(IAward.MEDAL, "silver", null, null, true);
+		Award silver = new Award(IAward.MEDAL, "silver", null, (String) null);
 		silver.setParameter("4");
-		Award bronze = new Award(IAward.MEDAL, "bronze", null, null, true);
+		Award bronze = new Award(IAward.MEDAL, "bronze", null, (String) null);
 		bronze.setParameter((4 + b) + "");
 		createMedalAwards(contest, gold, silver, bronze);
 
-		Award group = new Award(IAward.GROUP, "*", null, null, true);
+		Award group = new Award(IAward.GROUP, "*", null, (String) null);
 		group.setParameter("1");
 		createGroupAwards(contest, group);
 
-		Award fts = new Award(IAward.FIRST_TO_SOLVE, "*", null, null, true);
+		Award fts = new Award(IAward.FIRST_TO_SOLVE, "*", null, (String) null);
 		createFirstToSolveAwards(contest, fts);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
@@ -23,3 +23,4 @@ awardSolving={0}, and solving {1} problems in {2} minutes
 awardTop=Top {0}% of teams
 awardHonors={0}% Honors
 awardHonorableMention=Honorable mention
+teamListSubtitle=Solving {0} problems

--- a/Resolver/src/org/icpc/tools/resolver/TeamAwardPresentation.java
+++ b/Resolver/src/org/icpc/tools/resolver/TeamAwardPresentation.java
@@ -19,6 +19,7 @@ import javax.imageio.ImageIO;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IAward.AwardType;
+import org.icpc.tools.contest.model.IAward.DisplayMode;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IOrganization;
@@ -374,7 +375,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 
 		currentCache.mergedAwards = true;
 
-		boolean show = false;
+		DisplayMode mode = null;
 		int patternLen = IAward.FIRST_TO_SOLVE.getPattern("").length();
 		List<String> fts = new ArrayList<>();
 		List<IAward> list = new ArrayList<>();
@@ -389,8 +390,8 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 					continue;
 				}
 				fts.add(p.getLabel());
-				if (a.showAward())
-					show = true;
+				if (a.getDisplayMode() != null)
+					mode = a.getDisplayMode();
 			} else if (a.getId().contains("solution")) {
 				hasSolutionAward = true;
 				list.add(a);
@@ -401,10 +402,10 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			}
 		}
 
+		String[] teamIds = new String[] { currentCache.teamId };
 		int numFTS = fts.size();
 		if (numFTS == 1) {
-			list.add(new Award(IAward.FIRST_TO_SOLVE, fts.get(0), new String[] { currentCache.teamId },
-					"First to solve problem " + fts.get(0), show));
+			list.add(new Award(IAward.FIRST_TO_SOLVE, fts.get(0), teamIds, "First to solve problem " + fts.get(0), mode));
 		} else if (numFTS >= 2) {
 			fts.sort((s1, s2) -> s1.compareTo(s2));
 			fts.set(numFTS - 1, "and " + fts.get(numFTS - 1));
@@ -415,11 +416,10 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			else
 				citation = "First to solve problems " + String.join(", ", fts);
 
-			list.add(new Award(IAward.FIRST_TO_SOLVE, String.join("_", fts), new String[] { currentCache.teamId },
-					citation, show));
+			list.add(new Award(IAward.FIRST_TO_SOLVE, String.join("_", fts), teamIds, citation, mode));
 		} else if (fts.size() == 1) {
-			list.add(new Award(IAward.FIRST_TO_SOLVE, String.join("_", fts), new String[] { currentCache.teamId },
-					"First to solve problem " + fts.get(0), show));
+			list.add(new Award(IAward.FIRST_TO_SOLVE, String.join("_", fts), teamIds,
+					"First to solve problem " + fts.get(0), mode));
 		}
 
 		if (hasMedal && !hasSolutionAward) {
@@ -427,11 +427,11 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			ITeam team = contest.getTeamById(currentCache.teamId);
 			IStanding s = contest.getStanding(team);
 			if (s.getNumSolved() == 1)
-				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId,
-						Messages.getString("awardSolvedOne"), false));
+				list.add(new Award(IAward.OTHER, s.getNumSolved() + "", teamIds, Messages.getString("awardSolvedOne"),
+						DisplayMode.PAUSE));
 			else if (s.getNumSolved() > 1)
-				list.add(new Award(IAward.OTHER, s.getNumSolved(), currentCache.teamId,
-						Messages.getString("awardSolvedMultiple").replace("{0}", s.getNumSolved() + ""), false));
+				list.add(new Award(IAward.OTHER, s.getNumSolved() + "", teamIds,
+						Messages.getString("awardSolvedMultiple").replace("{0}", s.getNumSolved() + ""), DisplayMode.PAUSE));
 		}
 
 		currentCache.awards = list;

--- a/Resolver/src/org/icpc/tools/resolver/awards/AddAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AddAwardDialog.java
@@ -18,6 +18,7 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.icpc.tools.contest.model.IAward;
+import org.icpc.tools.contest.model.IAward.DisplayMode;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
@@ -122,12 +123,13 @@ public class AddAwardDialog extends Dialog {
 		citation.setLayoutData(data);
 
 		// show
-		Button show = new Button(comp, SWT.CHECK);
-		show.setText("Show team picture and citation (after pausing in the resolver)");
+		Combo mode = new Combo(comp, SWT.NONE);
+		mode.setItems(new String[] { "Stop to show details", "Pause and move on", "Show as list" });
+		mode.setText("Show team picture and citation (after pausing in the resolver)");
 		data = new GridData(SWT.FILL, SWT.CENTER, true, false);
 		data.horizontalSpan = 3;
-		show.setLayoutData(data);
-		show.setSelection(true);
+		mode.setLayoutData(data);
+		mode.select(DisplayMode.DETAIL.ordinal());
 
 		Label warning = new Label(comp, SWT.NONE);
 		data = new GridData(SWT.FILL, SWT.CENTER, true, false);
@@ -185,10 +187,10 @@ public class AddAwardDialog extends Dialog {
 					warning.setText("");
 			}
 		});
-		show.addSelectionListener(new SelectionAdapter() {
+		mode.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent event) {
-				award.setShowAward(show.getSelection());
+				award.setDisplayMode(DisplayMode.values()[mode.getSelectionIndex()]);
 			}
 		});
 		citation.addModifyListener(new ModifyListener() {

--- a/Resolver/src/org/icpc/tools/resolver/awards/EditAwardsDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/EditAwardsDialog.java
@@ -11,6 +11,7 @@ import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Dialog;
 import org.eclipse.swt.widgets.Group;
@@ -20,6 +21,7 @@ import org.eclipse.swt.widgets.Table;
 import org.eclipse.swt.widgets.TableItem;
 import org.eclipse.swt.widgets.Text;
 import org.icpc.tools.contest.model.IAward;
+import org.icpc.tools.contest.model.IAward.DisplayMode;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.internal.Award;
@@ -40,7 +42,7 @@ public class EditAwardsDialog extends Dialog {
 
 	protected Label citationLabel;
 	protected Text citation;
-	protected Button show;
+	protected Combo mode;
 
 	protected int rc;
 
@@ -169,7 +171,7 @@ public class EditAwardsDialog extends Dialog {
 				removeTeamFromAward();
 
 				Award a = new Award(selectedAward.getAwardType(), team.getId(), selectedAward.getCitation(),
-						selectedAward.showAward());
+						selectedAward.getDisplayMode());
 				awards.add(a);
 
 				updateAwards();
@@ -199,16 +201,16 @@ public class EditAwardsDialog extends Dialog {
 		});
 
 		// show
-		show = new Button(awardGroup, SWT.CHECK);
-		show.setText("Show team picture and citation (after pausing in the resolver)");
+		mode = new Combo(awardGroup, SWT.CHECK);
+		mode.setItems(new String[] { "Stop to show details", "Pause and move on", "Show as list" });
 		data = new GridData(SWT.FILL, SWT.CENTER, true, false);
 		data.horizontalSpan = 3;
-		show.setLayoutData(data);
-		show.addSelectionListener(new SelectionAdapter() {
+		mode.setLayoutData(data);
+		mode.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent event) {
 				if (selectedAward != null)
-					selectedAward.setShowAward(show.getSelection());
+					selectedAward.setDisplayMode(DisplayMode.values()[mode.getSelectionIndex()]);
 			}
 		});
 
@@ -311,11 +313,11 @@ public class EditAwardsDialog extends Dialog {
 			awardTable.setEnabled(false);
 
 			citation.setText("");
-			show.setSelection(false);
+			mode.select(0);
 
 			citationLabel.setEnabled(false);
 			citation.setEnabled(false);
-			show.setEnabled(false);
+			mode.setEnabled(false);
 			remove.setEnabled(false);
 		} else {
 			for (IAward a : awards) {
@@ -348,7 +350,11 @@ public class EditAwardsDialog extends Dialog {
 
 		selectedAward = (Award) awards.get(sel);
 		citation.setText(selectedAward.getCitation());
-		show.setSelection(selectedAward.showAward());
+		DisplayMode m = selectedAward.getDisplayMode();
+		if (m == null)
+			m = DisplayMode.DETAIL;
+
+		mode.select(m.ordinal());
 
 		remove.setEnabled(true);
 		split.setEnabled(isMultiTeamAwardSelected());

--- a/Resolver/src/org/icpc/tools/resolver/awards/GroupHighlightAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/GroupHighlightAwardDialog.java
@@ -16,8 +16,9 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
 import org.icpc.tools.contest.model.IAward;
-import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IAward.AwardType;
+import org.icpc.tools.contest.model.IAward.DisplayMode;
+import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.util.AwardUtil;
 
@@ -129,6 +130,6 @@ public class GroupHighlightAwardDialog extends AbstractAwardDialog {
 
 	@Override
 	protected void applyAwards(Contest aContest) {
-		AwardUtil.createGroupHighlightAwards(aContest, groupId, numToHighlight, citation, showPicture);
+		AwardUtil.createGroupHighlightAwards(aContest, groupId, numToHighlight, citation, showPicture ? DisplayMode.DETAIL : null);
 	}
 }

--- a/Resolver/src/org/icpc/tools/resolver/messages.properties
+++ b/Resolver/src/org/icpc/tools/resolver/messages.properties
@@ -10,4 +10,3 @@ splashPending={0} pending submissions
 
 teamListHM=Honorable Mention
 teamListTitle={0} Place
-teamListSubtitle=Solving {0} problems


### PR DESCRIPTION
--bill was created a few years ago, and it amounted to two things:
1. Use judge queue for Honorable Mention teams.
2. Show a list for Honorable Mention teams and subsequent groups of teams that solve each consecutive # of problems (except medals).

We've talked about how to make it a bit more standard, and this is the first step of that, for #2. Up to now the award generator/resolver has used a boolean attribute on awards called "show" that was either false (just pause, then move on, e.g. for FTS) or true (stop and show the team detail, e.g. for medals). This change turns it into a string display_mode attribute that has three options: "detail", "pause" (the same two options as before) and "list". Any award that has this last option will wait until every team has been resolved and then show the full list of teams. The code is backward compatible with old feeds and for now --bill creates hidden awards to stop at the same places as before.

Why all this? Besides cleaning up this custom code it means you can have awards for things like Honors and decide to show a list.