### PR TITLE
Don't parse "null" location string as -1

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONParser.java
@@ -87,7 +87,7 @@ public class JSONParser {
 				String value = (String) props.get(key);
 				return Double.parseDouble(value);
 			} catch (Exception e) {
-				return -1;
+				return Double.NaN;
 			}
 		}
 


### PR DESCRIPTION
Fredrik showed me a case where Kattis was outputting "null" for the decimal location attribute, but the CDS would interpret and export this as -1. This correctly reads as NaN, which will trigger the CDS to skip it on output.