### PR TITLE
Add nginx non-buffering header

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -129,6 +129,7 @@ public class ContestRESTService extends HttpServlet {
 
 				PrintWriter pw = response.getWriter();
 				response.setContentType("application/json");
+				response.setHeader("X-Accel-Buffering", "no");
 				cc.incrementFeed();
 				int ind = getSinceIdIndex(request, contest);
 				if (ind == -2) {

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -183,6 +183,7 @@ public class VideoServlet extends HttpServlet {
 		response.setHeader("Cache-Control", "no-cache");
 		response.setContentType("application/octet");
 		response.setHeader("Access-Control-Allow-Origin", "*");
+		response.setHeader("X-Accel-Buffering", "no");
 
 		OutputStream out = response.getOutputStream();
 		va.handler.writeHeader(out, stream);


### PR DESCRIPTION
Avoid nginx buffering streaming responses. User could turn this off globally on nginx, but better they don't even have to know about it.