### PR TITLE
Java 17 / Open Liberty 20.0.0.10

### DIFF
--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -5,5 +5,5 @@ RUN apt-get update \
    && apt-get install -y ant pandoc texlive \
    && rm -rf /var/lib/apt/lists/*
 COPY /cds wlp/usr/servers/cds
-RUN wget -O liberty.zip https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2021-01-13_1459/openliberty-webProfile8-21.0.0.1.zip \
+RUN wget -O liberty.zip https://public.dhe.ibm.com/ibmdl/export/pub/software/openliberty/runtime/release/2021-09-20_1900/openliberty-webProfile8-21.0.0.10.zip \
    && unzip liberty.zip && /wlp/bin/server package cds --archive=../../../../cds.zip --include=minify && rm -f liberty.zip && rm -rf wlp


### PR DESCRIPTION
Move to Open Liberty 20.0.0.10, which adds support for Java 17 to the CDS.