### PR TITLE
Scoring fixes

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -8,7 +8,7 @@
                 <div class="card-header">
                     <h3 class="card-title">Scoreboard</h3>
                     <div class="card-tools"><a href="<%= apiRoot %>/scoreboard">API</a>
-                    <button id="score-refresh" type="button" class="btn btn-tool" ><i class="fas fa-sync-alt"></i></button>
+                    <button id="score-refresh" type="button" class="btn btn-tool"><i class="fas fa-sync-alt"></i></button>
                     </div>
                 </div>
                 <div class="card-body p-0">
@@ -66,7 +66,7 @@
 <td class="text-center {{ scoreClass }}">{{num}}{{#solved}} / {{time}}{{/solved}}</td>
 </script>
 <script type="text/html" id="cell-score">
-<td class="text-center {{ scoreClass }}">{{score}}{{#solved}} / {{time}}{{/solved}}</td>
+<td class="text-center {{ scoreClass }}">{{score}}{{#score}} / {{time}}{{/score}}</td>
 </script>
 <script type="text/javascript">
 contest = new Contest("/api", "<%= cc.getId() %>");
@@ -99,18 +99,16 @@ function getRow(scr, type) {
             if (prob.problem_id == problems[j].id) {
                 if (prob.first_to_solve == true)
                     obj.scoreClass = 'bg-success';
-                else if (prob.solved == true)
+                else if (prob.solved == true || prob.score > 0)
                     obj.scoreClass = 'table-success';
                 else if (prob.num_pending > 0)
                     obj.scoreClass = 'table-warning';
                 else
                     obj.scoreClass = 'table-danger';
                 obj.num = prob.num_judged + prob.num_pending;
-                if (prob.solved) {
-                	obj.solved = true;
-                    obj.time = prob.time;
-                    obj.score = prob.score;
-            	}
+                obj.solved = prob.solved;
+                obj.time = prob.time;
+                obj.score = prob.score;
             }
         }
         if ("score" == type)
@@ -154,7 +152,7 @@ $(document).ready(function () {
         }
 
         score = contest.getScoreboard();
-        if ("score" == score.scoreboard_type)
+        if ("score" == contest.getInfo().scoreboard_type)
         	row.append(toHtml("header-end-score"));
         else
        		row.append(toHtml("header-end"));
@@ -170,7 +168,7 @@ $(document).ready(function () {
         teams = contest.getTeams();
         orgs = contest.getOrganizations();
         problems = contest.getProblems();
-        var type = score.scoreboard_type;
+        var type = contest.getInfo().scoreboard_type;
         for (var i = 0; i < score.rows.length; i++) {
         	var row = getRow(score.rows[i], type);
             $('#score-table tbody').append(row);
@@ -212,7 +210,7 @@ $(document).ready(function () {
 		});
     }
 
-    $.when(contest.loadOrganizations(), contest.loadTeams(), contest.loadProblems(), contest.loadScoreboard()).done(function () {
+    $.when(contest.loadInfo(),contest.loadOrganizations(), contest.loadTeams(), contest.loadProblems(), contest.loadScoreboard()).done(function () {
     	createTableHeader();
         fillTable();
     }).fail(function (result) {

--- a/ContestModel/src/org/icpc/tools/contest/model/IProblem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IProblem.java
@@ -61,4 +61,11 @@ public interface IProblem extends IContestObject, IPosition {
 	 * @return the time limit
 	 */
 	int getTimeLimit();
+
+	/**
+	 * Returns the maximum expected score for scoring contests.
+	 *
+	 * @return the max score
+	 */
+	Double getMaxScore();
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -56,9 +56,6 @@ public class Scoreboard {
 		}
 
 		ScoreboardType scoreboardType = contest.getScoreboardType();
-		if (scoreboardType != null)
-			pw.write("  \"scoreboard_type\":\"" + scoreboardType.name().toLowerCase() + "\",\n");
-
 		if (scoreboardType == null)
 			scoreboardType = ScoreboardType.PASS_FAIL;
 
@@ -110,13 +107,13 @@ public class Scoreboard {
 					pw.write("\"num_judged\":" + r.getNumJudged() + ",");
 					pw.write("\"num_pending\":" + r.getNumPending() + ",");
 					if (r.getStatus() == Status.SOLVED) {
-						pw.write("\"solved\":true,");
-						pw.write("\"time\":" + ContestUtil.getTime(r.getContestTime()));
 						if (ScoreboardType.PASS_FAIL.equals(scoreboardType)) {
+							pw.write("\"solved\":true");
 							if (r.isFirstToSolve())
 								pw.write(",\"first_to_solve\":true");
 						} else if (ScoreboardType.SCORE.equals(scoreboardType))
-							pw.write(",\"score\":" + round(r.getScore()));
+							pw.write("\"score\":" + round(r.getScore()));
+						pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
 					} else
 						pw.write("\"solved\":false");
 					pw.write("}");

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -20,6 +20,7 @@ public class Problem extends ContestObject implements IProblem {
 	private static final String X = "x";
 	private static final String Y = "y";
 	private static final String TIME_LIMIT = "time_limit";
+	private static final String MAX_SCORE = "max_score";
 
 	private int ordinal = Integer.MIN_VALUE;
 	private String label;
@@ -27,10 +28,11 @@ public class Problem extends ContestObject implements IProblem {
 	private String color;
 	private String rgb;
 	private Color colorVal;
-	private int testDataCount = -1;
+	private int testDataCount;
 	private double x = Double.MIN_VALUE;
 	private double y = Double.MIN_VALUE;
 	private int timeLimit;
+	private Double maxScore;
 
 	@Override
 	public ContestType getType() {
@@ -118,6 +120,11 @@ public class Problem extends ContestObject implements IProblem {
 	}
 
 	@Override
+	public Double getMaxScore() {
+		return maxScore;
+	}
+
+	@Override
 	protected boolean addImpl(String name2, Object value) throws Exception {
 		if (ORDINAL.equals(name2)) {
 			ordinal = parseInt(value);
@@ -140,6 +147,9 @@ public class Problem extends ContestObject implements IProblem {
 			return true;
 		} else if (TIME_LIMIT.equals(name2)) {
 			timeLimit = Decimal.parse((String) value);
+			return true;
+		} else if (MAX_SCORE.equals(name2)) {
+			maxScore = parseDouble(value);
 			return true;
 		} else if (X.equals(name2)) {
 			x = parseDouble(value);
@@ -166,10 +176,11 @@ public class Problem extends ContestObject implements IProblem {
 			props.put(X, round(x));
 		if (y != Double.MIN_VALUE)
 			props.put(Y, round(y));
-		if (testDataCount != -1)
-			props.put(TEST_DATA_COUNT, testDataCount);
+		props.put(TEST_DATA_COUNT, testDataCount);
 		if (timeLimit > 0)
 			props.put(TIME_LIMIT, Decimal.format(timeLimit));
+		if (maxScore != null)
+			props.put(MAX_SCORE, round(maxScore));
 	}
 
 	@Override
@@ -189,10 +200,11 @@ public class Problem extends ContestObject implements IProblem {
 			je.encode(X, round(x));
 		if (y != Double.MIN_VALUE)
 			je.encode(Y, round(y));
-		if (testDataCount != -1)
-			je.encode(TEST_DATA_COUNT, testDataCount);
+		je.encode(TEST_DATA_COUNT, testDataCount);
 		if (timeLimit > 0)
 			je.encodePrimitive(TIME_LIMIT, Decimal.format(timeLimit));
+		if (maxScore != null)
+			je.encode(MAX_SCORE, Math.round(maxScore * 10000.0) / 10000.0); // round to 4 decimals
 	}
 
 	private static double round(double d) {
@@ -209,7 +221,7 @@ public class Problem extends ContestObject implements IProblem {
 		if (label == null || label.isEmpty())
 			errors.add("Label missing");
 
-		if (testDataCount == -1)
+		if (testDataCount == 0)
 			errors.add("Test data count missing");
 
 		if (errors.isEmpty())

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
@@ -66,9 +66,7 @@ public class Result implements IResult {
 				status = Status.SOLVED;
 				numJudged++;
 				penalty = pendingPenalty;
-				if (j.getScore() == null)
-					score = 100;
-				else
+				if (j.getScore() != null)
 					score = j.getScore();
 			} else if (jt.isPenalty()) {
 				status = Status.FAILED;


### PR DESCRIPTION
Changing scoring with the assumption that the current ccs-specs PR icpc/ccs-specs#64 will get accepted. Most of these will make sense either way:
- No assumption that scoreboard_type is in the scoreboard.json.
- Solved attribute is required for pass-fail contests; score for scoring contests.
- Clients (including CDS) no longer need to make assumptions about judgement default scores.
- Added problem max_score.

Also made test_data_count non-optional as per the spec.