### PR TITLE
Sort problems by ordinal in CDS web

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/details-admin/problems.html
+++ b/CDS/WebContent/WEB-INF/jsps/details-admin/problems.html
@@ -37,7 +37,7 @@ registerContestObjectTable("problems");
 
 $(document).ready(function () {
     $.when(contest.loadProblems()).done(function () {
-        fillContestObjectTable("problems", contest.getProblems())
+        fillContestObjectTable("problems", sortProblems(contest.getProblems()))
     }).fail(function (result) {
     	console.log("Error loading problems: " + result);
     });

--- a/CDS/WebContent/WEB-INF/jsps/details/problems.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/problems.html
@@ -26,7 +26,7 @@ registerContestObjectTable("problems");
 
 $(document).ready(function () {
 	$.when(contest.loadProblems()).done(function () {
-        fillContestObjectTable("problems", contest.getProblems())
+        fillContestObjectTable("problems", sortProblems(contest.getProblems()))
     }).fail(function (result) {
     	console.log("Error loading problems: " + result);
     });

--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -67,7 +67,7 @@ $(document).ready(function () {
         var row = $('<tr></tr>');
         row.append(toHtml("header-start"));
    
-        problems = contest.getProblems();
+        problems = sortProblems(contest.getProblems());
         for (var i = 0; i < problems.length; i++) {
         	var p = { label: problems[i].label };
         	p = addColors(p, problems[i].rgb);
@@ -83,7 +83,7 @@ $(document).ready(function () {
         score = contest.getScoreboard();
         teams = contest.getTeams();
         orgs = contest.getOrganizations();
-        problems = contest.getProblems();
+        problems = sortProblems(contest.getProblems());
         for (var i = 0; i < score.rows.length; i++) {
             var scr = score.rows[i];
             var logoSrc = '';

--- a/CDS/WebContent/js/model.js
+++ b/CDS/WebContent/js/model.js
@@ -134,3 +134,7 @@ function isFirstToSolve(contest, submission) {
    }
    return false;
 }
+
+function sortProblems(problems) {
+   return problems.sort((a,b) => (a.ordinal > b.ordinal) ? 1 : ((b.ordinal > a.ordinal) ? -1 : 0));
+}


### PR DESCRIPTION
For reasons I can only assume are evil ;-), a certain Swedish CCS outputs problems in random order. This is spec-valid and can happen in other situations though (e.g. last minute problem reordering at finals), so the CDS web UI should handle it correctly. This change sorts CDS scoreboard by problem ordinal, and default sorts problems by ordinal on the details pages.