### PR TITLE
Add SVG library to classpath of Resolver

### DIFF
--- a/ContestModel/lib/BUILD
+++ b/ContestModel/lib/BUILD
@@ -3,3 +3,9 @@ java_import(
     jars = ["snakeyaml-1.27.jar"],
     visibility = ["//visibility:public"],
 )
+
+java_import(
+    name = "svgSalamander",
+    jars = ["svgSalamander-1.1.2.4.jar"],
+    visibility = ["//visibility:public"],
+)

--- a/PresContest/src/BUILD
+++ b/PresContest/src/BUILD
@@ -3,6 +3,7 @@ java_library(
     srcs = glob(["**/*.java"]),
     deps = [
         "//ContestModel/src:contestModel",
+        "//ContestModel/lib:svgSalamander",
         "//PresCore/src:presentCore",
         "//PresContest/lib:jna",
         "//PresContest/lib:vlcj",

--- a/Resolver/scripts/resolver.bat
+++ b/Resolver/scripts/resolver.bat
@@ -17,4 +17,4 @@ goto :loop
 
 :continue
 
-java -Xmx1024m -cp "%LIBDIR%\resolver.jar";"%LIBDIR%\tyrus-standalone-client-1.17.jar" org.icpc.tools.resolver.Resolver %params%
+java -Xmx1024m -cp "%LIBDIR%\resolver.jar";"%LIBDIR%\svgSalamander-1.1.2.4.jar";"%LIBDIR%\tyrus-standalone-client-1.17.jar" org.icpc.tools.resolver.Resolver %params%

--- a/Resolver/scripts/resolver.sh
+++ b/Resolver/scripts/resolver.sh
@@ -10,4 +10,4 @@ set -e
 export LIBDIR=$( dirname "${BASH_SOURCE}[0]" )/lib
 UNAME=$( uname  -s )
 
-java -Xmx1024m -cp "$LIBDIR/resolver.jar:$LIBDIR/tyrus-standalone-client-1.17.jar" org.icpc.tools.resolver.Resolver "$@"
+java -Xmx1024m -cp "$LIBDIR/resolver.jar:$LIBDIR/svgSalamander-1.1.2.4.jar:$LIBDIR/tyrus-standalone-client-1.17.jar" org.icpc.tools.resolver.Resolver "$@"

--- a/Resolver/src/BUILD
+++ b/Resolver/src/BUILD
@@ -4,6 +4,7 @@ java_binary(
     srcs = glob(["**/*.java"]),
     deps = [
         "//ContestModel/src:contestModel",
+        "//ContestModel/lib:svgSalamander",
         "//PresContest/src:presentations",
         "//PresCore/src:presentCore",
         "//SWTLauncher/lib:swt",


### PR DESCRIPTION
Following up the discussion in #402, I see that emoji SVGs have been implemented in 1833cd753c589c7cb935b7ee449d67235de246a5, thanks for that @deboer-tim! :smile: 

The emoji render fine when I run the resolver from IntelliJ, but when trying it from the built package, I got the following error:
```
$ ./resolver.sh ../event-feed-bapc/ --test
--- ICPC Resolver (2.4.582) ---
Log: logs/resolver_21.10.01_09.26.04.log
Unknown property ignored: awards/show
Test mode active, 0 unjudged submissions discarded.
Resolving 359 pending submissions out of the 1888 total submissions in the contest... 
Done resolving
  Playback time: 11m 1s
  Total pauses: 42
Error painting
   java.lang.NoClassDefFoundError: com/kitfox/svg/SVGUniverse
   at org.icpc.tools.presentation.contest.internal.TextHelper.loadEmojiFromFile(TextHelper.java:343)
   java.lang.ClassNotFoundException: com.kitfox.svg.SVGUniverse
   at org.icpc.tools.presentation.contest.internal.TextHelper.loadEmojiFromFile(TextHelper.java:343)
Logging second instance of exception, will not log again
Error painting
   java.lang.NoClassDefFoundError: com/kitfox/svg/SVGUniverse
   at org.icpc.tools.presentation.contest.internal.TextHelper.loadEmojiFromFile(TextHelper.java:343)
```

It seemed like the SVG library was not on the classpath. With this PR, I have fixed it for the Resolver, but I'm not experienced enough with Ant to say whether my fix is proper :stuck_out_tongue: (and perhaps, this library needs to be added to different components as well). For example, I've manually added the SVG library to the classpath in `resolver.{bat,sh}`, but I have the feeling that Ant should be able to automagically fix this. Let me know if I overlooked something! :slightly_smiling_face: 