### PR TITLE
Animated & improved scoreboard

### DIFF
--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -169,6 +169,10 @@ class Contest {
 		return this.loadObject('scoreboard', (result) => { this.scoreboard = result });
 	}
 
+	clearScoreboard() {
+		this.scoreboard = null;
+	}
+
 	loadAwards() {
 		if (this.awards != null)
 			return new $.Deferred().resolve();


### PR DESCRIPTION
Removed org column (table was getting too wide) and added a Refresh button. When you click, it re-downloads the scoreboard and animates the changes.

At some point this should be animated, and ideally triggered from event feed changes that affect the scoreboard. Leaving as manual now to get more feedback/testing (Safari & Chrome work) and make sure the animation is solid.