### PR TITLE
FileReference filename

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
+++ b/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
@@ -122,6 +122,7 @@ public class ReactionVideoRecorder {
 			if (files != null) {
 				for (File f : files) {
 					FileReference ref = new FileReference();
+					ref.filename = f.getName();
 					String name = f.getName().substring(0, f.getName().length() - 5);
 					ref.href = "contests/" + cc.getId() + "/submissions/" + submissionId + "/" + name;
 					ref.mime = "application/m2ts";

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -252,7 +252,7 @@ public class RESTContestSource extends DiskContestSource {
 		if (obj == null)
 			return null;
 
-		File file = super.getNewFile(obj.getType(), obj.getId(), property, ref.mime);
+		File file = super.getNewFile(obj.getType(), obj.getId(), property, ref);
 		if (file == null)
 			return null;
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
@@ -8,6 +8,7 @@ public class FileReference {
 	public String mime;
 	public String href = null;
 	public File file;
+	public String filename;
 	public long lastModified;
 	public String etag;
 	public int width = -1;
@@ -23,6 +24,7 @@ public class FileReference {
 		mime = obj.getString("mime");
 		height = obj.getInt("height");
 		width = obj.getInt("width");
+		filename = obj.getString("filename");
 	}
 
 	public String getURL() {
@@ -41,6 +43,8 @@ public class FileReference {
 		// if (file == null)
 		// return "{\"href\":\"" + href + "\"}";
 		StringBuilder sb = new StringBuilder("{\"href\":\"" + href + "\"");
+		if (filename != null)
+			sb.append(",\"filename\":\"" + filename + "\"");
 		if (mime != null)
 			sb.append(",\"mime\":\"" + mime + "\"");
 		if (width > 0)
@@ -69,6 +73,8 @@ public class FileReference {
 
 		FileReference ref = (FileReference) o;
 		if ((file == null && ref.file != null) || (file != null && !file.equals(ref.file)))
+			return false;
+		if ((filename == null && ref.filename != null) || (filename != null && !filename.equals(ref.filename)))
 			return false;
 		if ((mime == null && ref.mime != null) || (mime != null && !mime.equals(ref.mime)))
 			return false;


### PR DESCRIPTION
Added filename to file references according to the spec update. This change is backward compatible.
- CDS sets the filename when loading from disk or creating files.
- When downloading files (tools connecting to CDS, or CDS connecting to a CCS) it uses the given filename and extension if it exists. Falls back to CAF patterns if the filename is missing or invalid.