### PR TITLE
Avoid invalid contest object ids

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -365,8 +365,9 @@
     	addStartStatus("Contest Director", 0);
     }
 
-    function addStartStatus(id, status) {
-    	cds.doPut("start-status", id, '{"id":"' + id + '","label":"' + id + '","status":"' + status + '"}', function() { updateStartStatusTable(); });
+    function addStartStatus(text, status) {
+    	var id = text.replace(/[^a-zA-Z0-9_.-]+/g, '_');
+    	cds.doPut("start-status", id, '{"id":"' + id + '","label":"' + text + '","status":"' + status + '"}', function() { updateStartStatusTable(); });
     }
 
     function updateStartStatus(id, status) {

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -683,6 +683,9 @@ public class ContestRESTService extends HttpServlet {
 		} else if (ei.id == null && !IContestObject.isSingleton(ei.cType)) {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing id");
 			return;
+		} else if (!ei.id.matches("[a-zA-Z0-9_.-]*")) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid id");
+			return;
 		}
 
 		Contest contest = ei.cc.getContest();


### PR DESCRIPTION
Block the CDS from accepting PUTs on ids that are invalid, and have the admin UI automatically replace invalid chars with underscores