### PR TITLE
Fix loading from local feed

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -87,12 +87,8 @@ public abstract class ContestSource {
 			return new RESTContestSource(source, user, password);
 
 		File f = new File(source);
-		if (f.exists()) {
-			if (f.isDirectory())
-				return new DiskContestSource(f);
-
+		if (f.exists())
 			return new RESTContestSource(f, user, password);
-		}
 
 		throw new IOException("Could not parse or resolve contest source");
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -77,45 +77,35 @@ public class RESTContestSource extends DiskContestSource {
 	 * @throws MalformedURLException
 	 */
 	public RESTContestSource(String url, String user, String password) throws MalformedURLException {
-		this(null, null, url, user, password);
+		this(null, url, user, password);
 	}
 
 	/**
-	 * Creates a contest source from a local event feed file, with ability to load absolute
-	 * references, with local temp caching.
+	 * Creates a contest source from a local contest archive or event feed, with ability to load
+	 * absolute references, with local temp caching.
 	 *
-	 * @param eventFeedFile
+	 * @param file
 	 * @param user
 	 * @param password
 	 * @throws MalformedURLException
 	 */
-	public RESTContestSource(File eventFeedFile, String user, String password) throws MalformedURLException {
-		this(eventFeedFile, null, user, password);
+	public RESTContestSource(File file, String user, String password) throws MalformedURLException {
+		this(file, null, user, password);
 	}
 
 	/**
-	 * Creates a REST contest source backed by a local contest archive format folder.
+	 * General purpose constructor for a REST contest source. Creates a REST contest source backed
+	 * by a local contest archive format folder.
 	 *
-	 * @param folder
-	 * @param url
-	 * @param user
-	 * @param password
-	 * @param folder
+	 * Usually only one of the eventFeedFile and folder are used. URL is only optional if you
+	 * already have a local contest cached and only want the ability to load absolute file
+	 * references.
 	 */
-	public RESTContestSource(File folder, String url, String user, String password) throws MalformedURLException {
-		this(null, folder, url, user, password);
-	}
+	public RESTContestSource(File file, String url, String user, String password) throws MalformedURLException {
+		super(file, url);
 
-	/**
-	 * General purpose constructor for a REST contest source. Usually only one of the eventFeedFile
-	 * and folder are used. URL is only optional if you already have a local contest cached and only
-	 * want the ability to load absolute file references.
-	 */
-	private RESTContestSource(File eventFeedFile, File folder, String url, String user, String password)
-			throws MalformedURLException {
-		super(eventFeedFile, folder, url);
-
-		this.url = new URL(url);
+		if (url != null)
+			this.url = new URL(url);
 
 		if (user != null && user.trim().length() > 0)
 			this.user = user;
@@ -125,8 +115,10 @@ public class RESTContestSource extends DiskContestSource {
 
 		instance = this;
 
-		validateURL();
-		setup();
+		if (url != null) {
+			validateURL();
+			setup();
+		}
 
 		if (eventFeedFile == null) {
 			String name = System.getProperty("CDS-name");
@@ -430,7 +422,7 @@ public class RESTContestSource extends DiskContestSource {
 	}
 
 	private String getLastCachedEventId() throws Exception {
-		if (!feedCacheFile.exists())
+		if (feedCacheFile == null || !feedCacheFile.exists())
 			return null;
 
 		InputStream in = null;
@@ -468,7 +460,7 @@ public class RESTContestSource extends DiskContestSource {
 	}
 
 	private void readFromFeedCache() throws Exception {
-		if (!feedCacheFile.exists())
+		if (feedCacheFile == null || !feedCacheFile.exists())
 			return;
 
 		InputStream in = null;
@@ -526,7 +518,7 @@ public class RESTContestSource extends DiskContestSource {
 
 	@Override
 	protected void loadContestImpl() throws Exception {
-		if (feedFile != null)
+		if (url == null || feedFile != null)
 			return;
 
 		InputStream in = null;


### PR DESCRIPTION
I broke command line tools reading from a standalone event feed in PR #389. This was reported in issue #536. Instead of the fix suggested (undoing from REST to Disk source), I'm going all in.

In the beginning, there was a PC^2 source, then an XML socket source, then an XML disk source, and then a disk source that would read XML + logos... Then came JSON. At one point I counted something like 7 different ways that you could load contests, each of them was very different, and there were inconsistencies in all of them.

Now the only real/current sources are the Contest API, a contest archive, or a saved feed. Any of these could have a feed that contains relative or absolute URLs. We've already had requests to support a local feed that has absolute URLs requiring auth, which means you might need the REST connector and caching even when reading a local JSON file.

This change fixes the regression and goes one step further than before, having the command line tools always use the REST source (so that absolute references work), even when loading from disk. At some point maybe we should merge Disk/REST sources, or remove other references to the disk source, but IMHO this is a good step towards simplifying and consistency.