### PR TITLE
Use Java 17 for CDS Docker image, which is now supported by the CDS.

### DIFF
--- a/build/cds/Docker/Dockerfile
+++ b/build/cds/Docker/Dockerfile
@@ -6,15 +6,13 @@ ARG CDS_VERSION
 
 # Install dependencies
 RUN apt-get update && \ 
-    apt-get install -y --no-install-recommends unzip ca-certificates curl && \
+    apt-get install -y --no-install-recommends unzip ca-certificates curl zip && \
     rm -rf /var/lib/apt/lists/
 
-# Install java
-RUN mkdir -p /opt/jdk && \
-    curl -L -o /root/openjdk15.tar.gz https://download.java.net/java/GA/jdk15.0.2/0d1cfde4252546c6931946de8db48ee2/7/GPL/openjdk-15.0.2_linux-x64_bin.tar.gz && \
-    tar -zxf /root/openjdk15.tar.gz -C /opt/jdk && \
-    update-alternatives --install /usr/bin/java java /opt/jdk/jdk-15.0.2/bin/java 100 && \
-    update-alternatives --install /usr/bin/javac javac /opt/jdk/jdk-15.0.2/bin/javac 100
+# Install SDKMAN!
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+RUN curl -s "https://get.sdkman.io" | bash
+RUN source "$HOME/.sdkman/bin/sdkman-init.sh" && sdk install java 17.0.1-open
 
 # Install CDS
 RUN mkdir -p /opt && \

--- a/build/cds/Docker/start.sh
+++ b/build/cds/Docker/start.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -e
 
+source "$HOME/.sdkman/bin/sdkman-init.sh"
+
 if [ -n "${ADMIN_PASSWORD}" ]; then
     sed -i "s|__ADMIN_PASSWORD__|${ADMIN_PASSWORD}|" /opt/wlp/usr/servers/cds/users.xml
 fi


### PR DESCRIPTION
Note that we use SDKMAN! to install Java for two reasons:
* Ubuntu does not have 17.0.1 yet and it seems that the open 17.0.0 on Ubuntu from the Ubuntu repo still crashes with the JNDI error.
* We can now more easily upgrade to any version or JDK we want.