### PR TITLE
Add CDS name to web

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/about.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/about.jsp
@@ -12,7 +12,7 @@
             <table class="table table-sm table-hover table-striped mb-4">
                 <tbody>
                 <tr>
-                    <td>ICPC Tools</td>
+                    <td>ICPC Tools website</td>
                     <td><a href="http://tools.icpc.global"
                            target="_blank">http://tools.icpc.global</a></td>
                 </tr>
@@ -22,15 +22,9 @@
                            target="_blank">https://ccs-specs.icpc.io</a></td>
                 </tr>
                 <tr>
-                    <td>Github (private)</td>
+                    <td>Github</td>
                     <td>
                         <a href="https://github.com/icpctools/icpctools" target="_blank">https://github.com/icpctools/icpctools</a>
-                    </td>
-                </tr>
-                <tr>
-                    <td>All builds</td>
-                    <td>
-                        <a href="https://tools.icpc.global/all-builds/" target="_blank">https://tools.icpc.global/all-builds/</a>
                     </td>
                 </tr>
                 </tbody>

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -12,6 +12,7 @@
     	webroot = request.getContextPath() + "/contests/" + cc.getId();
     	apiRoot = request.getContextPath() + "/api/contests/" + cc.getId();
     }
+    String cdsName = System.getProperty("CDS-name");
     String[] menuPages = {"", "/details", "/registration", "/clarifications", "/submissions", "/scoreboard", "/commentary", "/admin", "/video", "/reports"};
     String[] menuTitles = {"Overview", "Details", "Registration", "Clarifications", "Submissions", "Scoreboard", "Commentary", "Admin", "Video", "Reports"};
     String[] menuIcons = {"fa-globe", "fa-info", "fa-users", "fa-comments", "fa-share", "fa-trophy", "fa-comments", "fa-user-cog", "fa-video", "fa-file-alt"};
@@ -29,7 +30,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
   <meta http-equiv="x-ua-compatible" content="ie=edge"/>
 
-  <title>CDS</title>
+  <title><% if ("cds".equals(cdsName)) { %>CDS<% } else { %><%= cdsName %><% } %></title>
 
   <link rel="stylesheet" href="${pageContext.request.contextPath}/fontawesome-free/css/all.min.css"/>
   <link rel="stylesheet" href="${pageContext.request.contextPath}/css/adminlte.min.css"/>
@@ -115,7 +116,9 @@
       <a href="/" class="brand-link">
         <img src="${pageContext.request.contextPath}/cdsIcon.png" alt="CDS Logo"
           class="brand-image img-circle elevation-3"/>
-        <span class="brand-text font-weight-light">Contest Data Server</span>
+        <span class="brand-text font-weight-light">
+          <% if ("cds".equals(cdsName)) { %>Contest Data Server<% } else { %><%= cdsName %><% } %>
+        </span>
       </a>
 
       <!-- Sidebar -->

--- a/CDS/WebContent/WEB-INF/jsps/welcome.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/welcome.jsp
@@ -1,11 +1,11 @@
 <% request.setAttribute("title", "Contests"); %>
+<%@ include file="layout/head.jsp" %>
 <script src="${pageContext.request.contextPath}/js/contest.js"></script>
 <script src="${pageContext.request.contextPath}/js/model.js"></script>
 <script src="${pageContext.request.contextPath}/js/luxon.min.js"></script>
 <script src="${pageContext.request.contextPath}/js/ui.js"></script>
 <script src="${pageContext.request.contextPath}/js/types.js"></script>
 <script src="${pageContext.request.contextPath}/js/mustache.min.js"></script>
-<%@ include file="layout/head.jsp" %>
 <div class="container-fluid">
   <div class="row">
     <div id="contests" class="col-12">


### PR DESCRIPTION
If you name a CDS (either through non-default folder name, or adding <cds name="My name"> to the cdsConfig.xml), we'll replace the standard CDS title at the top left and the page title so that you can tell multiple CDSs apart. Also updated the About page, and reordered the welcome include b/c it was affecting the header and footer.