### PR TITLE
Hide clar submit when no capability

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -33,7 +33,7 @@
 			</div>
         </div>
     </div>
-    <div class="row">
+    <div class="row" id="submit-clar-ui" style="display: none">
         <div class="col-12">
 			<div class="card">
 			    <div class="card-header">
@@ -82,6 +82,12 @@ function clarificationsRefresh() {
         for (var i = 0; i < problems.length; i++) {
         	$('#problem-id').append('<option id="' + problems[i].id + '">' + problems[i].label + ': ' + problems[i].name + '</option>');
 		}
+
+        $.when(contest.loadAccess()).done(function () {
+            var access = contest.getAccess();
+            if (access.capabilities.some(e => e === 'team_clar'))
+    	        $("#submit-clar-ui").show();
+        })
     }).fail(function (result) {
     	console.log("Error loading clarifications: " + result);
     })

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -1,11 +1,13 @@
 class Contest {
 	info;
+	access;
 	state;
 	organizations;
 	groups;
 	teams;
 	persons;
 	accounts;
+	account;
 	languages;
 	judgementTypes;
 	problems;
@@ -62,6 +64,13 @@ class Contest {
 			return new $.Deferred().resolve();
 
 		return this.loadObject('', (result) => { this.info = result });
+	}
+
+	loadAccess() {
+		if (this.access != null)
+			return new $.Deferred().resolve();
+
+		return this.loadObject('access', (result) => { this.access = result });
 	}
 
 	loadState() {
@@ -143,6 +152,13 @@ class Contest {
 		return this.loadObject('accounts', (result) => { this.accounts = result });
 	}
 
+	loadAccount() {
+		if (this.accounts != null)
+			return new $.Deferred().resolve();
+
+		return this.loadObject('account', (result) => { this.account = result });
+	}
+
 	loadSubmissions() {
 		if (this.submissions != null)
 			return new $.Deferred().resolve();
@@ -198,6 +214,7 @@ class Contest {
 
 	getContestURL() { return this.contestURL }
 	getInfo() { return this.info }
+	getAccess() { return this.access }
 	getState() { return this.state }
 	getStartStatus() { return this.startStatus }
 	getLanguages() { return this.languages }
@@ -208,6 +225,7 @@ class Contest {
 	getOrganizations() { return this.organizations }
 	getPersons() { return this.persons }
 	getAccounts() { return this.accounts }
+	getAccount() { return this.account }
 	getSubmissions() { return this.submissions }
 	getJudgements() { return this.judgements }
 	getRuns() { return this.runs }


### PR DESCRIPTION
Added support for /account and /access to Javascript contest model, and changed the clarifications page so that the submit UI only shows up if the capability is available.