### PR TITLE
Fix attribute overriding by CDS

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -108,13 +108,16 @@ public class Group extends ContestObject implements IGroup {
 	@Override
 	protected void getPropertiesImpl(Map<String, Object> props) {
 		super.getPropertiesImpl(props);
-		props.put(ICPC_ID, icpcId);
-		props.put(NAME, name);
+		if (icpcId != null)
+			props.put(ICPC_ID, icpcId);
+		if (name != null)
+			props.put(NAME, name);
 		if (type != null)
 			props.put(TYPE, type);
 		if (isHidden)
 			props.put(HIDDEN, "true");
-		props.put(LOGO, logo);
+		if (logo != null)
+			props.put(LOGO, logo);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -198,13 +198,20 @@ public class Organization extends ContestObject implements IOrganization {
 	@Override
 	protected void getPropertiesImpl(Map<String, Object> props) {
 		super.getPropertiesImpl(props);
-		props.put(ICPC_ID, icpcId);
-		props.put(NAME, name);
-		props.put(FORMAL_NAME, formalName);
-		props.put(COUNTRY, country);
-		props.put(COUNTRY_FLAG, countryFlag);
-		props.put(URL, url);
-		props.put(HASHTAG, hashtag);
+		if (icpcId != null)
+			props.put(ICPC_ID, icpcId);
+		if (name != null)
+			props.put(NAME, name);
+		if (formalName != null)
+			props.put(FORMAL_NAME, formalName);
+		if (country != null)
+			props.put(COUNTRY, country);
+		if (countryFlag != null)
+			props.put(COUNTRY_FLAG, countryFlag);
+		if (url != null)
+			props.put(URL, url);
+		if (hashtag != null)
+			props.put(HASHTAG, hashtag);
 		if (!Double.isNaN(latitude) || !Double.isNaN(longitude)) {
 			List<String> attrs = new ArrayList<>(2);
 			if (!Double.isNaN(latitude))

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -158,8 +158,10 @@ public class Problem extends ContestObject implements IProblem {
 		props.put(NAME, name);
 		if (ordinal != Integer.MIN_VALUE)
 			props.put(ORDINAL, ordinal);
-		props.put(COLOR, color);
-		props.put(RGB, rgb);
+		if (color != null)
+			props.put(COLOR, color);
+		if (rgb != null)
+			props.put(RGB, rgb);
 		if (x != Double.MIN_VALUE)
 			props.put(X, round(x));
 		if (y != Double.MIN_VALUE)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -408,18 +408,28 @@ public class Team extends ContestObject implements ITeam {
 		props.put(NAME, name);
 		if (displayName != null)
 			props.put(DISPLAY_NAME, displayName);
-		props.put(ICPC_ID, icpcId);
+		if (icpcId != null)
+			props.put(ICPC_ID, icpcId);
 		if (groupIds != null)
 			props.put(GROUP_IDS, "[\"" + String.join("\",\"", groupIds) + "\"]");
-		props.put(ORGANIZATION_ID, organizationId);
-		props.put(PHOTO, photo);
-		props.put(VIDEO, video);
-		props.put(BACKUP, backup);
-		props.put(KEY_LOG, keylog);
-		props.put(TOOL_DATA, tooldata);
-		props.put(DESKTOP, desktop);
-		props.put(WEBCAM, webcam);
-		props.put(AUDIO, audio);
+		if (organizationId != null)
+			props.put(ORGANIZATION_ID, organizationId);
+		if (photo != null)
+			props.put(PHOTO, photo);
+		if (video != null)
+			props.put(VIDEO, video);
+		if (backup != null)
+			props.put(BACKUP, backup);
+		if (keylog != null)
+			props.put(KEY_LOG, keylog);
+		if (tooldata != null)
+			props.put(TOOL_DATA, tooldata);
+		if (desktop != null)
+			props.put(DESKTOP, desktop);
+		if (webcam != null)
+			props.put(WEBCAM, webcam);
+		if (audio != null)
+			props.put(AUDIO, audio);
 		if (!Double.isNaN(x) || !Double.isNaN(y) || !Double.isNaN(rotation)) {
 			List<String> attrs = new ArrayList<>(3);
 			if (!Double.isNaN(x))


### PR DESCRIPTION
The org url and hashtag were being overwritten by the CCS. This fixes them by allowing null values to be overridden by default objects in PlaybackContest.