### PR TITLE
Fix scoreboard light mode

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/Legend.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/Legend.java
@@ -23,7 +23,7 @@ public class Legend {
 		font = ICPCFont.deriveFont(Font.BOLD, 24);
 	}
 
-	public static void drawLegend(Graphics2D g) {
+	public static void drawLegend(Graphics2D g, boolean light) {
 		if (font == null)
 			init(g);
 
@@ -32,7 +32,7 @@ public class Legend {
 		FontMetrics fm = g.getFontMetrics();
 
 		Color c = new Color(255, 255, 255);
-		g.setColor(new Color(0, 0, 0, 192));
+		g.setColor(light ? new Color(255, 255, 255, 192) : new Color(0, 0, 0, 192));
 
 		int fh = fm.getHeight();
 		int fx = fh * 2;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -631,6 +631,8 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 
 	@Override
 	public void setProperty(String value) {
+		super.setProperty(value);
+
 		if (value.startsWith("focusTeam:")) {
 			try {
 				setFocusOnTeam(value.substring(11)); // TODO 2017 look up team by number
@@ -643,7 +645,6 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 			} catch (Exception e) {
 				// ignore
 			}
-		} else
-			super.setProperty(value);
+		}
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
@@ -5,8 +5,8 @@ import java.awt.Graphics2D;
 
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.presentation.contest.internal.Animator;
-import org.icpc.tools.presentation.contest.internal.ScrollAnimator;
 import org.icpc.tools.presentation.contest.internal.Animator.Movement;
+import org.icpc.tools.presentation.contest.internal.ScrollAnimator;
 
 public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardPresentation {
 	private static final int MS_PER_PAGE = 12 * 1000; // scroll a page every 12 seconds
@@ -110,6 +110,8 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 
 	@Override
 	public void setProperty(String value) {
+		super.setProperty(value);
+
 		if (value.startsWith("scroll:")) {
 			try {
 				String val = value.substring(7);
@@ -119,7 +121,6 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 			} catch (Exception e) {
 				// ignore
 			}
-		} else
-			super.setProperty(value);
+		}
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/ScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/ScoreboardPresentation.java
@@ -125,7 +125,7 @@ public class ScoreboardPresentation extends AbstractScrollingScoreboardPresentat
 	protected void paintLegend(Graphics2D g) {
 		if (showLegend) {
 			g.translate(width - 30, height - 200);
-			Legend.drawLegend(g);
+			Legend.drawLegend(g, isLightMode());
 			g.translate(30 - width, 200 - height);
 		}
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
@@ -198,7 +198,7 @@ public class TimelinePresentation extends AbstractScrollingScoreboardPresentatio
 	@Override
 	protected void paintLegend(Graphics2D g) {
 		g.translate(width - 30, height - 230);
-		Legend.drawLegend(g);
+		Legend.drawLegend(g, isLightMode());
 		g.translate(30 - width, -(height - 230));
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -298,9 +298,9 @@ public class StandaloneLauncher {
 		} catch (Exception e) {
 			Trace.trace(Trace.WARNING, "Invalid display option: " + displayStr + " " + e.getMessage());
 		}
-		window.setPresentations(0, presentation, null);
-		((PresentationWindowImpl) window).showFPS(true);
 		if (lightMode)
 			((PresentationWindowImpl) window).setLightMode(true);
+		window.setPresentations(0, presentation, null);
+		((PresentationWindowImpl) window).showFPS(true);
 	}
 }

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -451,6 +451,10 @@ public class PresentationWindowImpl extends PresentationWindow {
 		Dimension d = getPresentationSize();
 		for (Presentation p : newPresentations) {
 			Trace.trace(Trace.INFO, "Initializing presentation " + p);
+			if (lightMode)
+				p.setProperty("lightMode:light");
+			else
+				p.setProperty("lightMode:dark");
 			if (!p.getSize().equals(d))
 				p.setSize(d);
 			p.init();
@@ -472,11 +476,6 @@ public class PresentationWindowImpl extends PresentationWindow {
 
 		// trace plan
 		Trace.trace(Trace.INFO, "Next presentation plan: " + nextPlan);
-
-		if (lightMode)
-			setProperty("lightMode", "light");
-		else
-			setProperty("lightMode", "dark");
 
 		notifyPaintThread();
 	}


### PR DESCRIPTION
The main/old scoreboard header wasn't handling light mode because it was set after the header image was created. This makes sure it is set before setting the size or other methods. Also fixed the legend and made setProperty() always call the super first.