### PR TITLE
TextHelper: give emoji PNGs priority over font glyphs

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCFont.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCFont.java
@@ -23,7 +23,9 @@ public class ICPCFont {
 		String overrideFont = System.getenv("ICPC_FONT");
 		if (overrideFont != null) {
 			Trace.trace(Trace.INFO, "Font override: " + overrideFont);
-			MASTER_FONT = new Font(overrideFont, Font.PLAIN, 20);
+			MASTER_FONT = new File(overrideFont).exists() ?
+					getFontFromFile(FONT_TYPE, overrideFont) :
+					new Font(overrideFont, Font.PLAIN, 20);
 		} else
 			MASTER_FONT = getFontFromFile(FONT_TYPE, FONT_NAME);
 


### PR DESCRIPTION
Based on the follow-up discussion in #402:

This PR simplifies the rendering of emoji. Previously, the emoji PNGs were only consulted when the main font did not contain a glyph for a certain Unicode code point. Now, the code points of a string are first scanned to see if they contain sequences that can be printed using Twemoji's PNGs, which includes sequences that contain the Zero-Width Joiner.

Additionally, this PR contains some general refactorings to the TextHelper class, and a way to override the `ICPC_FONT` environment variable using a local font file.