### PR TITLE
Fix RESTContestSource url matching

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/ArgumentParser.java
@@ -207,7 +207,7 @@ public class ArgumentParser {
 				cs[i] = ContestSource.parseSource(source.src[i], source.user, source.password);
 
 			return cs;
-		} catch (IOException e) {
+		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Invalid contest source: " + e.getMessage());
 			System.exit(1);
 		}


### PR DESCRIPTION
If you provide an incorrect contest URL, the updated RESTContestSource was silently auto-connecting to the 'best' one. This could lead to you thinking you're connecting to 'dress' but actually connecting to 'finals'.

I've refactored the code to clearly deal with these cases:
1) Connecting to a contest URL (/contests/x): Should just work and never modify URL.
  Connecting to ACM ICPC World Finals 2018 at https://localhost:8443/api/contests/backslash

2) Connecting to a Contest API root (/ or /contests): Pick the best contest, and tell you what it's connecting to:
  Invalid contest source: Possible Contest API at https://localhost/api/contests but no contests found
or
  Only 1 contest found, connecting to https://localhost/api/contests/finals - World Finals starting at 7:00.00 a.m. April 04, 2019
or
  2 contests found, auto-connecting to https://localhost/api/contests/finals - World Finals starting at 7:00.00 a.m. April 04, 2019
or
  Contest API found, but couldn't pick a contest. Try one of the following URLs:
    https://localhost/api/contests/backslash - ACM ICPC World Finals 2018 starting at 9:51.37 p.m. April 18, 2018
    https://localhost/api/contests/finals - World Finals starting at 7:00.00 a.m. April 04, 2019
  Invalid contest source: Could not pick contest at https://localhost/api/contests

3) Invalid URL: Try to detect a contest root and list possible contests:
  No contest found at the given URL, but I found these instead:
    https://localhost/api/contests/backslash - ACM ICPC World Finals 2018 starting at 9:51.37 p.m. April 18, 2018
    https://localhost/api/contests/finals - World Finals starting at 7:00.00 a.m. April 04, 2019
  Invalid contest source: Could not detect Contest API at https://localhost/missing