### PR TITLE
Fix and update floor map

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestWriter.java
@@ -5,12 +5,12 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.PrintWriter;
 
+import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.internal.Contest;
 
 public class ContestWriter {
-
 	public static void write(IContest contest, File folder) {
 		if (!folder.exists())
 			folder.mkdirs();
@@ -26,23 +26,28 @@ public class ContestWriter {
 				try {
 					File f = new File(folder, name + ".json");
 					BufferedWriter bw = new BufferedWriter(new FileWriter(f));
-					JSONArrayWriter jw = new JSONArrayWriter(new PrintWriter(bw));
-					jw.writePrelude();
+					PrintWriter pw = new PrintWriter(bw);
+					JSONArrayWriter jw = new JSONArrayWriter(pw);
+					if (IContestObject.isSingleton(type)) {
+						jw.write(objs[0]);
+					} else {
+						jw.writePrelude();
 
-					boolean first = true;
-					for (IContestObject co : objs) {
-						if (!first)
-							jw.writeSeparator();
-						else
-							first = false;
+						boolean first = true;
+						for (IContestObject co : objs) {
+							if (!first)
+								jw.writeSeparator();
+							else
+								first = false;
 
-						jw.write(co);
+							jw.write(co);
+						}
+
+						jw.writePostlude();
 					}
-
-					jw.writePostlude();
-					bw.close();
+					pw.close();
 				} catch (Exception e) {
-					e.printStackTrace();
+					Trace.trace(Trace.ERROR, "Could not write contest: " + e.getMessage(), e);
 				}
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/MapInfo.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/MapInfo.java
@@ -123,7 +123,7 @@ public class MapInfo extends ContestObject implements IMapInfo {
 			return false;
 		}
 
-		public void set(double x, double y) {
+		public void setLocation(double x, double y) {
 			this.x = x;
 			this.y = y;
 		}
@@ -240,7 +240,7 @@ public class MapInfo extends ContestObject implements IMapInfo {
 		} else if (PRINTER.equals(name)) {
 			JsonObject obj = JSONParser.getOrReadObject(value);
 			Printer p = new Printer();
-			p.set(obj.getDouble("x"), obj.getDouble("y"));
+			p.setLocation(obj.getDouble("x"), obj.getDouble("y"));
 			printer = p;
 			return true;
 		} else if (SPARE_TEAMS.equals(name)) {
@@ -249,9 +249,7 @@ public class MapInfo extends ContestObject implements IMapInfo {
 			for (Object ob : arr) {
 				JsonObject obj = (JsonObject) ob;
 				Team t = new Team();
-				t.add("x", obj.getDouble("x") + "");
-				t.add("y", obj.getDouble("y") + "");
-				t.add("rotation", obj.getDouble("rotation") + "");
+				t.setLocation(obj.getDouble("x"), obj.getDouble("y"), obj.getDouble("rotation"));
 				spareTeams.add(t);
 			}
 			return true;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -102,6 +102,12 @@ public class Team extends ContestObject implements ITeam {
 		return y;
 	}
 
+	public void setLocation(double x, double y, double rotation) {
+		this.x = x;
+		this.y = y;
+		this.rotation = rotation;
+	}
+
 	@Override
 	public double getRotation() {
 		return rotation;
@@ -298,10 +304,6 @@ public class Team extends ContestObject implements ITeam {
 				}
 				return true;
 			}
-			case "group_id": { /// deprecated - temporary support for Nov 2017 feeds
-				groupIds = new String[] { (String) value };
-				return true;
-			}
 			case ORGANIZATION_ID: {
 				organizationId = (String) value;
 				return true;
@@ -316,18 +318,6 @@ public class Team extends ContestObject implements ITeam {
 			}
 			case DISPLAY_NAME: {
 				displayName = (String) value;
-				return true;
-			}
-			case X: { // deprecated - use child location object
-				x = parseDouble(value);
-				return true;
-			}
-			case Y: { // deprecated - use child location object
-				y = parseDouble(value);
-				return true;
-			}
-			case ROTATION: { // deprecated - use child location object
-				rotation = parseDouble(value);
 				return true;
 			}
 			case LOCATION: {
@@ -373,9 +363,9 @@ public class Team extends ContestObject implements ITeam {
 				isHidden = parseBoolean(value);
 				return true;
 			}
+			default:
+				return false;
 		}
-
-		return false;
 	}
 
 	@Override

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2020.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGenerator2020.java
@@ -5,8 +5,11 @@ import java.io.File;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
 import org.icpc.tools.contest.model.FloorMap.Path;
+import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IPrinter;
+import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.DiskContestSource;
 
 public class FloorGenerator2020 extends FloorGenerator {
 	// team area width (in meters). ICPC standard is 3.0
@@ -18,8 +21,6 @@ public class FloorGenerator2020 extends FloorGenerator {
 	private static final float aisle = 2f + tad * 3 / 2;
 
 	private static FloorMap floor = new FloorMap(taw, tad, 3.3, 0.95);
-
-	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 	protected static float createAisleOfTeams(int teamNumber, float xx, float y) {
 		float x = xx;
@@ -70,12 +71,19 @@ public class FloorGenerator2020 extends FloorGenerator {
 
 			IPrinter p = floor.createPrinter(x - taw, y - taw - 2);
 
-			double bx = x - taw * 8;
-			for (int i = 0; i < 13; i++)
-				floor.createBalloon(balloon.charAt(i) + "", bx + 2 * i, y - taw - 2);
+			if (args != null && args.length > 0) {
+				File f = new File(args[0]);
+				DiskContestSource source = new DiskContestSource(f);
+				IContest contest2 = source.getContest();
+				source.waitForContest(10000);
+				IProblem[] problems = contest2.getProblems();
 
-			if (args != null && args.length > 0)
-				floor.write(new File(args[0]));
+				double bx = x - taw * 8;
+				for (int i = 0; i < problems.length; i++)
+					floor.createBalloon(problems[i].getId(), bx + 2 * i, y - taw - 2);
+
+				floor.write(f);
+			}
 
 			long time = System.currentTimeMillis();
 			ITeam t1 = floor.getTeam(57);

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC.java
@@ -8,8 +8,11 @@ import java.util.List;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
 import org.icpc.tools.contest.model.FloorMap.Path;
+import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IPrinter;
+import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.DiskContestSource;
 
 public class FloorGeneratorNAC extends FloorGenerator {
 	// team area width (in meters). ICPC standard is 3.0
@@ -19,8 +22,6 @@ public class FloorGeneratorNAC extends FloorGenerator {
 	private static final float tad = 2.0f;
 
 	private static FloorMap floor = new FloorMap(taw, tad, 1.8, 0.8);
-
-	private static final String balloon = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 	protected static void createTeamPod(int num, int startingId, float x, float y, int skipTable) {
 		int teamId = startingId;
@@ -117,10 +118,6 @@ public class FloorGeneratorNAC extends FloorGenerator {
 
 			// floor.createAisle(rightAisle, y, leftAisle, y);
 
-			double bx = 0;
-			for (int i = 0; i < 10; i++)
-				floor.createBalloon(balloon.charAt(i) + "", bx + i * 2, -8);
-
 			IPrinter p = floor.createPrinter(25, 5);
 
 			// fix teams
@@ -129,10 +126,21 @@ public class FloorGeneratorNAC extends FloorGenerator {
 			// ((Team) floor.getTeam(62)).add("id", "<-1>");
 			// ((Team) floor.getTeam(63)).add("id", "<-1>");
 
-			floor.rotate(-90);
+			if (args != null && args.length > 0) {
+				File f = new File(args[0]);
+				DiskContestSource source = new DiskContestSource(f);
+				IContest contest2 = source.getContest();
+				source.waitForContest(10000);
+				IProblem[] problems = contest2.getProblems();
 
-			if (args != null && args.length > 0)
-				floor.write(new File(args[0]));
+				double bx = 0;
+				for (int i = 0; i < problems.length; i++)
+					floor.createBalloon(problems[i].getId(), bx + i * 2, -8);
+
+				floor.rotate(-90);
+
+				floor.write(f);
+			}
 
 			long time = System.currentTimeMillis();
 			ITeam t1 = floor.getTeam(10);


### PR DESCRIPTION
Fix regressions with floor map that Nicky reported, fix issues writing the extended MapInfo to disk, and break backward compatibility (figured it's a good time due to the floor map switch to json) to make problem location consistent with team.

- Team: remove support for old group_id, and standalone x/y/rotation attributes (they've been inside a location object for a few years). Add setLocation() helper.
- Problem: move x/y into a location object to match team, for addImpl() use switch statement instead of lots of ifs, make test data count optional again. Add setLocation() helper.
- ContestWriter: add support for writing singleton objects like State and MapInfo. (missed that before)
- MapInfo: change printer helper to be called setLocation to match others, and use the setLocation() helpers.
- FloorMap: use setLocation() helpers, clean up rotating entire floor.
- FloorGenerators: load existing contest from disk so that the problem ids match.

There is still a small regression in that the floor map UI shows only the data about to be written to the floor map - there are no problem labels (since we don't really want them duplicated in the floor map data) so it uses the longer problem ids. There are a couple options here (e.g. copy labels from one contest to the other, or merge before showing), but I haven't decided which is best (or if it's actually necessary) so doing neither for now.