### PR TITLE
Hidden Groups -> Team

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -355,6 +355,20 @@ public class PlaybackContest extends Contest {
 			}
 		}
 
+		if (obj instanceof Group) {
+			Group g = (Group) obj;
+			if (g.isHidden()) {
+				for (ITeam team : getTeams()) {
+					for (String gId : team.getGroupIds()) {
+						if (gId.equals(g.getId()) && !team.isHidden()) {
+							((Team) team).add("hidden", "true");
+							add(team);
+						}
+					}
+				}
+			}
+		}
+
 		if (obj instanceof Submission) {
 			Submission sub = (Submission) obj;
 


### PR DESCRIPTION
When a group becomes hidden after the teams are created, the CDS doesn't support backward compatibility and make the teams hidden. This should fix that.