### PR TITLE
Presentation color/minor fixes

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
@@ -655,6 +655,18 @@ public class FloorMap {
 		// r.y - (int) ((bounds.y - p.getY()) * scale));
 	}
 
+	public Point2D getPosition(Rectangle r, ITeam team) {
+		double teamAreaDepth = 0;
+		IMapInfo mapInfo = contest.getMapInfo();
+		if (mapInfo != null)
+			teamAreaDepth = mapInfo.getTeamAreaDepth();
+
+		double rad = Math.toRadians(team.getRotation() + 180);
+		double x = (team.getX() + Math.cos(rad) * teamAreaDepth / 3);
+		double y = (team.getY() - Math.sin(rad) * teamAreaDepth / 3);
+		return getPosition(r, x, y);
+	}
+
 	public Point2D getPosition(Rectangle r, double x, double y) {
 		Rectangle2D.Double bounds = getBounds(true);
 		double scale = Math.min(r.width / bounds.width, r.height / bounds.height);
@@ -764,9 +776,13 @@ public class FloorMap {
 			String id = t.getId();
 			BufferedImage img = colors.getTeamLogo(id);
 
-			if (img != null)
-				g.drawImage(img, (int) (x1 + t.getX() * scale - img.getWidth() / 2),
-						(int) (y1 + t.getY() * scale - img.getHeight() / 2), null);
+			if (img != null) {
+				double rad = Math.toRadians(t.getRotation() + 180);
+				double x = x1 + (t.getX() + Math.cos(rad) * teamAreaDepth / 3) * scale;
+				double y = y1 + (t.getY() - Math.sin(rad) * teamAreaDepth / 3) * scale;
+
+				g.drawImage(img, (int) (x - img.getWidth() / 2), (int) (y - img.getHeight() / 2), null);
+			}
 		}
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemDetailChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemDetailChart.java
@@ -98,6 +98,9 @@ public class ProblemDetailChart extends AbstractChartPresentation {
 	public void setProperty(String value) {
 		if (value == null || value.isEmpty())
 			return;
+		if (value.startsWith("lightMode:"))
+			return;
+
 		try {
 			targetProblem = Integer.parseInt(value);
 		} catch (Exception e) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
@@ -44,6 +44,7 @@ public class CountdownPresentation extends ClockPresentation {
 		super.aboutToShow();
 		setClockTarget();
 		clock.resetToTarget();
+		clockColor = isLightMode() ? Color.BLACK : Color.WHITE;
 	}
 
 	private void setClockTarget() {
@@ -100,7 +101,7 @@ public class CountdownPresentation extends ClockPresentation {
 
 		if ((startTime - now) < -(switchPoint / timeMultiplier)) {
 			clockColor = EOC_COLOR;
-			return -Math.round((startTime - now) * timeMultiplier + duration);
+			return Math.round((startTime - now) * timeMultiplier + duration);
 		}
 
 		clockColor = isLightMode() ? Color.BLACK : Color.WHITE;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/StatusCountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/StatusCountdownPresentation.java
@@ -132,7 +132,6 @@ public class StatusCountdownPresentation extends CountdownPresentation {
 		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		g.drawOval(x, y, o, o);
 
-		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		FontMetrics fm = g.getFontMetrics();
 		g.drawString(ss.getLabel(), px + o * 5, py + (int) (fm.getAscent() / 2.2f));
 	}
@@ -141,7 +140,6 @@ public class StatusCountdownPresentation extends CountdownPresentation {
 	public void paint(Graphics2D g) {
 		super.paint(g);
 
-		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		g.setFont(font);
 		String s = "Status: Go";
 		IContest contest = getContest();
@@ -153,7 +151,7 @@ public class StatusCountdownPresentation extends CountdownPresentation {
 				s = "Status: Paused";
 		}
 
-		g.setColor(isLightMode() ? Color.WHITE : Color.BLACK);
+		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		FontMetrics fm = g.getFontMetrics();
 		g.drawString(s, (width - fm.stringWidth(s)) / 2, (int) ((height + height / 2.5f) / 2f) + fm.getHeight() * 2);
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/floor/ContestFloorPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/floor/ContestFloorPresentation.java
@@ -19,6 +19,10 @@ import org.icpc.tools.presentation.contest.internal.TextHelper;
 
 public class ContestFloorPresentation extends AbstractICPCPresentation {
 	private static final int MS_PER_TEAM = 2000;
+	private static final Color LIGHTER_GRAY = new Color(240, 240, 240);
+	private static final Color DARKISH_GRAY = new Color(96, 96, 96);
+	private static final Color DARKER_GRAY = new Color(40, 40, 40);
+	private static final Color DARKEST_GRAY = new Color(25, 25, 25);
 
 	protected FloorMap floor;
 
@@ -74,19 +78,44 @@ public class ContestFloorPresentation extends AbstractICPCPresentation {
 			}
 
 			@Override
+			public Color getTeamAreaFillColor() {
+				return isLightMode() ? Color.WHITE : Color.BLACK;
+			}
+
+			@Override
+			public Color getTeamAreaOutlineColor() {
+				return isLightMode() ? Color.LIGHT_GRAY : Color.GRAY;
+			}
+
+			@Override
+			public Color getSeatFillColor() {
+				return isLightMode() ? Color.LIGHT_GRAY : DARKEST_GRAY;
+			}
+
+			@Override
+			public Color getSeatOutlineColor() {
+				return isLightMode() ? Color.GRAY : DARKISH_GRAY;
+			}
+
+			@Override
+			public Color getTextColor() {
+				return isLightMode() ? Color.BLACK : Color.WHITE;
+			}
+
+			@Override
 			public Color getDeskOutlineColor(String teamId) {
-				return Color.BLACK;
+				return isLightMode() ? Color.DARK_GRAY : Color.GRAY;
 			}
 
 			@Override
 			public Color getDeskFillColor(String teamId) {
-				return Color.GRAY;
+				return isLightMode() ? LIGHTER_GRAY : DARKER_GRAY;
 			}
 		});
 
 		if (team != null) {
 			g.setFont(font);
-			g.setColor(Color.WHITE);
+			g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 			String s = team.getActualDisplayName();
 			FontMetrics fm = g.getFontMetrics();
 			int hh = fm.getHeight() + 10;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
@@ -27,6 +27,8 @@ import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.ImageScaler;
 
 public class BalloonMapPresentation extends AbstractICPCPresentation {
+	private static final double DEFAULT_LONGITUDE = 55.75376;
+	private static final double DEFAULT_LATITUDE = 37.61225;
 	private static final long TIME_TO_KEEP_SOLVED = 11000;
 	private static final long TIME_TO_KEEP_FAILED = 8000;
 	private static final long TIME_TO_KEEP_RECENT = 14000;
@@ -173,10 +175,10 @@ public class BalloonMapPresentation extends AbstractICPCPresentation {
 
 		double o_lon = contest.getLongitude();
 		if (Double.isNaN(o_lon))
-			o_lon = -8.6178885;
+			o_lon = DEFAULT_LONGITUDE;
 		double o_lat = contest.getLatitude();
 		if (Double.isNaN(o_lat))
-			o_lat = 41.1465519;
+			o_lat = DEFAULT_LATITUDE;
 
 		ITeam team = contest.getTeamById(submission.getTeamId());
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileRankScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TileRankScoreboardPresentation.java
@@ -94,21 +94,21 @@ public class TileRankScoreboardPresentation extends ScrollingTileScoreboardPrese
 		int i = 0;
 		while (i < groups.size()) {
 			Group gr = groups.get(i);
-			int arc = tileDim.width / 40;
+			int arc = tileDim.width / 60;
 
-			g.setColor(Color.DARK_GRAY);
+			g.setColor(isLightMode() ? TeamTileHelper.TILE_BG_LIGHT : Color.DARK_GRAY);
 			g.fillRoundRect(0, (int) (gr.y * (tileDim.height + TILE_V_GAP)), margin - TILE_H_GAP,
 					gr.numRows * (tileDim.height + TILE_V_GAP) - TILE_V_GAP, arc, arc);
 
 			String s = gr.numSolved + "";
-			g.setColor(Color.WHITE);
+			g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 			g.setFont(numFont);
 			g.drawString(s, (margin - TILE_H_GAP - fm.stringWidth(s)) / 2,
 					fm.getAscent() + (int) (gr.y * (tileDim.height + TILE_V_GAP)) + TILE_V_GAP * 2);
 
 			if (gr.numRows > 1) {
 				s = Messages.numSolved;
-				g.setColor(Color.LIGHT_GRAY);
+				g.setColor(isLightMode() ? Color.DARK_GRAY : Color.LIGHT_GRAY);
 				g.setFont(solvedFont);
 				g.drawString(s, (margin - TILE_H_GAP - fm2.stringWidth(s)) / 2,
 						fm.getAscent() + fm2.getAscent() + (int) (gr.y * (tileDim.height + TILE_V_GAP)) + TILE_V_GAP * 4);

--- a/PresContest/src/org/icpc/tools/presentation/core/chart/AbstractChartPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/core/chart/AbstractChartPresentation.java
@@ -207,7 +207,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 			g.setFont(titleFont);
 			FontMetrics fm = g.getFontMetrics();
 
-			g.setColor(Color.WHITE);
+			g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 			g.drawString(title, (width / 2) - fm.stringWidth(title) / 2, fm.getAscent() + GAP);
 
 			int ind = fm.getHeight() + GAP * 3;
@@ -236,7 +236,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 			fm = g.getFontMetrics();
 			ind += (fm.getHeight() + GAP);
 			g.setFont(verticalAxisFont);
-			g.setColor(Color.WHITE);
+			g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 			g.drawString(verticalAxisTitle, fm.getHeight(), (height + fm.stringWidth(verticalAxisTitle)) / 2);
 
 			r.width -= (fm.getHeight() + GAP); // right edge
@@ -271,7 +271,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 		}
 
 		// draw left labels
-		g.setColor(Color.WHITE);
+		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		for (int i = 0; i < numLines + 1; i++) {
 			// int y = r.y + r.height * i / size;
 			int y = r.y + r.height;
@@ -287,7 +287,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 		rect = r;
 		initXPoints();
 		numLines = xPoints.length;
-		g.setColor(Color.WHITE);
+		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		int h = r.y + r.height + fm.getAscent() + 8;
 		for (int i = 0; i < numLines; i++) {
 			String s = horizontalLabels[i];
@@ -523,7 +523,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 			if (a < 255)
 				g.setPaint(new Color(255, 255, 255, a));
 			else
-				g.setPaint(Color.WHITE);
+				g.setPaint(isLightMode() ? Color.BLACK : Color.WHITE);
 			for (int i = 0; i < size; i++) {
 				String s = series.getValueLabel(i);
 				FontMetrics fm = g.getFontMetrics();
@@ -626,7 +626,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 		rect = paintBackgroundRect(g);
 
 		// draw rectangle
-		g.setColor(Color.WHITE);
+		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		g.drawLine(rect.x, rect.y + rect.height, rect.x + rect.width, rect.y + rect.height);
 
 		Graphics2D g2 = (Graphics2D) g.create();
@@ -687,10 +687,10 @@ public abstract class AbstractChartPresentation extends Presentation {
 			w = Math.max(w, MARGIN * 2 + fh + MARGIN + fm.stringWidth(s[i]));
 
 		g.translate(-w, 0);
-		g.setColor(new Color(0, 0, 0, 192));
+		g.setColor(isLightMode() ? new Color(255, 255, 255, 192) : new Color(0, 0, 0, 192));
 		g.fillRect(0, 0, w, h);
 
-		g.setColor(Color.WHITE);
+		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		g.drawRect(0, 0, w, h);
 
 		g.translate(MARGIN, MARGIN);
@@ -705,7 +705,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 			g.setStroke(new BasicStroke(2.0f));
 			g.setPaint(series.getOutline(i));
 			g.drawRect(0, y, fh, fh);
-			g.setColor(Color.WHITE);
+			g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 			g.drawString(series.getTitle(), MARGIN + fh, y + fm.getAscent() + 1);
 			y += fh + MARGIN;
 		}


### PR DESCRIPTION
Changes:
- Fixed countdown so it shows pause time even if opened after pause. EoC countdown now negative.
- Floor map presentations - move team logo over the chairs and improved colours.
- Balloon floor presentation - stop balloons at 2m instead of 98%, logo under balloons when small.
- Default contest location changed to Moscow.
- Light mode for charts, floor maps, etc