### PR TITLE
Support single team member name, email

### DIFF
--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -399,7 +399,7 @@ public class CoachView extends Panel {
 			String[] names = new String[contestants.size()];
 			for (int i = 0; i < contestants.size(); i++) {
 				ITeamMember tm = contestants.get(i);
-				names[i] = tm.getFirstName() + " " + tm.getLastName();
+				names[i] = tm.getName();
 			}
 			drawLine(g, y, "Contestants", names);
 
@@ -408,7 +408,7 @@ public class CoachView extends Panel {
 			names = new String[staff.size()];
 			for (int i = 0; i < staff.size(); i++) {
 				ITeamMember tm = staff.get(i);
-				names[i] = tm.getFirstName() + " " + tm.getLastName() + " (" + tm.getRole() + ")";
+				names[i] = tm.getName() + " (" + tm.getRole() + ")";
 			}
 			drawLine(g, y, "Staff", names);
 			g.translate(-x, 0);

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeamMember.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeamMember.java
@@ -15,18 +15,18 @@ public interface ITeamMember extends IContestObject {
 	String getICPCId();
 
 	/**
-	 * The person's first name.
+	 * The person's name.
 	 *
-	 * @return the first name
+	 * @return the name
 	 */
-	String getFirstName();
+	String getName();
 
 	/**
-	 * The person's last name.
+	 * The person's email.
 	 *
-	 * @return the last name
+	 * @return the email
 	 */
-	String getLastName();
+	String getEmail();
 
 	/**
 	 * The person's sex (male or female).

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -801,8 +801,8 @@ public class Contest implements IContest {
 		Arrays.sort(tempMembers, (o1, o2) -> {
 			if (o1.getRole() != null && o2.getRole() != null && !o1.getRole().equals(o2.getRole()))
 				return -o1.getRole().compareTo(o2.getRole());
-			if (o1.getLastName() != null && o2.getLastName() != null)
-				return collator.compare(o1.getLastName(), o2.getLastName());
+			if (o1.getName() != null && o2.getName() != null)
+				return collator.compare(o1.getName(), o2.getName());
 			return 0;
 		});
 		return tempMembers;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/TeamMember.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/TeamMember.java
@@ -16,6 +16,8 @@ public class TeamMember extends ContestObject implements ITeamMember {
 	private static final String TEAM_ID = "team_id";
 	private static final String FIRST_NAME = "first_name";
 	private static final String LAST_NAME = "last_name";
+	private static final String NAME = "name";
+	private static final String EMAIL = "email";
 	private static final String SEX = "sex";
 	private static final String ROLE = "role";
 	private static final String PHOTO = "photo";
@@ -29,6 +31,8 @@ public class TeamMember extends ContestObject implements ITeamMember {
 	private String icpcId;
 	private String firstName;
 	private String lastName;
+	private String name;
+	private String email;
 	private String sex;
 	private String teamId;
 	private String role;
@@ -50,14 +54,24 @@ public class TeamMember extends ContestObject implements ITeamMember {
 		return icpcId;
 	}
 
-	@Override
 	public String getFirstName() {
 		return firstName;
 	}
 
-	@Override
 	public String getLastName() {
 		return lastName;
+	}
+
+	@Override
+	public String getName() {
+		if (name == null && firstName != null && lastName != null)
+			return firstName + " " + lastName;
+		return name;
+	}
+
+	@Override
+	public String getEmail() {
+		return email;
 	}
 
 	@Override
@@ -111,6 +125,14 @@ public class TeamMember extends ContestObject implements ITeamMember {
 			}
 			case LAST_NAME: {
 				lastName = (String) value;
+				return true;
+			}
+			case NAME: {
+				name = (String) value;
+				return true;
+			}
+			case EMAIL: {
+				email = (String) value;
 				return true;
 			}
 			case SEX: {
@@ -267,6 +289,8 @@ public class TeamMember extends ContestObject implements ITeamMember {
 		t.icpcId = icpcId;
 		t.firstName = firstName;
 		t.lastName = lastName;
+		t.name = name;
+		t.email = email;
 		t.sex = sex;
 		t.teamId = teamId;
 		t.role = role;
@@ -276,9 +300,16 @@ public class TeamMember extends ContestObject implements ITeamMember {
 	@Override
 	protected void getPropertiesImpl(Map<String, Object> props) {
 		super.getPropertiesImpl(props);
-		props.put(ICPC_ID, icpcId);
-		props.put(FIRST_NAME, firstName);
-		props.put(LAST_NAME, lastName);
+		if (icpcId != null)
+			props.put(ICPC_ID, icpcId);
+		if (firstName != null)
+			props.put(FIRST_NAME, firstName);
+		if (lastName != null)
+			props.put(LAST_NAME, lastName);
+		if (name != null)
+			props.put(NAME, name);
+		if (email != null)
+			props.put(EMAIL, email);
 		props.put(SEX, sex);
 		props.put(TEAM_ID, teamId);
 		props.put(ROLE, role);
@@ -296,8 +327,14 @@ public class TeamMember extends ContestObject implements ITeamMember {
 		je.encode(ID, id);
 		if (icpcId != null)
 			je.encode(ICPC_ID, icpcId);
-		je.encode(FIRST_NAME, firstName);
-		je.encode(LAST_NAME, lastName);
+		if (firstName != null)
+			je.encode(FIRST_NAME, firstName);
+		if (lastName != null)
+			je.encode(LAST_NAME, lastName);
+		if (name != null)
+			je.encode(NAME, name);
+		if (email != null)
+			je.encode(EMAIL, email);
 		je.encode(SEX, sex);
 		je.encode(TEAM_ID, teamId);
 		je.encode(ROLE, role);
@@ -317,11 +354,8 @@ public class TeamMember extends ContestObject implements ITeamMember {
 		if (c.getTeamById(teamId) == null)
 			errors.add("Invalid team " + teamId);
 
-		if (firstName == null || firstName.isEmpty())
-			errors.add("First name missing");
-
-		if (lastName == null || lastName.isEmpty())
-			errors.add("Last name missing");
+		if (getName() == null || getName().isEmpty())
+			errors.add("Name missing");
 
 		if (sex == null || sex.isEmpty())
 			errors.add("Sex missing");

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/TSVImporter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/TSVImporter.java
@@ -256,7 +256,7 @@ public class TSVImporter {
 								t = tm;
 
 						if (t == null) {
-							System.err.println("Warning: person " + p.getFirstName() + " " + p.getLastName() + " in unknown team " + teamId);
+							System.err.println("Warning: person " + p.getName() + " in unknown team " + teamId);
 						} else {
 							add(p, TEAM_ID, t.getId());
 							String role = st[3];

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
@@ -166,7 +166,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			int size = members.length;
 			currentCache.members = new String[size];
 			for (int i = 0; i < size; i++) {
-				String s = members[i].getFirstName() + " " + members[i].getLastName();
+				String s = members[i].getName();
 				if (!"contestant".equals(members[i].getRole().toLowerCase()))
 					s += " (" + members[i].getRole() + ")";
 				currentCache.members[i] = s;


### PR DESCRIPTION
This is an awkward attempt to move to the new spec but still support the old attributes. For now, the CDS will pass through either set of attributes, but the Java contest API and all clients (Coach view, TSV import, team award pres, contest) have been updated to use just the full name. I suspect we may want to go full toward the new spec at some point, but this has drawbacks in terms of backward compatibility (current feed clients, ability to generate CCS spec members.tsv from CMS data) that I'm not ready to accept for now.