### PR TITLE
Use lighter grays in light mode tiles presentation

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/ScrollingTileScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/ScrollingTileScoreboardPresentation.java
@@ -160,7 +160,7 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 			g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
 			int h = rows * (tileDim.height + TILE_V_GAP) - TILE_V_GAP;
-			g.setColor(Color.DARK_GRAY);
+			g.setColor(isLightMode() ? TeamTileHelper.TILE_BG_LIGHT : TeamTileHelper.TILE_BG);
 			g.fillRect(0, 0, margin - TILE_H_GAP, h);
 			g.setColor(Color.GRAY);
 			g.drawLine(margin - TILE_H_GAP, 0, margin - TILE_H_GAP, h);
@@ -170,7 +170,7 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 				Graphics2D gg = (Graphics2D) g.create();
 				gg.setFont(titleFont);
 				FontMetrics fm = gg.getFontMetrics();
-				gg.setColor(Color.WHITE);
+				gg.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 				gg.translate((margin - TILE_H_GAP + fm.getAscent()) / 2, (h + fm.stringWidth(title)) / 2);
 				gg.rotate(-Math.PI / 2);
 				gg.drawString(title, 0, 0);
@@ -179,9 +179,9 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 
 			if (showClock) {
 				if (getContest().getState().isFrozen())
-					g.setColor(ICPCColors.YELLOW);
+					g.setColor(isLightMode() ? Color.ORANGE.darker() : ICPCColors.YELLOW);
 				else
-					g.setColor(Color.WHITE);
+					g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 				g.setFont(clockFont);
 				FontMetrics fm = g.getFontMetrics();
 				String s = getContestTime();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
@@ -29,7 +29,7 @@ import org.icpc.tools.presentation.contest.internal.TextHelper;
 public class TeamTileHelper {
 	private static final int IN_TILE_GAP = 3;
 	protected static final Color TILE_BG = new Color(50, 50, 50);
-	protected static final Color TILE_BG_LIGHT = new Color(200, 200, 200);
+	protected static final Color TILE_BG_LIGHT = new Color(240, 240, 240);
 	private static final Color PROBLEM_BG = new Color(90, 90, 90);
 	private static final Color PROBLEM_BG_LIGHT = new Color(160, 160, 160);
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileScoreboardPresentation.java
@@ -92,7 +92,7 @@ public class TileScoreboardPresentation extends ScrollingTileScoreboardPresentat
 
 		// draw lines at each change in num solved
 		int arc = tileDim.width / 90;
-		g.setColor(Color.LIGHT_GRAY);
+		g.setColor(isLightMode() ? Color.DARK_GRAY : Color.LIGHT_GRAY);
 		g.setStroke(new BasicStroke(2f));
 		for (Integer i : breaks) {
 			int x = ((i / rows) * (tileDim.width + TILE_H_GAP));


### PR DESCRIPTION
- march tile gray color in header in both light and dark mode
- use dark orange for frozen contest time

<img width="743" alt="Screen Shot 2021-10-04 at 09 50 37" src="https://user-images.githubusercontent.com/995961/135806002-6f3ba20c-181c-43c3-abb9-e7620cf68372.png">

