### PR TITLE
Account improvements

### DIFF
--- a/CDS/README.md
+++ b/CDS/README.md
@@ -97,25 +97,14 @@ which contains the file _cdsConfig.xml_ (see below).
 * a list of _features_ used by the JavaEE server (not normally changed by CDS users).
 
 
-#### Configuring CDS User Roles
+#### Configuring CDS Accounts
 
-The _server.xml_ file by default defines four _security roles_ and several _user names_ occupying those roles, as follows:
+Access to the CDS is configured via an _accounts.json_ file in the same folder as cdsConfig.xml. This account file follows the
+Contest API and Contest Archive Format specifications and allows you to configure any number of users to access the CDS.
+In addition to the spec-defined account types of admin, staff, analyst, team, the CDS supports three additional roles:
+spectator (receives additional non-public data like commentary), balloon (typically used for printing balloons at the World Finals)
+and presAdmin (users who can control presentations).
 
-| Role | Purpose | Default User Names 
-| --- | --- | ---
-| admin | Super user | admin
-| blue |  Read-only access to all data | blue
-| balloon | World Finals specific | balloon
-| trusted | Data accessible to trusted tools | myicpc, live
-| public | Data accessible to anyone | public, presentation
-
-The user names can be changed to anything you wish and can be added or removed, but must remain be in an appropriate "CDS role".
-The CDS verifies that authenticated users have the appropriate role before granting access to a specific CDS service.
-(The "blue" role name comes from the ICPC World Finals network configuration, where core components occupy a network 
-segment called the "Blue Network"; the names "live", "myicpc", and "presentation" refer to groups or functions at the World Finals.) 
-
-The Contest Administrator can add, delete, or change the roles and/or the user names defined in the _server.xml_ file -- but as noted above, 
-be aware that some ICPCTools rely on a user being part of a specific role.
 
 #### Configuring CDS Services
 

--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationWebSocket.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationWebSocket.java
@@ -97,7 +97,7 @@ public class PresentationWebSocket {
 				try {
 					Trace.trace(Trace.INFO, "Disconnecting user " + user + " with incorrect admin role");
 					session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION,
-							"CDS: User cannot be an admin - try blue, trusted, or public user"));
+							"CDS: User cannot be an admin - try staff, analyst, or public user"));
 				} catch (Exception e) {
 					Trace.trace(Trace.ERROR, "Error disconnecting websocket with invalid role");
 				}

--- a/CDS/src/org/icpc/tools/cds/service/LoginServlet.java
+++ b/CDS/src/org/icpc/tools/cds/service/LoginServlet.java
@@ -41,7 +41,7 @@ public class LoginServlet extends HttpServlet {
 
 		if (request.getRemoteUser() == null)
 			request.getRequestDispatcher("/WEB-INF/jsps/loginError.jsp").forward(request, response);
-
-		request.getRequestDispatcher("/WEB-INF/jsps/welcome.jsp").forward(request, response);
+		else
+			request.getRequestDispatcher("/WEB-INF/jsps/welcome.jsp").forward(request, response);
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/IAccount.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAccount.java
@@ -9,6 +9,7 @@ public interface IAccount extends IContestObject {
 	public String JUDGE = "judge";
 	public String ANALYST = "analyst";
 	public String TEAM = "team";
+	public String SPECTATOR = "spectator";
 	public String BALLOON = "balloon";
 	public String PRES_ADMIN = "presAdmin";
 


### PR DESCRIPTION
Fixed the following:
- Adds admin/staff/analyst/spectator/balloon accounts to all contests when they exist on the CDS.
- Fixes synchronization issue when someone logs in the first time while events are happening.
- Fixes a double-forward when using an invalid login.
- Avoids a potential NPE when nobody has used public access prior to confirming freeze.
- Changed string account types to use constants.
- Cleaned up docs and some references to blue/trusted accounts.