### PR TITLE
Use Google Maps to geocode organization lat/lon if not present.

### DIFF
--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/GoogleMapsGeocoder.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/GoogleMapsGeocoder.java
@@ -1,0 +1,68 @@
+package org.icpc.tools.contest.util.cms;
+
+import org.icpc.tools.contest.model.feed.JSONParser;
+import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
+import org.icpc.tools.contest.model.internal.Organization;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Class that uses the Google Maps geocode API to find the address of an organization
+ */
+public class GoogleMapsGeocoder {
+	private final String apiKey;
+
+	private static final HttpClient httpClient = HttpClient.newBuilder().build();
+
+	public GoogleMapsGeocoder(String apiKey) {
+		this.apiKey = apiKey;
+	}
+
+	public void geocode(Organization org) {
+		String address = URLEncoder.encode(org.getFormalName() + " " + org.getCountry(), StandardCharsets.UTF_8);
+		String fullUrl = "https://maps.googleapis.com/maps/api/geocode/json?address=" + address + "&key=" + apiKey;
+
+		try {
+			HttpRequest request = HttpRequest.newBuilder(new URI(fullUrl))
+					.header("Accept", "application/json")
+					.build();
+
+			HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+			if (response.statusCode() != 200)
+				return;
+
+			JsonObject json = (new JSONParser(response.body())).readObject();
+
+			if (!json.containsKey("results")) {
+				return;
+			}
+
+			Object[] results = json.getArray("results");
+			if (results.length > 1) {
+				System.err.println("Geocode for " + org.getName() + " returned " + results.length + " results, using first one");
+			} else if (results.length == 0) {
+				System.err.println("Geocode for " + org.getName() + " returned no results");
+				return;
+			}
+
+			JsonObject result = (JsonObject) results[0];
+			JsonObject location = result.getJsonObject("geometry").getJsonObject("location");
+			String lat = location.getString("lat");
+			String lon = location.getString("lng");
+			JsonObject obj = new JsonObject();
+			obj.props.put("latitude", lat);
+			obj.props.put("longitude", lon);
+			org.add("location", obj);
+		} catch (URISyntaxException | IOException | InterruptedException | IllegalArgumentException e) {
+			e.printStackTrace();
+		}
+	}
+}

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -57,9 +57,11 @@ public class JsonToTSVConverter {
 	protected static List<CMSWinner> winnerList = new ArrayList<>();
 	protected static List<String> contestIdList = new ArrayList<>();
 
+	protected static GoogleMapsGeocoder geocoder;
+
 	public static void main(String[] args) {
-		if (args == null || args.length < 1 || args.length > 3) {
-			System.err.println("Usage: command [cmsRoot] [contestRoot] [option]");
+		if (args == null || args.length < 1 || args.length > 4) {
+			System.err.println("Usage: command [cmsRoot] [contestRoot] [googleMapsKey] [option]");
 			System.exit(1);
 		}
 
@@ -71,7 +73,10 @@ public class JsonToTSVConverter {
 			System.exit(1);
 		}
 
-		if (args.length == 3 && "--finals".equals(args[2]))
+		if (args.length >= 3)
+			geocoder = new GoogleMapsGeocoder(args[2]);
+
+		if (args.length == 4 && "--finals".equals(args[3]))
 			FINALS_NAMING = true;
 
 		generateContest(cmsRoot, contestRoot);
@@ -271,6 +276,14 @@ public class JsonToTSVConverter {
 			memberList.sort((m1, m2) -> compare(m1.getTeamId(), m2.getTeamId()));
 		} catch (Exception e) {
 			e.printStackTrace();
+		}
+
+		if (geocoder != null) {
+			for (Organization o : orgList) {
+				if (Double.isNaN(o.getLatitude()) || Double.isNaN(o.getLongitude())) {
+					geocoder.geocode(o);
+				}
+			}
 		}
 
 		try {


### PR DESCRIPTION
For now it is automatically used if you add a third argument to the JsonToTSVConverter with (a valid) Google Maps API key. Later if we have something decent from the CMS we can move the call.

I tested it on the BAPC dataset (which only has 3 out of 13 orgs with lat/lon in the CMS) and it seems to work.