### PR TITLE
Add test clock drawing of local time and time sync

### DIFF
--- a/PresContest/src/META-INF/presentations.xml
+++ b/PresContest/src/META-INF/presentations.xml
@@ -426,6 +426,7 @@
       category="Test"
       description="The current system time on the presentation machine."
       image="images/presentations/testClock.png"
+      properties="localTimeOn,localTimeOff"
       class="org.icpc.tools.presentation.contest.internal.presentations.test.TestClockPresentation"/>
    <presentation
       id="org.icpc.tools.presentation.contest.test.bsod"

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/test/TestClockPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/test/TestClockPresentation.java
@@ -13,22 +13,45 @@ public class TestClockPresentation extends Presentation {
 	private static final Color DARK_GRAY = new Color(12, 12, 12);
 	private static final Color LIGHT_GRAY = new Color(250, 250, 250);
 
+	public Color getTextBackgroundColor() {
+		return isLightMode() ? LIGHT_GRAY : DARK_GRAY;
+	}
+
+	public Color getTextForegroundColor() {
+		return isLightMode() ? Color.BLACK : Color.WHITE;
+	}
+
 	@Override
 	public void setSize(Dimension d) {
 		super.setSize(d);
 	}
 
+	private boolean showLocalTime;
+
 	@Override
-	public long getDelayTimeMs() {
-		// paint 5 times a second
-		return 200;
+	public void setProperty(String value) {
+		if (value == null || value.isEmpty())
+			return;
+		if ("localTimeOn".equals(value))
+			showLocalTime = true;
+		else if ("localTimeOff".equals(value))
+			showLocalTime = false;
+		else
+			super.setProperty(value);
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
-		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-		long ms = getTimeMs();
+	public long getDelayTimeMs() {
+		if (showLocalTime) {
+			// Paint ASAP
+			return 0;
+		} else {
+			// paint 20 times a second
+			return 50;
+		}
+	}
 
+	private String timeString(long ms) {
 		int s = 0;
 		int m = 0;
 		int h = 0;
@@ -57,8 +80,82 @@ public class TestClockPresentation extends Presentation {
 			sb.append("0");
 		sb.append(s);
 
-		int w = DigitalFont.stringWidth(sb.toString(), (int) (0.19f * width));
-		DigitalFont.drawString(g, sb.toString(), (width - w) / 2, (int) (height * 0.6f), (int) (0.19f * width),
-				isLightMode() ? Color.BLACK : Color.WHITE, isLightMode() ? LIGHT_GRAY : DARK_GRAY);
+		return sb.toString();
+	}
+
+	@Override
+	public void paint(Graphics2D g) {
+		if (showLocalTime) {
+			drawSyncLine(g);
+			drawServerTimeDiff(g);
+		}
+		drawClock(g);
+	}
+
+	public void drawClock(Graphics2D g) {
+		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+		//g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+		long ms = getTimeMs();
+
+		String s = timeString(ms);
+		int w = DigitalFont.stringWidth(s, (int) (0.19f * width));
+		DigitalFont.drawString(g, s, (width - w) / 2, (int) (height * 0.6f), (int) (0.19f * width),
+				getTextForegroundColor(), getTextBackgroundColor());
+	}
+
+	long avgMilliDiff;
+	int avgMilliDiffCount;
+	long firstNanoDiffMs;
+	int firstNanoDiffCount;
+
+	public void drawServerTimeDiff(Graphics2D g) {
+		long serverMillis = this.getTimeMs();
+		long milliDiff = System.currentTimeMillis() - serverMillis;
+		avgMilliDiff = (avgMilliDiff * avgMilliDiffCount + milliDiff) / (avgMilliDiffCount + 1);
+		if (avgMilliDiffCount < 10) {
+			avgMilliDiffCount++;
+		}
+		int x = 25;
+		int y = 3 * height / 17;
+		int h = 2 * height / 17;
+		DigitalFont.drawString(g, "" + avgMilliDiff, x, y, h,
+				getTextForegroundColor(), getTextBackgroundColor());
+		g.setColor(getTextForegroundColor());
+		g.drawString("Server time diff [ms]", x, y + g.getFontMetrics().getHeight());
+
+		long nanoDiffMs = System.nanoTime() / (int) 1e6 - System.currentTimeMillis();
+		if (firstNanoDiffCount < 10) {
+			firstNanoDiffMs = (firstNanoDiffMs * firstNanoDiffCount + nanoDiffMs) / (firstNanoDiffCount + 1);
+			firstNanoDiffCount++;
+		}
+		final long nanoDiffThresholdMs = 10;
+		if (Math.abs(nanoDiffMs - firstNanoDiffMs) > nanoDiffThresholdMs) {
+			x = width / 3 + 25;
+			DigitalFont.drawString(g, "" + (nanoDiffMs - firstNanoDiffMs), x, y, h,
+					getTextForegroundColor(), getTextBackgroundColor());
+			g.setColor(getTextForegroundColor());
+			g.drawString("nanoTime diff [ms]", x, y + g.getFontMetrics().getHeight());
+		}
+
+		long localMs = System.currentTimeMillis();
+		String s = timeString(localMs);
+		int w = DigitalFont.stringWidth(s, h);
+		x = width - 25 - w;
+		DigitalFont.drawString(g, s, x, y, h,
+				getTextForegroundColor(), getTextBackgroundColor());
+		g.setColor(getTextForegroundColor());
+		g.drawString("Local time", x, y + g.getFontMetrics().getHeight());
+	}
+
+	public void drawSyncLine(Graphics2D g) {
+		long serverMillis = getTimeMs();
+		int x = (int) (System.currentTimeMillis() % 1000) * width / 1000;
+		g.setColor(getTextBackgroundColor());
+		int h = 2 * this.height / 17;
+		g.fillRect(x, 0, width / 100, 2 * h);
+		x = (int) (serverMillis % 1000) * width / 1000;
+		g.setColor(Color.GREEN);
+		g.fillRect(x, 0, width / 100, 2 * h);
 	}
 }


### PR DESCRIPTION
Add a property to enable drawing of local time and time sync details,
and a visible 1 second sync line. When enabled, the server time diff
and local time are shown with a description. If the system nanoTime
and currentTimeMillis differs by more than a threshold, it is also
shown.