### PR TITLE
Add Accounts endpoint

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IAccount.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAccount.java
@@ -1,0 +1,48 @@
+package org.icpc.tools.contest.model;
+
+/**
+ * An account.
+ */
+public interface IAccount extends IContestObject {
+	/**
+	 * The username
+	 *
+	 * @return the username
+	 */
+	String getUsername();
+
+	/**
+	 * The password.
+	 *
+	 * @return the password
+	 */
+	String getPassword();
+
+	/**
+	 * The type of account.
+	 *
+	 * @return the type
+	 */
+	String getAccountType();
+
+	/**
+	 * The ip address.
+	 *
+	 * @return the ip
+	 */
+	String getIp();
+
+	/**
+	 * The id of the team they belong to.
+	 *
+	 * @return the id
+	 */
+	String getTeamId();
+
+	/**
+	 * The person this account is for.
+	 *
+	 * @return the id
+	 */
+	String getPeopleId();
+}

--- a/ContestModel/src/org/icpc/tools/contest/model/IContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContest.java
@@ -573,6 +573,21 @@ public interface IContest {
 	boolean isBeforeFreeze(ISubmission s);
 
 	/**
+	 * Return the accounts in this contest.
+	 *
+	 * @return the accounts
+	 */
+	IAccount[] getAccounts();
+
+	/**
+	 * Returns the account with the given id.
+	 *
+	 * @param id an identifier
+	 * @return an account, or <code>null</code> if the id was invalid
+	 */
+	IAccount getAccountById(String id);
+
+	/**
 	 * Return the awards given in this contest.
 	 *
 	 * @return the awards

--- a/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
@@ -3,6 +3,7 @@ package org.icpc.tools.contest.model;
 import java.util.List;
 import java.util.Map;
 
+import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Award;
 import org.icpc.tools.contest.model.internal.Clarification;
 import org.icpc.tools.contest.model.internal.Commentary;
@@ -24,12 +25,12 @@ import org.icpc.tools.contest.model.internal.TeamMember;
 
 public interface IContestObject {
 	enum ContestType {
-		CONTEST, LANGUAGE, GROUP, ORGANIZATION, TEAM, STATE, RUN, SUBMISSION, JUDGEMENT, CLARIFICATION, AWARD, JUDGEMENT_TYPE, TEST_DATA, PROBLEM, PAUSE, TEAM_MEMBER, MAP_INFO, START_STATUS, COMMENTARY
+		CONTEST, LANGUAGE, GROUP, ORGANIZATION, TEAM, STATE, RUN, SUBMISSION, JUDGEMENT, CLARIFICATION, AWARD, JUDGEMENT_TYPE, TEST_DATA, PROBLEM, PAUSE, TEAM_MEMBER, MAP_INFO, START_STATUS, COMMENTARY, ACCOUNT
 	}
 
 	String[] ContestTypeNames = new String[] { "contests", "languages", "groups", "organizations", "teams", "state",
 			"runs", "submissions", "judgements", "clarifications", "awards", "judgement-types", "testdata", "problems",
-			"pause", "team-members", "map-info", "start-status", "commentary" };
+			"pause", "team-members", "map-info", "start-status", "commentary", "accounts" };
 
 	static String getTypeName(ContestType type) {
 		return ContestTypeNames[type.ordinal()];
@@ -91,6 +92,8 @@ public interface IContestObject {
 			return new MapInfo();
 		else if (ContestType.COMMENTARY.equals(type))
 			return new Commentary();
+		else if (ContestType.ACCOUNT.equals(type))
+			return new Account();
 
 		// don't import unrecognized elements
 		return null;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Account.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Account.java
@@ -1,0 +1,158 @@
+package org.icpc.tools.contest.model.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.icpc.tools.contest.model.IAccount;
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IContestObject;
+import org.icpc.tools.contest.model.feed.JSONEncoder;
+
+public class Account extends ContestObject implements IAccount {
+	private static final String USERNAME = "username";
+	private static final String PASSWORD = "password";
+	private static final String TYPE = "type";
+	private static final String IP = "ip";
+	private static final String TEAM_ID = "team_id";
+	private static final String PEOPLE_ID = "people_id";
+
+	private String username;
+	private String password;
+	private String type;
+	private String ip;
+	private String teamId;
+	private String peopleId;
+
+	@Override
+	public ContestType getType() {
+		return ContestType.ACCOUNT;
+	}
+
+	@Override
+	public String getUsername() {
+		return username;
+	}
+
+	@Override
+	public String getPassword() {
+		return password;
+	}
+
+	@Override
+	public String getAccountType() {
+		return type;
+	}
+
+	@Override
+	public String getIp() {
+		return ip;
+	}
+
+	@Override
+	public String getTeamId() {
+		return teamId;
+	}
+
+	@Override
+	public String getPeopleId() {
+		return peopleId;
+	}
+
+	@Override
+	protected boolean addImpl(String name2, Object value) throws Exception {
+		switch (name2) {
+			case USERNAME: {
+				username = (String) value;
+				return true;
+			}
+			case PASSWORD: {
+				password = (String) value;
+				return true;
+			}
+			case TYPE: {
+				type = (String) value;
+				return true;
+			}
+			case IP: {
+				ip = (String) value;
+				return true;
+			}
+			case TEAM_ID: {
+				teamId = (String) value;
+				return true;
+			}
+			case PEOPLE_ID: {
+				peopleId = (String) value;
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	@Override
+	public IContestObject clone() {
+		Account a = new Account();
+		a.id = id;
+		a.username = username;
+		a.password = password;
+		a.type = type;
+		a.ip = ip;
+		a.teamId = teamId;
+		a.peopleId = peopleId;
+		return a;
+	}
+
+	@Override
+	protected void getPropertiesImpl(Map<String, Object> props) {
+		super.getPropertiesImpl(props);
+		if (username != null)
+			props.put(USERNAME, username);
+		if (password != null)
+			props.put(PASSWORD, password);
+		if (type != null)
+			props.put(TYPE, type);
+		if (ip != null)
+			props.put(IP, ip);
+		if (teamId != null)
+			props.put(TEAM_ID, teamId);
+		if (peopleId != null)
+			props.put(PEOPLE_ID, peopleId);
+	}
+
+	@Override
+	public void writeBody(JSONEncoder je) {
+		je.encode(ID, id);
+		if (username != null)
+			je.encode(USERNAME, username);
+		if (password != null)
+			je.encode(PASSWORD, password);
+		if (type != null)
+			je.encode(TYPE, type);
+		if (ip != null)
+			je.encode(IP, ip);
+		if (teamId != null)
+			je.encode(TEAM_ID, teamId);
+		if (peopleId != null)
+			je.encode(PEOPLE_ID, peopleId);
+	}
+
+	@Override
+	public List<String> validate(IContest c) {
+		List<String> errors = new ArrayList<>();
+
+		if (getUsername() == null || getUsername().isEmpty())
+			errors.add("Username missing");
+
+		if (teamId != null && c.getTeamById(teamId) == null)
+			errors.add("Invalid team " + teamId);
+
+		if (peopleId != null && c.getTeamMemberById(peopleId) == null)
+			errors.add("Invalid team member " + peopleId);
+
+		if (errors.isEmpty())
+			return null;
+		return errors;
+	}
+}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -11,6 +11,7 @@ import java.util.Locale;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
+import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.ICommentary;
@@ -62,6 +63,7 @@ public class Contest implements IContest {
 	private ICommentary[] commentary;
 	private IRun[] runs;
 	private IStartStatus[] startStatus;
+	private IAccount[] accounts;
 	private IAward[] awards;
 	private IPause[] pauses;
 	private IMapInfo mapInfo;
@@ -193,6 +195,7 @@ public class Contest implements IContest {
 			runs = null;
 			clars = null;
 			commentary = null;
+			accounts = null;
 
 			order = null;
 			orderedTeams = null;
@@ -292,6 +295,8 @@ public class Contest implements IContest {
 			members = null;
 		} else if (type == ContestType.START_STATUS) {
 			startStatus = null;
+		} else if (type == ContestType.ACCOUNT) {
+			accounts = null;
 		} else if (type == ContestType.AWARD) {
 			awards = null;
 		} else if (type == ContestType.PAUSE) {
@@ -847,6 +852,26 @@ public class Contest implements IContest {
 
 			organizations = data.getByType(IOrganization.class, ContestType.ORGANIZATION);
 			return organizations;
+		}
+	}
+
+	@Override
+	public IAccount getAccountById(String id) {
+		return (IAccount) data.getById(id, ContestType.ACCOUNT);
+	}
+
+	@Override
+	public IAccount[] getAccounts() {
+		IAccount[] temp = accounts;
+		if (temp != null)
+			return temp;
+
+		synchronized (data) {
+			if (accounts != null)
+				return accounts;
+
+			accounts = data.getByType(IAccount.class, ContestType.ACCOUNT);
+			return accounts;
 		}
 	}
 


### PR DESCRIPTION
Add new /accounts endpoint from Contest API. It refers to 'people_id' which makes no sense on the current CDS, but I figured it's marginally better to implement matching the current API and clean up any minor issues later.