### PR TITLE
Replace teamUser and host use with accounts, add /account

### DIFF
--- a/CDS/README.md
+++ b/CDS/README.md
@@ -353,47 +353,17 @@ The attribute associated with the *user* element is as follows:
 
 * name: the name of a user, which must match one of the existing users.
 
-###### teamUser Element
+###### host Element
 
 ```
-<teamUser>
-  <user name="team1" teamId="1"/>
-  <user name="steven" teamId="2"/>
-  <user name="mark" teamId="2"/>
-</teamUser>
+<host host="10.0.0.{0}"/>
 ```
 
-The global *teamUser* element allows you to map a team user login (account) to their identity (team id) within a contest. By providing
-this mapping the team will be able to see all of their own judgements and clarifications in the contest. In the example above,
-there is one login for the team with id 1, and two logins for team 2.
-
-If your users are on a locked-down network with known host names or IP addresses, you can also use the hosts attribute to enable
-auto-login. When this is specified any user from the given host will be automatically logged into the CDS. In order for this
-feature to work, you must be using basic authentication with the users.xml in the default location (in order for the CDS to
-look up passwords).
-
-The attributes associated with the *user* element is as follows:
-
-* name: the name of a user, which must match one of the existing users.
-* teamId: the team's id within a contest.
-
-###### hosts Element
-
-```
-<hosts>
-  <host teamId="team1" host="myhost.com"/>
-  <host host="10.0.0.{0}"/>
-</hosts>
-```
-
-The global *hosts* element allows you to map hostnames to teams, either for ease of configuring streaming video urls or auto-login.
-Each element can either specify a single team id and host to map that specific team to one machine, or omit the teamId attribute
-and use the substitution variable {0} to map all teams to a host. When using this second option, {0} will be substituted with every
-team id.
+The global *host* element allows you to map hostnames to teams, either for ease of configuring streaming video urls or auto-login.
+Each element uses a substitution variable {0} (the team id) to map every team to the given host.
 
 The attributes associated with the *host* element is as follows:
 
-* teamId: the team's id within a contest. Do not include when using the {0} substitution variable to map all teams.
 * host: an IP address or host name.
 
 ### Starting the CDS

--- a/CDS/src/org/icpc/tools/cds/service/BasicAuthFilter.java
+++ b/CDS/src/org/icpc/tools/cds/service/BasicAuthFilter.java
@@ -51,16 +51,16 @@ public class BasicAuthFilter implements Filter {
 
 		// check for team host-based auto-login
 		CDSConfig config = CDSConfig.getInstance();
-		String teamId = config.getTeamIdFromHost(request.getRemoteHost());
-		if (teamId == null)
-			teamId = config.getTeamIdFromHost(request.getRemoteAddr());
+		String username = config.getUserFromHost(request.getRemoteHost());
+		if (username == null)
+			username = config.getUserFromHost(request.getRemoteAddr());
 
-		if (teamId != null) {
+		if (username != null) {
 			try {
-				String user = config.getTeamUserName(teamId);
-				String password = config.getTeamPassword(teamId);
-				Trace.trace(Trace.INFO, "Auto-login user: " + user + " / " + password);
-				request.login(user, password);
+				String password = config.getUserPassword(username);
+				Trace.trace(Trace.INFO, "Auto-login user: " + username + " / " + password);
+				if (password != null)
+					request.login(username, password);
 				filterChain.doFilter(request, response);
 				return;
 			} catch (Exception e) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -875,6 +875,24 @@ public class Contest implements IContest {
 		}
 	}
 
+	/**
+	 * Tries to find a team id for a given user, e.g. "team57" to "57".
+	 *
+	 * @param username
+	 * @return the team's id, or null if not found
+	 */
+	public String getTeamIdFromUser(String username) {
+		if (username == null || username.isEmpty())
+			return null;
+
+		IAccount[] temp = getAccounts();
+		for (IAccount account : temp) {
+			if (username.equals(account.getUsername()) && account.getTeamId() != null)
+				return account.getTeamId();
+		}
+		return null;
+	}
+
 	@Override
 	public IAward getAwardById(String id) {
 		return (IAward) data.getById(id, ContestType.AWARD);


### PR DESCRIPTION
Remove teamUser and hosts with teamId from CDS config. These overlap with accounts, and now that we have accounts we should use them instead. After this change, all team to account and individual team to host configuration is done via accounts as per the Contest API.

After this change:
- If you want to associate a team to IP/host or account, it must be done via an account in a contest. No more global config except for <host> mapping all team to host patterns.
- If you want a user to be able to log into the CDS, you configure them in (copy username and password to) users.xml.
- If you want auto-login, the user's password must be in accounts.json and there must be an IP or host in accounts.json or <host> in CDS config.
- User accounts are 'global', so if I can login to one contest and the same username exists in another contest that's the same account (though possibly with different a team id).
- Public users can't see anything in /accounts, trusted users can see /accounts but w/o passwords, teams can only see their own account w/o password.

Also implemented /account, which just tries to find a match in /accounts from the same contest. For now, additional CDS accounts are not added to /accounts.