### PR TITLE
Deprecated methods and cleanup

### DIFF
--- a/CDS/src/org/icpc/tools/cds/presentations/Client.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/Client.java
@@ -300,7 +300,7 @@ public class Client {
 
 		// delta difference is < 20ms for at least 2 pings, we know enough
 		if (count > 1 && max < 20)
-			return new Long(total / count);
+			return Long.valueOf(total / count);
 
 		if (count < 3)
 			// not enough response time data yet
@@ -311,7 +311,7 @@ public class Client {
 			return null;
 
 		// we've had at least 3 pings, get rid of 'worst' time outlier and use average
-		return new Long((total - max) / (count - 1));
+		return Long.valueOf((total - max) / (count - 1));
 	}
 
 	protected void writePing() {

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/GoogleMapsGeocoder.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/GoogleMapsGeocoder.java
@@ -1,16 +1,15 @@
 package org.icpc.tools.contest.util.cms;
 
-import org.icpc.tools.contest.model.feed.JSONParser;
-import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
-import org.icpc.tools.contest.model.internal.Organization;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
+
+import org.icpc.tools.contest.model.feed.JSONParser;
+import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
+import org.icpc.tools.contest.model.internal.Organization;
 
 /**
  * Class that uses the Google Maps geocode API to find the address of an organization
@@ -26,7 +25,7 @@ public class GoogleMapsGeocoder {
 		try {
 			String address = URLEncoder.encode(org.getFormalName() + " " + org.getCountry(), "UTF-8");
 			String fullUrl = "https://maps.googleapis.com/maps/api/geocode/json?address=" + address + "&key=" + apiKey;
-			
+
 			HttpURLConnection conn = (HttpURLConnection) (new URL(fullUrl)).openConnection();
 			conn.setRequestProperty("Accept", "application/json");
 			conn.setRequestMethod("GET");
@@ -34,8 +33,7 @@ public class GoogleMapsGeocoder {
 			if (conn.getResponseCode() != 200)
 				return;
 
-			BufferedReader in = new BufferedReader(
-					new InputStreamReader(conn.getInputStream()));
+			BufferedReader in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
 			String inputLine;
 			StringBuilder content = new StringBuilder();
 			while ((inputLine = in.readLine()) != null) {
@@ -52,7 +50,8 @@ public class GoogleMapsGeocoder {
 
 			Object[] results = json.getArray("results");
 			if (results.length > 1) {
-				System.err.println("Geocode for " + org.getName() + " returned " + results.length + " results, using first one");
+				System.err.println(
+						"Geocode for " + org.getName() + " returned " + results.length + " results, using first one");
 			} else if (results.length == 0) {
 				System.err.println("Geocode for " + org.getName() + " returned no results");
 				return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -205,8 +205,8 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void incrementTimeMs(long dt) {
-		dt *= timeFactor;
+	public void incrementTimeMs(long dt2) {
+		long dt = (long) (dt2 * timeFactor);
 		if (zooms == null || zooms.length == 0)
 			return;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/WorldPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/WorldPresentation.java
@@ -44,6 +44,7 @@ public class WorldPresentation extends AbstractICPCPresentation {
 
 	Map<String, String> organizationGroups = new TreeMap<>();
 	Map<String, Color> groupColors = new TreeMap<>();
+
 	void groupColors() {
 		IContest contest = getContest();
 
@@ -60,8 +61,8 @@ public class WorldPresentation extends AbstractICPCPresentation {
 				String[] groupIds = t.getGroupIds();
 				if (org != null && GroupPresentation.belongsToGroup(groupIds, groupId)) {
 					if (organizationGroups.containsKey(org.getId())) {
-						System.out.println("" + org.getName() + " belongs to " + org.getName() + " and " +
-								contest.getOrganizationById(organizationGroups.get(org.getId())).getName());
+						System.out.println("" + org.getName() + " belongs to " + org.getName() + " and "
+								+ contest.getOrganizationById(organizationGroups.get(org.getId())).getName());
 					}
 					organizationGroups.put(org.getId(), groupId);
 					memberCount++;
@@ -73,7 +74,7 @@ public class WorldPresentation extends AbstractICPCPresentation {
 		System.out.println("" + contest.getOrganizations().length + " orgs");
 	}
 
-	private float hue(Color c) {
+	private static float hue(Color c) {
 		return Color.RGBtoHSB(c.getRed(), c.getGreen(), c.getBlue(), null)[0];
 	}
 
@@ -135,20 +136,15 @@ public class WorldPresentation extends AbstractICPCPresentation {
 		}
 
 		if (drawLogos && worldLogos != null) {
-			g.setRenderingHint(
-					RenderingHints.KEY_ANTIALIASING,
-					RenderingHints.VALUE_ANTIALIAS_ON);
+			g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 			for (TeamIntroPresentation.Position p : worldLogos.instPos) {
-				int x = (int) (width * (p.x + 180.0) / 360.0);
-				int y = (int) (height * (90 - p.y) / 180.0);
-				if (p.smImage == null) {
+				if (p.smImage == null)
 					continue;
-				}
-				BufferedImage im = p.smImage;
-				//g.drawImage(im, x - im.getWidth() / 2, y - im.getHeight() / 2, null);
 
-				AffineTransform at = AffineTransform.getTranslateInstance(
-						(width * (p.x + 180.0) / 360.0),
+				BufferedImage im = p.smImage;
+				// g.drawImage(im, x - im.getWidth() / 2, y - im.getHeight() / 2, null);
+
+				AffineTransform at = AffineTransform.getTranslateInstance((width * (p.x + 180.0) / 360.0),
 						(height * (90 - p.y) / 180.0));
 				g.drawImage(im, at, null);
 			}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
@@ -192,8 +192,8 @@ public class TeamTileHelper {
 		}
 		if (img == null) {
 			if (approximateRendering) {
-				Trace.trace(Trace.INFO, "" + hashWidth + " approximating " + maxwid +
-						" vs natural width " + naturalWidth + " for " + team.getActualDisplayName());
+				Trace.trace(Trace.INFO, "" + hashWidth + " approximating " + maxwid + " vs natural width " + naturalWidth
+						+ " for " + team.getActualDisplayName());
 			}
 			g.setFont(teamFont);
 			TextHelper text = new TextHelper(g, team.getActualDisplayName());
@@ -210,19 +210,15 @@ public class TeamTileHelper {
 
 			nameImages.put(hash, img);
 		}
-		g.drawImage(img, ww + tileDim.height + IN_TILE_GAP - 1, tileDim.height * 1 / 10 - 2, maxwid + 2,
-				img.getHeight(), null);
+		g.drawImage(img, ww + tileDim.height + IN_TILE_GAP - 1, tileDim.height * 1 / 10 - 2, maxwid + 2, img.getHeight(),
+				null);
 	}
 
 	private void paintTileForeground(Graphics2D g, ITeam team, int timeMs) {
-		RenderPerfTimer.Counter rankAndScoreMeasure =
-				RenderPerfTimer.measure(RenderPerfTimer.Category.RANK_AND_SCORE);
-		RenderPerfTimer.Counter nameMeasure =
-				RenderPerfTimer.measure(RenderPerfTimer.Category.NAME);
-		RenderPerfTimer.Counter problemMeasure =
-				RenderPerfTimer.measure(RenderPerfTimer.Category.PROBLEM);
-		RenderPerfTimer.Counter activeProblemMeasure =
-				RenderPerfTimer.measure(RenderPerfTimer.Category.ACTIVE_PROBLEM);
+		RenderPerfTimer.Counter rankAndScoreMeasure = RenderPerfTimer.measure(RenderPerfTimer.Category.RANK_AND_SCORE);
+		RenderPerfTimer.Counter nameMeasure = RenderPerfTimer.measure(RenderPerfTimer.Category.NAME);
+		RenderPerfTimer.Counter problemMeasure = RenderPerfTimer.measure(RenderPerfTimer.Category.PROBLEM);
+		RenderPerfTimer.Counter activeProblemMeasure = RenderPerfTimer.measure(RenderPerfTimer.Category.ACTIVE_PROBLEM);
 		rankAndScoreMeasure.startMeasure();
 		g.setFont(rankFont);
 		FontMetrics rankFm = g.getFontMetrics();
@@ -287,7 +283,8 @@ public class TeamTileHelper {
 			if (!preRendering && !g.getClip().intersects(xx + (int) (w * i), y, w, h)) {
 				continue;
 			}
-			String hash = r.getNumSubmissions() + "-" + ContestUtil.getTime(r.getContestTime()) + " " + r.getStatus().name() + " " + (int) w;
+			String hash = r.getNumSubmissions() + "-" + ContestUtil.getTime(r.getContestTime()) + " "
+					+ r.getStatus().name() + " " + (int) w;
 			if (r.isFirstToSolve()) {
 				hash += " FIRST";
 			}
@@ -345,8 +342,8 @@ public class TeamTileHelper {
 		problemMeasure.stopMeasure();
 	}
 
-	private BufferedImage getCacheOrRender(String hash, Map<String, BufferedImage> cache,
-										   int w, int h, Consumer<Graphics2D> renderer) {
+	private static BufferedImage getCacheOrRender(String hash, Map<String, BufferedImage> cache, int w, int h,
+			Consumer<Graphics2D> renderer) {
 		BufferedImage img = cache.get(hash);
 		if (img == null) {
 			Trace.trace(Trace.INFO, "cache miss " + hash);
@@ -356,7 +353,7 @@ public class TeamTileHelper {
 		return img;
 	}
 
-	private BufferedImage renderBufferedImage(int w, int h, Consumer<Graphics2D> renderer) {
+	private static BufferedImage renderBufferedImage(int w, int h, Consumer<Graphics2D> renderer) {
 		BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_4BYTE_ABGR);
 		Graphics2D gg = (Graphics2D) img.getGraphics();
 		gg.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
@@ -410,7 +407,7 @@ public class TeamTileHelper {
 				s = r.getNumSubmissions() + "\u200A-\u200A" + ContestUtil.getTime(r.getContestTime());
 
 			g.setFont(statusFont);
-			//g.drawString(s, x + (w - fm.stringWidth(s)) / 2 - 1, y + (h + fm.getAscent()) / 2 - 1);
+			// g.drawString(s, x + (w - fm.stringWidth(s)) / 2 - 1, y + (h + fm.getAscent()) / 2 - 1);
 			// TODO: Use TextHelper.drawFit to fit text that does not fit in the avilable space
 			// note: 9-999 is used to guess the space needed, but number of submissions may be above 9
 			// and not fit.
@@ -450,7 +447,7 @@ public class TeamTileHelper {
 				s = r.getNumSubmissions() + "\u200A-\u200A" + ContestUtil.getTime(r.getContestTime());
 
 			g.setFont(statusFont);
-			//g.drawString(s, (w - fm.stringWidth(s)) / 2 - 1, (h + fm.getAscent()) / 2 - 1);
+			// g.drawString(s, (w - fm.stringWidth(s)) / 2 - 1, (h + fm.getAscent()) / 2 - 1);
 			TextHelper text = new TextHelper(g, s);
 			int sw = text.getWidth();
 			text.drawFit((w - Math.min(sw, w - 4)) / 2 - 2, (h - fm.getAscent()) / 2, w - 4);


### PR DESCRIPTION
Eclipse has been warning me about deprecated methods and code/style cleanup, so throwing a few of these together:

Client - Switch from deprecated 'new Long()' to 'Long.valueOf()'.
GoogleMapsGeocoder - Remove unused import.
TeamIntroPresentation - Don't reassign parameter.
WorldPresentation - Make method static and remove unused vars.
TeamTileHelper - Make 2 methods static.

Apologies for auto formatting changes, but at least it makes these consistent with other classes.