### PR TITLE
Use network interfaces to look up local IP address.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/NetworkUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/NetworkUtil.java
@@ -2,7 +2,10 @@ package org.icpc.tools.contest.model.internal;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
 import java.net.Socket;
+import java.net.SocketException;
+import java.util.Enumeration;
 
 public class NetworkUtil {
 	private static String localAddress;
@@ -20,6 +23,8 @@ public class NetworkUtil {
 		if (localAddress != null)
 			return localAddress;
 
+		// Try to use a socket to connect to google and find the local IP address for the socket
+		// This is the best approach but only works when there is internet
 		try (Socket socket = new Socket()) {
 			socket.connect(new InetSocketAddress("google.com", 80));
 			localAddress = socket.getLocalAddress().getHostAddress();
@@ -27,6 +32,28 @@ public class NetworkUtil {
 		} catch (Exception e) {
 			// ignore
 		}
+
+		// Loop over all network interfaces and find the first non-IPv6, non loopback IP
+		try {
+			Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
+			while (networkInterfaces.hasMoreElements()) {
+				NetworkInterface networkInterface = networkInterfaces.nextElement();
+				Enumeration<InetAddress> addresses = networkInterface.getInetAddresses();
+				while (addresses.hasMoreElements()) {
+					String address = addresses.nextElement().getHostAddress();
+					// Do not consider localhost or IPv6 addresses
+					if (!address.startsWith("127.") && !address.contains(":")) {
+						return address;
+					}
+				}
+			}
+		} catch (SocketException e) {
+			// ignore
+		}
+
+		// All else failed, use the local IP address. This looks up the hostname and tries
+		// to resolve it. Most Linux machines map this to 127.0.0.1 or similar, so it's not
+		// very useful
 		try {
 			localAddress = InetAddress.getLocalHost().getHostAddress();
 			return localAddress;


### PR DESCRIPTION
Noticed that on the contest floor we didn't report the correct IP address. This should fix it as long as you have one network interface. If you have more, it will report one of them.