### PR TITLE
Team List presentation improvements

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -121,9 +121,6 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 			zooms[i].startTime = time;
 			time += TIME_PER_GROUP + zooms[i].instPos.length * TIME_PER_TEAM;
 			zooms[i].endTime = time;
-			// System.out
-			// .println(zooms[i].name + " " + zooms[i].numTeams + " " + zooms[i].startTime + " " +
-			// zooms[i].endTime);
 		}
 	}
 
@@ -367,6 +364,6 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 		g.fillRect(0, y, width, h);
 		g.setComposite(AlphaComposite.SrcOver.derive(1f));
 		g.setColor(Color.WHITE);
-		text.drawFit(Math.max(border, (width - text.getWidth()) / 2), y + (h - text.getHeight()) / 2, width - border * 2);
+		text.drawFit(Math.max(border, width - text.getWidth()) / 2, y + (h - text.getHeight()) / 2, width - border * 2);
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -405,8 +405,7 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 			g.fillRect(0, 0, width, (int) (rowHeight + 0.9f));
 
 			// check if the selection type indicates there should be a white outline box
-			if (selectType == SelectType.HIGHLIGHT || selectType == SelectType.FTS_HIGHLIGHT
-					|| selectType == SelectType.TEAM_LIST) {
+			if (selectType == SelectType.HIGHLIGHT || selectType == SelectType.FTS_HIGHLIGHT) {
 				g.setColor(Color.WHITE);
 				g.drawRect(-1, 0, width + 2, (int) (rowHeight));
 			}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
@@ -322,8 +322,7 @@ public class JudgePresentation extends AbstractScoreboardPresentation {
 		g.setFont(rowFont);
 		fm = g.getFontMetrics();
 		int xx = BORDER + fm.stringWidth("199 ") + (int) rowHeight;
-		TextHelper.drawString(g, s, xx, fm.getAscent() + 5,
-				(int) (width - BORDER * 2 - fm.stringWidth("199 9 9999") - rowHeight));
+		TextHelper.drawString(g, s, xx, 5, (int) (width - BORDER * 2 - fm.stringWidth("199 9 9999") - rowHeight));
 
 		drawRight(g, contest, team, standing, sr);
 	}

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -615,7 +615,7 @@ public class Resolver {
 						Trace.trace(Trace.INFO, "Team list award for: " + teamIds[j]);
 					}
 
-					Trace.trace(Trace.USER, "list award: " + citation + " " + rank);
+					Trace.trace(Trace.INFO, "list award: " + citation + " " + rank);
 					finalContest.add(new Award(IAward.OTHER, i + "", teamIds, citation, DisplayMode.LIST));
 				}
 				teamGroup = new ArrayList<>();


### PR DESCRIPTION
- Changed team list to a single column with teams flying in from the bottom.
- Changed scoreboard highlight for lists to not outline every item.
- Changed text helper to use a layout (allowing potential reuse later) and draw all items based on their center position.
- Removed some old code and unnecessary user messages.