### PR TITLE
Account fixes

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -93,14 +93,13 @@ public class CDSConfig {
 	private String[] hosts;
 	private File file;
 	private long lastModified;
-	// private boolean loadedPasswords;
-	private List<IAccount> userAccounts;
+	private List<IAccount> userAccounts = new ArrayList<IAccount>();
 
 	private CDSConfig(File file) {
 		this.file = file;
 
 		try {
-			userAccounts = loadAccounts(file.getParentFile());
+			loadAccounts(file.getParentFile());
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Could not load accounts", e);
 		}
@@ -270,12 +269,11 @@ public class CDSConfig {
 		}
 	}
 
-	private static List<IAccount> loadAccounts(File folder) throws IOException {
+	private void loadAccounts(File folder) throws IOException {
 		File f = new File(folder, "accounts.json");
 
-		List<IAccount> list = new ArrayList<>();
 		if (!f.exists())
-			return list;
+			return;
 
 		try (BufferedReader br = new BufferedReader(new FileReader(f))) {
 			JSONParser parser = new JSONParser(new FileInputStream(f));
@@ -287,12 +285,11 @@ public class CDSConfig {
 				for (String key : data.props.keySet())
 					co.add(key, data.props.get(key));
 
-				list.add((IAccount) co);
+				userAccounts.add((IAccount) co);
 			}
 		}
 
 		Trace.trace(Trace.INFO, "Imported " + f.getName());
-		return list;
 	}
 
 	public List<IAccount> getAccounts() {

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -50,6 +50,15 @@ import org.icpc.tools.contest.model.internal.account.TeamContest;
 import org.w3c.dom.Element;
 
 public class ConfiguredContest {
+	private static final IAccount PUBLIC_ACCOUNT = new Account();
+
+	static {
+		Account ac = (Account) PUBLIC_ACCOUNT;
+		ac.add("id", "public");
+		ac.add("username", "public");
+		ac.add("type", "public");
+	}
+
 	public enum Mode {
 		ARCHIVE, PLAYBACK, LIVE
 	}
@@ -65,8 +74,6 @@ public class ConfiguredContest {
 	private View view;
 
 	private DiskContestSource contestSource;
-
-	private IAccount PUBLIC_ACCOUNT = new Account();
 
 	private Contest contest;
 
@@ -493,6 +500,9 @@ public class ConfiguredContest {
 	}
 
 	private static Contest createAccountContest(IAccount account) {
+		if (account.getAccountType() == null)
+			return new PublicContest();
+
 		switch (account.getAccountType()) {
 			case IAccount.STAFF:
 				return new StaffContest();
@@ -536,7 +546,7 @@ public class ConfiguredContest {
 
 	private Contest getContestForAccount(IAccount account) {
 		// return the full contest for administrators
-		if ("admin".equals(account.getAccountType()))
+		if (IAccount.ADMIN.equals(account.getAccountType()))
 			return contest;
 
 		// find the associated contest for every other account
@@ -872,7 +882,7 @@ public class ConfiguredContest {
 		if (account == null)
 			return false;
 		String type = account.getAccountType();
-		return "admin".equals(type);
+		return IAccount.ADMIN.equals(type);
 	}
 
 	public boolean isStaff(HttpServletRequest request) {
@@ -880,7 +890,7 @@ public class ConfiguredContest {
 		if (account == null)
 			return false;
 		String type = account.getAccountType();
-		return "admin".equals(type) || "staff".equals(type);
+		return IAccount.ADMIN.equals(type) || IAccount.STAFF.equals(type);
 	}
 
 	public boolean isAnalyst(HttpServletRequest request) {
@@ -888,7 +898,7 @@ public class ConfiguredContest {
 		if (account == null)
 			return false;
 		String type = account.getAccountType();
-		return "admin".equals(type) || "staff".equals(type) || "analyst".equals(type);
+		return IAccount.ADMIN.equals(type) || IAccount.STAFF.equals(type) || IAccount.ANALYST.equals(type);
 	}
 
 	public boolean isBalloon(HttpServletRequest request) {
@@ -896,14 +906,14 @@ public class ConfiguredContest {
 		if (account == null)
 			return false;
 		String type = account.getAccountType();
-		return "balloon".equals(type);
+		return IAccount.BALLOON.equals(type);
 	}
 
 	public boolean isTeam(HttpServletRequest request) {
 		IAccount account = getAccount(request.getRemoteUser());
 		if (account == null)
 			return false;
-		return "team".equals(account.getAccountType());
+		return IAccount.TEAM.equals(account.getAccountType());
 	}
 
 	public void add(Session session) {


### PR DESCRIPTION
- Fix NPE when account type is null.
- Add some details to the public account to make it easier to debug.
- Make sure user accounts is empty if loading fails instead of null.
- Switch a few more account type strings to constants.