### PR TITLE
Support for problem package

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -47,6 +47,8 @@ public class PlaybackContest extends Contest {
 	private static final String FILES = "files";
 	private static final String REACTION = "reaction";
 	private static final String COUNTRY_FLAG = "country_flag";
+	private static final String PACKAGE = "package";
+	private static final String STATEMENT = "statement";
 
 	protected ConfiguredContest cc;
 	protected String contestId;
@@ -147,6 +149,15 @@ public class PlaybackContest extends Contest {
 			downloadMissingFiles(src, obj, LOGO, i.getLogo());
 			downloadMissingFiles(src, obj, BANNER, i.getBanner());
 			src.attachLocalResources(i);
+		} else if (obj instanceof Problem) {
+			Problem p = (Problem) obj;
+			downloadMissingFiles(src, obj, PACKAGE, p.getPackage());
+			downloadMissingFiles(src, obj, STATEMENT, p.getStatement());
+			src.attachLocalResources(p);
+		} else if (obj instanceof Group) {
+			Group g = (Group) obj;
+			downloadMissingFiles(src, obj, LOGO, g.getLogo());
+			src.attachLocalResources(g);
 		} else if (obj instanceof Team) {
 			Team t = (Team) obj;
 			downloadMissingFiles(src, obj, PHOTO, t.getPhoto());

--- a/ContestModel/src/org/icpc/tools/contest/model/IGroup.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IGroup.java
@@ -50,14 +50,14 @@ public interface IGroup extends IContestObject {
 	double getLongitude();
 
 	/**
-	 * The logo of the organization.
+	 * The logo of the group.
 	 *
 	 * @return the logo
 	 */
 	File getLogo(int width, int height, boolean force);
 
 	/**
-	 * The logo of the organization.
+	 * The logo of the group.
 	 *
 	 * @return the logo
 	 */

--- a/ContestModel/src/org/icpc/tools/contest/model/IProblem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IProblem.java
@@ -1,6 +1,7 @@
 package org.icpc.tools.contest.model;
 
 import java.awt.Color;
+import java.io.File;
 
 /**
  * A problem.
@@ -68,4 +69,18 @@ public interface IProblem extends IContestObject, IPosition {
 	 * @return the max score
 	 */
 	Double getMaxScore();
+
+	/**
+	 * The problem package.
+	 *
+	 * @return the package
+	 */
+	File getPackage(boolean force);
+
+	/**
+	 * The problem statement.
+	 *
+	 * @return the statement
+	 */
+	File getStatement(boolean force);
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -1,12 +1,14 @@
 package org.icpc.tools.contest.model.internal;
 
 import java.awt.Color;
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.feed.Decimal;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
@@ -25,6 +27,8 @@ public class Problem extends ContestObject implements IProblem {
 	private static final String Y = "y";
 	private static final String TIME_LIMIT = "time_limit";
 	private static final String MAX_SCORE = "max_score";
+	private static final String PACKAGE = "package";
+	private static final String STATEMENT = "statement";
 
 	private int ordinal = Integer.MIN_VALUE;
 	private String label;
@@ -37,6 +41,8 @@ public class Problem extends ContestObject implements IProblem {
 	private double y = Double.NaN;
 	private int timeLimit;
 	private Double maxScore;
+	private FileReferenceList package_;
+	private FileReferenceList statement;
 
 	@Override
 	public ContestType getType() {
@@ -133,6 +139,24 @@ public class Problem extends ContestObject implements IProblem {
 		return maxScore;
 	}
 
+	public FileReferenceList getPackage() {
+		return package_;
+	}
+
+	@Override
+	public File getPackage(boolean force) {
+		return getFile(package_.first(), PACKAGE, force);
+	}
+
+	public FileReferenceList getStatement() {
+		return statement;
+	}
+
+	@Override
+	public File getStatement(boolean force) {
+		return getFile(statement.first(), STATEMENT, force);
+	}
+
 	@Override
 	protected boolean addImpl(String name2, Object value) throws Exception {
 		switch (name2) {
@@ -175,9 +199,38 @@ public class Problem extends ContestObject implements IProblem {
 				y = obj.getDouble(Y);
 				return true;
 			}
+			case PACKAGE: {
+				package_ = new FileReferenceList(value);
+				return true;
+			}
+			case STATEMENT: {
+				statement = new FileReferenceList(value);
+				return true;
+			}
 			default:
 				return false;
 		}
+	}
+
+	@Override
+	public IContestObject clone() {
+		Problem p = new Problem();
+		p.id = id;
+		p.ordinal = ordinal;
+		p.name = name;
+		p.label = label;
+		p.color = color;
+
+		p.rgb = rgb;
+		p.testDataCount = testDataCount;
+		p.x = x;
+		p.y = y;
+		p.timeLimit = timeLimit;
+		p.maxScore = maxScore;
+
+		p.package_ = package_;
+		p.statement = statement;
+		return p;
 	}
 
 	@Override
@@ -206,6 +259,11 @@ public class Problem extends ContestObject implements IProblem {
 				attrs.add("\"" + Y + "\":" + round(y));
 			props.put(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
+
+		if (package_ != null)
+			props.put(PACKAGE, package_);
+		if (statement != null)
+			props.put(STATEMENT, statement);
 	}
 
 	@Override
@@ -236,6 +294,9 @@ public class Problem extends ContestObject implements IProblem {
 				attrs.add("\"" + Y + "\":" + round(y));
 			je.encodePrimitive(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
+
+		je.encode(PACKAGE, package_, false);
+		je.encode(STATEMENT, statement, false);
 	}
 
 	private static double round(double d) {


### PR DESCRIPTION
API support for problem package and statement (assuming my proposal for renaming the property is accepted - otherwise we'll rename later). Updated CDS so that it will automatically download and cache package & statement locally to ensure it can serve these to downstream users.

Fixed two minor issues with group that I noticed while implementing - Javadoc copy/paste from org and not automatically downloading group logos (a spec extension).