### PR TITLE
Add option to use team intro presentation for organizations.

### DIFF
--- a/PresContest/src/META-INF/presentations.xml
+++ b/PresContest/src/META-INF/presentations.xml
@@ -175,7 +175,7 @@
       description="Map of the world."
       properties="logosOn - show logos,
          logosOn - hide logos,
-         logoSize: - logo percent size,
+         logoSize - logo percent size,
          groupLinesOn - show group lines,
          groupLinesOff - hide group lines"
       image="images/presentations/world.png"
@@ -192,7 +192,9 @@
       name="Team Intro"
       category="Maps"
       description="Steps through all teams on a map."
-      properties="timeFactor: - time scaling factor"
+      properties="timeFactor - time scaling factor,
+        showOrganizations - show organizations instead of teams,
+        showTeams - show teams"
       image="images/presentations/world.png"
       class="org.icpc.tools.presentation.contest.internal.presentations.map.TeamIntroPresentation"/>
    <presentation


### PR DESCRIPTION
cc @niemela , who suggested this during NWERC.

This uses the same team intro presentation, but then uses it for organizations. Useful if you have multiple teams per org.

I tried it in the SWERC dataset. It *does* work, but since uni's are still pretty close in these contests, it doesn't look great. Maybe we later should improve that.

Note I had to call `setup()` again to re-set up the data. Changing the property while the presentation is running makes it flicker for a few ms, but I'm not sure if we can fix that.