### PR TITLE
When current list is null or empty, use local list.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -846,7 +846,11 @@ public class DiskContestSource extends ContestSource {
 		if (localList == null || localList.isEmpty())
 			return curList;
 
+		if (curList == null || curList.isEmpty())
+			return localList;
+
 		FileReferenceList list = localList;
+
 		for (FileReference ref : curList) {
 			if (ref.height <= 0 || ref.width <= 0)
 				continue;


### PR DESCRIPTION
My CDS gave an error if I had JSON's without logo's but then had logo's on disk. This fixes it, but I'll leave it to you to decide if this makes sense.