### PR TITLE
Modernize use of deprecated methods to new ways

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/Balloon.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/Balloon.java
@@ -95,11 +95,11 @@ public class Balloon {
 
 	public void load(String s) throws NumberFormatException {
 		StringTokenizer st = new StringTokenizer(s, DELIM);
-		id = new Integer(st.nextToken()).intValue();
+		id = Integer.parseInt(st.nextToken());
 		submissionId = st.nextToken();
-		flags = new Integer(st.nextToken()).intValue();
-		printed = new Boolean(st.nextToken()).booleanValue();
-		delivered = new Boolean(st.nextToken()).booleanValue();
+		flags = Integer.parseInt(st.nextToken());
+		printed = Boolean.parseBoolean(st.nextToken());
+		delivered = Boolean.parseBoolean(st.nextToken());
 	}
 
 	public String save() {

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -469,7 +469,7 @@ public class ContestRESTService extends HttpServlet {
 
 			if (countdownTime != null && !"null".equals(countdownTime))
 				try {
-					newTime = new Long(-RelativeTime.parse(countdownTime.toString()));
+					newTime = (long) -RelativeTime.parse(countdownTime.toString());
 					Trace.trace(Trace.INFO, "Patch countdown time: " + RelativeTime.format(newTime.intValue()));
 				} catch (Exception e) {
 					Trace.trace(Trace.WARNING, "Invalid patch countdown time: " + e.getMessage());

--- a/CDS/src/org/icpc/tools/cds/service/ReportGenerator.java
+++ b/CDS/src/org/icpc/tools/cds/service/ReportGenerator.java
@@ -57,7 +57,7 @@ public class ReportGenerator {
 			return;
 
 		Integer in = (Integer) obj;
-		map2.put(key, new Integer(in.intValue() + 1));
+		map2.put(key, in + 1);
 	}
 
 	// { {"name":"Catch the Plane", "solved":5, "failed":2, "total":7 }, ... }
@@ -82,10 +82,10 @@ public class ReportGenerator {
 			map.put(ID, id);
 			map.put(NAME, name);
 			for (IJudgementType jt : jts)
-				map.put(jt.getId(), new Integer(0));
-			map.put(SOLVED, new Integer(0));
-			map.put(FAILED, new Integer(0));
-			map.put(TOTAL, new Integer(0));
+				map.put(jt.getId(), 0);
+			map.put(SOLVED, 0);
+			map.put(FAILED, 0);
+			map.put(TOTAL, 0);
 			list.add(map);
 		}
 
@@ -133,10 +133,10 @@ public class ReportGenerator {
 			map.put(ID, id);
 			map.put(NAME, name);
 			for (IJudgementType jt : jts)
-				map.put(jt.getId(), new Integer(0));
-			map.put(SOLVED, new Integer(0));
-			map.put(FAILED, new Integer(0));
-			map.put(TOTAL, new Integer(0));
+				map.put(jt.getId(), 0);
+			map.put(SOLVED, 0);
+			map.put(FAILED, 0);
+			map.put(TOTAL, 0);
 			list.add(map);
 		}
 
@@ -194,7 +194,7 @@ public class ReportGenerator {
 			map.put(ID, id);
 			map.put("Id", id);
 			map.put(NAME, name);
-			map.put(TOTAL, new Integer(0));
+			map.put(TOTAL, 0);
 			list.add(map);
 		}
 

--- a/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
+++ b/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
@@ -66,7 +66,7 @@ public class StartTimeService {
 			if (command.startsWith("absolute:")) {
 				setStartTime(cc, Timestamp.parse(command.substring(8).trim()));
 			} else if (command.startsWith("set:")) {
-				setStartTime(cc, new Long(-RelativeTime.parse(command.substring(4).trim())));
+				setStartTime(cc, (long) -RelativeTime.parse(command.substring(4).trim()));
 			} else if (command.startsWith("add:")) {
 				if (errorIfContestNotPaused(currentStart, response))
 					return;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -81,7 +81,7 @@ public abstract class ContestObject implements IContestObject {
 		try {
 			@SuppressWarnings("unchecked")
 			Class<ContestObject> cl = (Class<ContestObject>) getClass();
-			ContestObject co = cl.newInstance();
+			ContestObject co = cl.getDeclaredConstructor().newInstance();
 			Map<String, Object> props = getProperties();
 			for (String key : props.keySet())
 				co.add(key, props.get(key));

--- a/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
@@ -95,7 +95,7 @@ public class ArgumentParser {
 				throw new IllegalArgumentException("Integer expected " + o + " for " + option + " " + name);
 			else if ("float".contentEquals(type) && !(o instanceof Float)) {
 				if (o instanceof Integer)
-					args.set(i, new Float((Integer) o)); // auto-convert from int to float
+					args.set(i, (float) (int) o); // auto-convert from int to float
 				else
 					throw new IllegalArgumentException("Float expected " + o + " for " + option + " " + name);
 			} else if ("boolean".contentEquals(type) && !(o instanceof Boolean))

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/PresentationClient.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/PresentationClient.java
@@ -147,7 +147,7 @@ public class PresentationClient extends BasicClient {
 			ClassLoader classLoader = getClass().getClassLoader();
 			Class<?> c = classLoader.loadClass(className);
 			if (c != null) {
-				T newObject = (T) c.newInstance();
+				T newObject = (T) c.getDeclaredConstructor().newInstance();
 
 				if (newObject != null) {
 					Trace.trace(Trace.INFO, "Class loaded ok");

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -281,7 +281,7 @@ public class StandaloneLauncher {
 			try {
 				String className = info.getClassName();
 				Class<?> c = pres.getClass().getClassLoader().loadClass(className);
-				presentation[i] = (Presentation) c.newInstance();
+				presentation[i] = (Presentation) c.getDeclaredConstructor().newInstance();
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "      Could not load presentation");
 				return;


### PR DESCRIPTION
- new Integer/Long/Float/Boolean(String)

Deprecated and marked for removal.
Use parseInt/Long/Float/Boolean(String) to convert to primitives, or
valueOf(String) to create objects.

- new Long/Integer/Float(long/int/float)

Deprecated and marked for removal.
Use Long.valueOf(long/int/float). Auto-boxing usually compiles into this.
(see https://stackoverflow.com/questions/31445024/does-autoboxing-call-valueof )

- Class.newInstance()

Deprecated,
can be replaced by clazz.getDeclaredConstructor().newInstance().