### PR TITLE
Presentation admin dark mode

### DIFF
--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/ClientsControl.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/ClientsControl.java
@@ -466,7 +466,6 @@ public class ClientsControl extends Canvas {
 		shell.setLayout(layout);
 
 		Text t = new Text(shell, SWT.MULTI | SWT.H_SCROLL | SWT.V_SCROLL);
-		t.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
 		t.setText(log);
 		GridData data = new GridData(GridData.FILL_BOTH);
 		data.widthHint = 800;
@@ -680,7 +679,7 @@ public class ClientsControl extends Canvas {
 		// long time = System.currentTimeMillis();
 
 		GC gc = event.gc;
-		gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		gc.fillRectangle(rect.x + 1, rect.y + 1, rect.width - 2, rect.height - 2);
 
 		Font font = getDisplay().getSystemFont();
@@ -762,7 +761,7 @@ public class ClientsControl extends Canvas {
 				if (selection.contains(uid))
 					gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT));
 				else
-					gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
+					gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_LIST_FOREGROUND));
 
 				// name & current resolution/fps
 				if (dc != null && dc.id != -1)

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/PresentationInfoListControl.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/PresentationInfoListControl.java
@@ -494,7 +494,7 @@ public class PresentationInfoListControl extends Canvas {
 			return;
 
 		GC gc = event.gc;
-		gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_WHITE));
+		gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_LIST_BACKGROUND));
 		gc.fillRectangle(rect.x + 1, rect.y + 1, rect.width - 2, rect.height - 2);
 
 		Font font = getDisplay().getSystemFont();
@@ -557,7 +557,7 @@ public class PresentationInfoListControl extends Canvas {
 
 					// draw category
 					if (categoryIsClosed)
-						gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_GRAY));
+						gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_TITLE_INACTIVE_BACKGROUND));
 					else
 						gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
 
@@ -630,7 +630,7 @@ public class PresentationInfoListControl extends Canvas {
 			}
 
 			if (displayStyle == DisplayStyle.CATEGORY) {
-				gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_DARK_GRAY));
+				gc.setBackground(getDisplay().getSystemColor(SWT.COLOR_WIDGET_BACKGROUND));
 				if (lastIsSelection)
 					gc.fillRectangle(x - GAP + 1 + SEL_MARGIN, y, GAP - 1 - SEL_MARGIN, thumbnailSize.height + 1);
 				else
@@ -655,7 +655,7 @@ public class PresentationInfoListControl extends Canvas {
 			if (selection == info)
 				gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_LIST_SELECTION_TEXT));
 			else
-				gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_BLACK));
+				gc.setForeground(getDisplay().getSystemColor(SWT.COLOR_LIST_FOREGROUND));
 
 			String name = getName(info);
 			Point p = gc.textExtent(name);


### PR DESCRIPTION
When running on Java 17 SWT picks up the system dark mode correctly, but custom components had hard coded colours.