### PR TITLE
Improve text fit when names are too long

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCFont.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCFont.java
@@ -23,7 +23,8 @@ public class ICPCFont {
 		String overrideFont = System.getenv("ICPC_FONT");
 		if (overrideFont != null) {
 			Trace.trace(Trace.INFO, "Font override: " + overrideFont);
-			MASTER_FONT = new Font(overrideFont, Font.PLAIN, 20);
+			MASTER_FONT = new File(overrideFont).exists() ? getFontFromFile(FONT_TYPE, overrideFont)
+					: new Font(overrideFont, Font.PLAIN, 20);
 		} else
 			MASTER_FONT = getFontFromFile(FONT_TYPE, FONT_NAME);
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/TextHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/TextHelper.java
@@ -25,13 +25,13 @@ import javax.imageio.ImageIO;
 
 import org.icpc.tools.contest.Trace;
 
+/**
+ * A helper class that can layout and draw a set of text and images. It handles some special cases
+ * like automatically converting emojis in strings to colour images. All items are automatically
+ * vertically aligned in the middle.
+ */
 public class TextHelper {
-	public enum Alignment {
-		TOP, MIDDLE, BOTTOM
-	}
-
 	abstract class Item {
-		protected Alignment align = Alignment.MIDDLE;
 		protected Dimension d;
 
 		protected abstract void draw();
@@ -42,12 +42,7 @@ public class TextHelper {
 
 		@Override
 		protected void draw() {
-			if (align == Alignment.TOP)
-				g.drawImage(img, 0, 0, null);
-			else if (align == Alignment.MIDDLE)
-				g.drawImage(img, 0, (bounds.height - img.getHeight()) / 2, null);
-			else if (align == Alignment.BOTTOM)
-				g.drawImage(img, 0, bounds.height - img.getHeight(), null);
+			g.drawImage(img, 0, (bounds.height - img.getHeight()) / 2, null);
 		}
 	}
 
@@ -55,12 +50,7 @@ public class TextHelper {
 	class EmojiItem extends ImageItem {
 		@Override
 		protected void draw() {
-			if (align == Alignment.TOP)
-				g.drawImage(img, 0, 1, null);
-			else if (align == Alignment.MIDDLE)
-				g.drawImage(img, 0, (bounds.height - img.getHeight()) / 2, null);
-			else if (align == Alignment.BOTTOM)
-				g.drawImage(img, 0, bounds.height - img.getHeight() - 1, null);
+			g.drawImage(img, 0, (bounds.height - img.getHeight()) / 2, null);
 		}
 	}
 
@@ -69,12 +59,7 @@ public class TextHelper {
 
 		@Override
 		protected void draw() {
-			if (align == Alignment.TOP)
-				g.drawString(s, 0, fm.getAscent());
-			else if (align == Alignment.MIDDLE)
-				g.drawString(s, 0, (bounds.height - fm.getHeight()) / 2 + fm.getAscent());
-			else if (align == Alignment.BOTTOM)
-				g.drawString(s, 0, bounds.height - fm.getDescent());
+			g.drawString(s, 0, (bounds.height - fm.getHeight()) / 2 + fm.getAscent());
 		}
 	}
 
@@ -83,12 +68,7 @@ public class TextHelper {
 
 		@Override
 		protected void draw() {
-			if (align == Alignment.TOP)
-				g.drawGlyphVector(gv, 0, fm.getAscent());
-			else if (align == Alignment.MIDDLE)
-				g.drawGlyphVector(gv, 0, (bounds.height - fm.getHeight()) / 2 + fm.getAscent());
-			else if (align == Alignment.BOTTOM)
-				g.drawGlyphVector(gv, 0, (bounds.height - fm.getDescent()));
+			g.drawGlyphVector(gv, 0, (bounds.height - fm.getHeight()) / 2 + fm.getAscent());
 		}
 	}
 
@@ -107,7 +87,7 @@ public class TextHelper {
 	public TextHelper(Graphics2D g, String s) {
 		this.g = g;
 		this.fm = g.getFontMetrics();
-		addString(s, Alignment.MIDDLE);
+		addString(s);
 	}
 
 	public TextHelper(Graphics2D g) {
@@ -115,15 +95,14 @@ public class TextHelper {
 		this.fm = g.getFontMetrics();
 	}
 
-	public void addPlainText(String s, Alignment align) {
+	public void addPlainText(String s) {
 		StringItem item = new StringItem();
 		item.s = s;
-		item.align = align;
 		item.d = new Dimension(fm.stringWidth(s), fm.getHeight());
 		add(item);
 	}
 
-	public void addString(String s, Alignment align) {
+	public void addString(String s) {
 		FontRenderContext frc = g.getFontRenderContext();
 		Font font = g.getFont();
 
@@ -195,10 +174,9 @@ public class TextHelper {
 		add(item);
 	}
 
-	public void addImage(BufferedImage img, Alignment align) {
+	public void addImage(BufferedImage img) {
 		ImageItem item = new ImageItem();
 		item.img = img;
-		item.align = align;
 		item.d = new Dimension(img.getWidth(), img.getHeight());
 		add(item);
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -22,7 +22,6 @@ import org.icpc.tools.presentation.contest.internal.Animator3D;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.ImageScaler;
 import org.icpc.tools.presentation.contest.internal.TextHelper;
-import org.icpc.tools.presentation.contest.internal.TextHelper.Alignment;
 
 public class TeamIntroPresentation extends AbstractICPCPresentation {
 	private static final long GROUP_INTRO_TIME = 4000;
@@ -355,11 +354,11 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 		g.setFont(font);
 		TextHelper text = new TextHelper(g);
 		if (pos.smImage != null) {
-			text.addImage(pos.smImage, Alignment.MIDDLE);
+			text.addImage(pos.smImage);
 			text.addSpacer(border);
 		}
 
-		text.addString(pos.label, Alignment.MIDDLE);
+		text.addString(pos.label);
 		int h = Math.max(border, height / 12) + border;
 		int y = height - border - h;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -22,6 +22,7 @@ import org.icpc.tools.presentation.contest.internal.Animator3D;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.ImageScaler;
 import org.icpc.tools.presentation.contest.internal.TextHelper;
+import org.icpc.tools.presentation.contest.internal.TextHelper.Alignment;
 
 public class TeamIntroPresentation extends AbstractICPCPresentation {
 	private static final long GROUP_INTRO_TIME = 4000;
@@ -352,24 +353,21 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 
 		// draw team name and logo across the bottom
 		g.setFont(font);
-		int max = width - border * 5;
-		if (pos.smImage != null)
-			max -= pos.smImage.getWidth();
-		TextHelper text = new TextHelper(g, pos.label, max);
-		int tw = text.getWidth();
-
+		TextHelper text = new TextHelper(g);
 		if (pos.smImage != null) {
-			border = Math.max(border, pos.smImage.getHeight() / 2 + 10);
-			g.drawImage(pos.smImage, (width - tw) / 2 - pos.smImage.getWidth() / 2 - border,
-					height - border - 20 - pos.smImage.getHeight() / 2, null);
+			text.addImage(pos.smImage, Alignment.MIDDLE);
+			text.addSpacer(border);
 		}
 
-		FontMetrics fm = g.getFontMetrics();
-		int ty = fm.getAscent();
-		g.setColor(Color.DARK_GRAY);
-		text.draw((width - tw) / 2 + 20 + border + 2, height - border - 20 + ty / 2);
-		text.draw((width - tw) / 2 + 20 + border, height - border - 20 + ty / 2 + 2);
+		text.addString(pos.label, Alignment.MIDDLE);
+		int h = Math.max(border, height / 12) + border;
+		int y = height - border - h;
+
+		g.setComposite(AlphaComposite.SrcOver.derive(0.5f));
+		g.setColor(Color.BLACK);
+		g.fillRect(0, y, width, h);
+		g.setComposite(AlphaComposite.SrcOver.derive(1f));
 		g.setColor(Color.WHITE);
-		text.draw((width - tw) / 2 + 20 + border, height - border - 20 + ty / 2);
+		text.drawFit(Math.max(border, (width - text.getWidth()) / 2), y + (h - text.getHeight()) / 2, width - border * 2);
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/FloorNamePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/FloorNamePresentation.java
@@ -2,7 +2,6 @@ package org.icpc.tools.presentation.contest.internal.presentations.old;
 
 import java.awt.Color;
 import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 
@@ -50,9 +49,8 @@ public class FloorNamePresentation extends AbstractICPCPresentation {
 		if (team != null) {
 			g.setFont(font);
 			g.setColor(Color.WHITE);
-			FontMetrics fm = g.getFontMetrics();
 			TextHelper text = new TextHelper(g, team.getActualDisplayName());
-			text.draw((width - text.getWidth()) / 2, fm.getAscent() + 20);
+			text.draw((width - text.getWidth()) / 2, 20);
 		}
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -438,8 +438,8 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 		fm = g.getFontMetrics();
 
 		int xx = BORDER + fm.stringWidth("199 ") + (int) rowHeight;
-		TextHelper text = new TextHelper(g, s, (int) (width - BORDER * 2 - fm.stringWidth("199 9 9999 ") - rowHeight));
-		text.draw(xx, fm.getAscent() + 5);
+		TextHelper text = new TextHelper(g, s);
+		text.drawFit(xx, 5, (int) (width - BORDER * 2 - fm.stringWidth("199 9 9999 ") - rowHeight));
 
 		int n = standing.getNumSolved();
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
@@ -254,9 +254,9 @@ public class TeamTileHelper {
 		String s = team.getActualDisplayName();
 
 		g.setColor(Color.WHITE);
-		TextHelper text = new TextHelper(g, s,
+		TextHelper text = new TextHelper(g, s);
+		text.drawFit(ww + tileDim.height + IN_TILE_GAP, (tileDim.height * 7 / 10 - fm.getAscent()) / 2 - 1,
 				tileDim.width - tileDim.height - ww - IN_TILE_GAP * 2 - 2 - fm.stringWidth(" 10"));
-		text.draw(ww + tileDim.height + IN_TILE_GAP, (tileDim.height * 7 / 10 + fm.getAscent()) / 2 - 2);
 	}
 
 	private void paintTileForeground(Graphics2D g, ITeam team, boolean includeName, long timeMs) {


### PR DESCRIPTION
It was annoying me that the team intro presentation logos weren't always near the text and sometimes too wide for the screen. Improved the text helper to correctly handle alignment and scaling to fit within a specific bounds. Also improves text fitting on the scoreboard and tile scoreboard when names are too long.