### PR TITLE
Add title to /team-member and add temporary /persons endpoint

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -48,7 +48,7 @@ import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.Deletion;
 
-@WebServlet(urlPatterns = { "/api/", "/api/*" }, asyncSupported = true)
+@WebServlet(urlPatterns = { "/api", "/api/", "/api/*" }, asyncSupported = true)
 public class ContestRESTService extends HttpServlet {
 	private static final long serialVersionUID = 1L;
 
@@ -182,6 +182,10 @@ public class ContestRESTService extends HttpServlet {
 			ReportGenerator.report(response.getWriter(), contest, segments[2]);
 			return;
 		}
+
+		// TODO: temporarily alias /persons to /team-members
+		if (segments.length >= 2 && "persons".equals(segments[1]))
+			segments[1] = "team-members";
 
 		String typeName = "contests";
 		String id = cc.getId();

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeamMember.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeamMember.java
@@ -22,6 +22,13 @@ public interface ITeamMember extends IContestObject {
 	String getName();
 
 	/**
+	 * The person's title.
+	 *
+	 * @return the title
+	 */
+	String getTitle();
+
+	/**
 	 * The person's email.
 	 *
 	 * @return the email

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/TeamMember.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/TeamMember.java
@@ -17,6 +17,7 @@ public class TeamMember extends ContestObject implements ITeamMember {
 	private static final String FIRST_NAME = "first_name";
 	private static final String LAST_NAME = "last_name";
 	private static final String NAME = "name";
+	private static final String TITLE = "title";
 	private static final String EMAIL = "email";
 	private static final String SEX = "sex";
 	private static final String ROLE = "role";
@@ -32,6 +33,7 @@ public class TeamMember extends ContestObject implements ITeamMember {
 	private String firstName;
 	private String lastName;
 	private String name;
+	private String title;
 	private String email;
 	private String sex;
 	private String teamId;
@@ -67,6 +69,11 @@ public class TeamMember extends ContestObject implements ITeamMember {
 		if (name == null && firstName != null && lastName != null)
 			return firstName + " " + lastName;
 		return name;
+	}
+
+	@Override
+	public String getTitle() {
+		return title;
 	}
 
 	@Override
@@ -129,6 +136,10 @@ public class TeamMember extends ContestObject implements ITeamMember {
 			}
 			case NAME: {
 				name = (String) value;
+				return true;
+			}
+			case TITLE: {
+				title = (String) value;
 				return true;
 			}
 			case EMAIL: {
@@ -308,6 +319,8 @@ public class TeamMember extends ContestObject implements ITeamMember {
 			props.put(LAST_NAME, lastName);
 		if (name != null)
 			props.put(NAME, name);
+		if (title != null)
+			props.put(TITLE, title);
 		if (email != null)
 			props.put(EMAIL, email);
 		props.put(SEX, sex);
@@ -333,6 +346,8 @@ public class TeamMember extends ContestObject implements ITeamMember {
 			je.encode(LAST_NAME, lastName);
 		if (name != null)
 			je.encode(NAME, name);
+		if (title != null)
+			je.encode(TITLE, title);
 		if (email != null)
 			je.encode(EMAIL, email);
 		je.encode(SEX, sex);


### PR DESCRIPTION
Made the following changes:
- Make /api respond to requests in addition to /api/. Technically this isn't required by the spec, but I think it's better to do both.
- Add title to team member, the one property that's missing from person.
- Make /persons an alias to /team-members. This is a temporary hack that would be removed when team members is renamed.

The last change means that the /persons endpoint can be supported as per the spec *if read from disk* (or from a CCS that supports team-members and you don't need the new properties) and *if you don't care about the event-feed*. It's temporary, it's ugly, but it's a really cheap way to get a working /persons endpoint for now. FWIW I thought about implementing a full alias or putting both types on the feed, but that seemed like overkill.