### PR TITLE
Team members -> Persons

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -27,10 +27,10 @@ import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IJudgement;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.ITeamMember;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.ContestSource.ConnectionState;
 import org.icpc.tools.contest.model.feed.ContestSource.ContestSourceListener;
@@ -734,9 +734,9 @@ public class ConfiguredContest {
 			ITeam team = (ITeam) obj;
 			if (contest.isTeamHidden(team))
 				return null;
-		} else if (obj instanceof ITeamMember) {
-			ITeamMember member = (ITeamMember) obj;
-			ITeam team = contest.getTeamById(member.getTeamId());
+		} else if (obj instanceof IPerson) {
+			IPerson person = (IPerson) obj;
+			ITeam team = contest.getTeamById(person.getTeamId());
 			if (contest.isTeamHidden(team))
 				return null;
 		} else if (obj instanceof ISubmission) {

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -206,9 +206,9 @@ public class ContestRESTService extends HttpServlet {
 			return;
 		}
 
-		// TODO: temporarily alias /persons to /team-members
-		if (segments.length >= 2 && "persons".equals(segments[1]))
-			segments[1] = "team-members";
+		// TODO: temporarily alias /team-members to /persons
+		if (segments.length >= 2 && "team-members".equals(segments[1]))
+			segments[1] = "persons";
 
 		String typeName = "contests";
 		String id = cc.getId();

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -32,12 +32,12 @@ import org.icpc.tools.contest.model.internal.Group;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.Judgement;
 import org.icpc.tools.contest.model.internal.Organization;
+import org.icpc.tools.contest.model.internal.Person;
 import org.icpc.tools.contest.model.internal.Problem;
 import org.icpc.tools.contest.model.internal.Run;
 import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.internal.Submission;
 import org.icpc.tools.contest.model.internal.Team;
-import org.icpc.tools.contest.model.internal.TeamMember;
 
 public class PlaybackContest extends Contest {
 	private static final String LOGO = "logo";
@@ -164,8 +164,8 @@ public class PlaybackContest extends Contest {
 			downloadMissingFiles(src, obj, VIDEO, t.getVideo());
 			// later: backup, key_log or tool data
 			src.attachLocalResources(t);
-		} else if (obj instanceof TeamMember) {
-			TeamMember tm = (TeamMember) obj;
+		} else if (obj instanceof Person) {
+			Person tm = (Person) obj;
 			downloadMissingFiles(src, obj, PHOTO, tm.getPhoto());
 			src.attachLocalResources(tm);
 		} else if (obj instanceof Organization) {
@@ -293,9 +293,9 @@ public class PlaybackContest extends Contest {
 				if (getJudgementById(run.getJudgementTypeId()) == null)
 					return;
 			}
-			if (obj instanceof TeamMember) {
-				TeamMember member = (TeamMember) obj;
-				ITeam team = getTeamById(member.getTeamId());
+			if (obj instanceof Person) {
+				Person person = (Person) obj;
+				ITeam team = getTeamById(person.getTeamId());
 				if (team == null)
 					return;
 			}
@@ -402,7 +402,7 @@ public class PlaybackContest extends Contest {
 		ContestType type = obj.getType();
 		boolean configType = true;
 		if (type == ContestType.PROBLEM || type == ContestType.GROUP || type == ContestType.LANGUAGE
-				|| type == ContestType.JUDGEMENT_TYPE || type == ContestType.TEAM || type == ContestType.TEAM_MEMBER
+				|| type == ContestType.JUDGEMENT_TYPE || type == ContestType.TEAM || type == ContestType.PERSON
 				|| type == ContestType.ORGANIZATION) {
 			applyDefaults(obj);
 			configType = true;

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -48,12 +48,12 @@ import org.icpc.tools.contest.model.IContestListener;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IOrganization;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IResult;
 import org.icpc.tools.contest.model.IStanding;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.ITeamMember;
 import org.icpc.tools.contest.model.Status;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
@@ -385,20 +385,20 @@ public class CoachView extends Panel {
 			y = drawLine(g, y, "Hashtag", org.getHashtag());
 		}
 
-		ITeamMember[] members = contest.getTeamMembersByTeamId(team.getId());
-		if (members != null && members.length > 0) {
-			List<ITeamMember> contestants = new ArrayList<>();
-			List<ITeamMember> staff = new ArrayList<>();
-			for (int i = 0; i < members.length; i++) {
-				if (members[i].getRole().equalsIgnoreCase("contestant"))
-					contestants.add(members[i]);
+		IPerson[] persons = contest.getPersonsByTeamId(team.getId());
+		if (persons != null && persons.length > 0) {
+			List<IPerson> contestants = new ArrayList<>();
+			List<IPerson> staff = new ArrayList<>();
+			for (int i = 0; i < persons.length; i++) {
+				if (persons[i].getRole().equalsIgnoreCase("contestant"))
+					contestants.add(persons[i]);
 				else
-					staff.add(members[i]);
+					staff.add(persons[i]);
 			}
 
 			String[] names = new String[contestants.size()];
 			for (int i = 0; i < contestants.size(); i++) {
-				ITeamMember tm = contestants.get(i);
+				IPerson tm = contestants.get(i);
 				names[i] = tm.getName();
 			}
 			drawLine(g, y, "Contestants", names);
@@ -407,7 +407,7 @@ public class CoachView extends Panel {
 			g.translate(x, 0);
 			names = new String[staff.size()];
 			for (int i = 0; i < staff.size(); i++) {
-				ITeamMember tm = staff.get(i);
+				IPerson tm = staff.get(i);
 				names[i] = tm.getName() + " (" + tm.getRole() + ")";
 			}
 			drawLine(g, y, "Staff", names);

--- a/ContestModel/src/org/icpc/tools/contest/model/IContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContest.java
@@ -384,33 +384,33 @@ public interface IContest {
 	int getOrderOf(ITeam team);
 
 	/**
-	 * Returns the total number of team members.
+	 * Returns the total number of persons.
 	 *
-	 * @return the total number of team members
+	 * @return the total number of persons
 	 */
-	int getNumTeamMembers();
+	int getNumPersons();
 
 	/**
-	 * Returns a list of all team members competing in the contest.
+	 * Returns a list of all persons competing in the contest.
 	 *
-	 * @return a list of all team members
+	 * @return a list of all persons
 	 */
-	ITeamMember[] getTeamMembers();
+	IPerson[] getPersons();
 
 	/**
-	 * Returns the team member with the given id.
+	 * Returns the person with the given id.
 	 *
 	 * @param id an identifier
-	 * @return a team member, or <code>null</code> if the id was invalid
+	 * @return a person, or <code>null</code> if the id was invalid
 	 */
-	ITeamMember getTeamMemberById(String teamId);
+	IPerson getPersonById(String teamId);
 
 	/**
-	 * Returns a list of all team members in the given team id.
+	 * Returns a list of all persons with the given team id.
 	 *
-	 * @return a list of all team members in the given team id
+	 * @return a list of all persons with the given team id
 	 */
-	ITeamMember[] getTeamMembersByTeamId(String teamId);
+	IPerson[] getPersonsByTeamId(String teamId);
 
 	/**
 	 * Returns the total number of submissions.

--- a/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
@@ -15,22 +15,22 @@ import org.icpc.tools.contest.model.internal.Language;
 import org.icpc.tools.contest.model.internal.MapInfo;
 import org.icpc.tools.contest.model.internal.Organization;
 import org.icpc.tools.contest.model.internal.Pause;
+import org.icpc.tools.contest.model.internal.Person;
 import org.icpc.tools.contest.model.internal.Problem;
 import org.icpc.tools.contest.model.internal.Run;
 import org.icpc.tools.contest.model.internal.StartStatus;
 import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.internal.Submission;
 import org.icpc.tools.contest.model.internal.Team;
-import org.icpc.tools.contest.model.internal.TeamMember;
 
 public interface IContestObject {
 	enum ContestType {
-		CONTEST, LANGUAGE, GROUP, ORGANIZATION, TEAM, STATE, RUN, SUBMISSION, JUDGEMENT, CLARIFICATION, AWARD, JUDGEMENT_TYPE, TEST_DATA, PROBLEM, PAUSE, TEAM_MEMBER, MAP_INFO, START_STATUS, COMMENTARY, ACCOUNT
+		CONTEST, LANGUAGE, GROUP, ORGANIZATION, TEAM, STATE, RUN, SUBMISSION, JUDGEMENT, CLARIFICATION, AWARD, JUDGEMENT_TYPE, TEST_DATA, PROBLEM, PAUSE, PERSON, MAP_INFO, START_STATUS, COMMENTARY, ACCOUNT
 	}
 
 	String[] ContestTypeNames = new String[] { "contests", "languages", "groups", "organizations", "teams", "state",
 			"runs", "submissions", "judgements", "clarifications", "awards", "judgement-types", "testdata", "problems",
-			"pause", "team-members", "map-info", "start-status", "commentary", "accounts" };
+			"pause", "persons", "map-info", "start-status", "commentary", "accounts" };
 
 	static String getTypeName(ContestType type) {
 		return ContestTypeNames[type.ordinal()];
@@ -67,8 +67,8 @@ public interface IContestObject {
 				return new Organization();
 			case TEAM:
 				return new Team();
-			case TEAM_MEMBER:
-				return new TeamMember();
+			case PERSON:
+				return new Person();
 			case ACCOUNT:
 				return new Account();
 			case JUDGEMENT_TYPE:

--- a/ContestModel/src/org/icpc/tools/contest/model/IPerson.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IPerson.java
@@ -4,9 +4,9 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 
 /**
- * A team member.
+ * A person.
  */
-public interface ITeamMember extends IContestObject {
+public interface IPerson extends IContestObject {
 	/**
 	 * The ICPC id of the person.
 	 *

--- a/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
@@ -28,11 +28,11 @@ public interface ISubmission extends IContestObject {
 	String getTeamId();
 
 	/**
-	 * Returns the id of the team member that made this submission.
+	 * Returns the id of the person that made this submission.
 	 *
-	 * @return the team member id
+	 * @return the person id
 	 */
-	String getTeamMemberId();
+	String getPersonId();
 
 	/**
 	 * Returns the optional entry point this submission.

--- a/ContestModel/src/org/icpc/tools/contest/model/TSVImporter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/TSVImporter.java
@@ -7,12 +7,13 @@ import java.io.IOException;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
+import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.Group;
 import org.icpc.tools.contest.model.internal.Organization;
 import org.icpc.tools.contest.model.internal.Team;
-import org.icpc.tools.contest.model.internal.TeamMember;
+import org.icpc.tools.contest.model.internal.Person;
 
 public class TSVImporter {
 	private static final String ID = "id";
@@ -30,6 +31,9 @@ public class TSVImporter {
 	private static final String LAST_NAME = "last_name";
 	private static final String SEX = "sex";
 	private static final String ROLE = "role";
+	private static final String TYPE = "type";
+	private static final String USERNAME = "username";
+	private static final String PASSWORD = "password";
 
 	private static void add(ContestObject co, String name, Object value) {
 		if (value == null)
@@ -163,7 +167,7 @@ public class TSVImporter {
 			while (s != null) {
 				String[] st = s.split("\\t");
 				if (st != null && st.length > 0) {
-					TeamMember p = new TeamMember();
+					Person p = new Person();
 					add(p, ID, id + "");
 					id++;
 					add(p, TEAM_ID, st[0]);
@@ -184,6 +188,36 @@ public class TSVImporter {
 						if (st.length >= 6)
 							add(p, ICPC_ID, st[5]);
 						contest.add(p);
+					}
+				}
+				s = br.readLine();
+			}
+		}
+	}
+
+	public static void importAccounts(Contest contest, File f) throws IOException {
+		try (BufferedReader br = new BufferedReader(new FileReader(f))) {
+			// read header
+			br.readLine();
+
+			String s = br.readLine();
+			while (s != null) {
+				String[] st = s.split("\\t");
+				if (st != null && st.length > 0) {
+					Account a = new Account();
+					try {
+						add(a, ContestObject.ID, st[1]);
+						if (st.length < 4)
+							Trace.trace(Trace.WARNING, "Account missing columns: " + s);
+						else {
+							add(a, TYPE, st[0]);
+							// add(a, NAME, st[1]);
+							add(a, USERNAME, st[2]);
+							add(a, PASSWORD, st[3]);
+							contest.add(a);
+						}
+					} catch (Exception e) {
+						Trace.trace(Trace.ERROR, "Error parsing accounts.tsv, account " + a.getId(), e);
 					}
 				}
 				s = br.readLine();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -38,9 +38,9 @@ import org.icpc.tools.contest.model.internal.Group;
 import org.icpc.tools.contest.model.internal.IContestModifier;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.Organization;
+import org.icpc.tools.contest.model.internal.Person;
 import org.icpc.tools.contest.model.internal.Submission;
 import org.icpc.tools.contest.model.internal.Team;
-import org.icpc.tools.contest.model.internal.TeamMember;
 import org.icpc.tools.contest.model.internal.YamlParser;
 
 /**
@@ -837,7 +837,7 @@ public class DiskContestSource extends ContestSource {
 				return new FilePattern(type, id, property, "txt");
 			if (TOOL_DATA.equals(property))
 				return new FilePattern(type, id, property, "txt");
-		} else if (type == ContestType.TEAM_MEMBER) {
+		} else if (type == ContestType.PERSON) {
 			if (PHOTO.equals(property))
 				return new FilePattern(type, id, property, PHOTO_EXTENSIONS);
 		} else if (type == ContestType.ORGANIZATION) {
@@ -909,9 +909,9 @@ public class DiskContestSource extends ContestSource {
 			team.setBackup(mergeRefs(team.getBackup(), getFilesWithPattern(obj, BACKUP)));
 			team.setKeyLog(mergeRefs(team.getKeyLog(), getFilesWithPattern(obj, KEY_LOG)));
 			team.setToolData(mergeRefs(team.getToolData(), getFilesWithPattern(obj, TOOL_DATA)));
-		} else if (obj instanceof TeamMember) {
-			TeamMember member = (TeamMember) obj;
-			member.setPhoto(mergeRefs(member.getPhoto(), getFilesWithPattern(obj, PHOTO)));
+		} else if (obj instanceof Person) {
+			Person person = (Person) obj;
+			person.setPhoto(mergeRefs(person.getPhoto(), getFilesWithPattern(obj, PHOTO)));
 		} else if (obj instanceof Submission) {
 			Submission submission = (Submission) obj;
 			submission.setFiles(mergeRefs(submission.getFiles(), getFilesWithPattern(obj, FILES)));
@@ -1069,11 +1069,11 @@ public class DiskContestSource extends ContestSource {
 			File f = getConfigFile(root, "members.tsv");
 			if (f.exists()) {
 				TSVImporter.importTeamMembers(contest, f);
-				Trace.trace(Trace.INFO, "Imported team members tsv");
+				Trace.trace(Trace.INFO, "Imported persons tsv");
 			}
 		} catch (Exception e) {
-			configValidation.err("Error importing team-members: " + e.getMessage());
-			Trace.trace(Trace.ERROR, "Error importing team-members", e);
+			configValidation.err("Error importing persons: " + e.getMessage());
+			Trace.trace(Trace.ERROR, "Error importing persons", e);
 		}
 
 		// load jsons

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Account.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Account.java
@@ -148,8 +148,8 @@ public class Account extends ContestObject implements IAccount {
 		if (teamId != null && c.getTeamById(teamId) == null)
 			errors.add("Invalid team " + teamId);
 
-		if (personId != null && c.getTeamMemberById(personId) == null)
-			errors.add("Invalid team member " + personId);
+		if (personId != null && c.getPersonById(personId) == null)
+			errors.add("Invalid person " + personId);
 
 		if (errors.isEmpty())
 			return null;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -28,6 +28,7 @@ import org.icpc.tools.contest.model.ILanguage;
 import org.icpc.tools.contest.model.IMapInfo;
 import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.IPause;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IProblemSummary;
 import org.icpc.tools.contest.model.IResult;
@@ -37,7 +38,6 @@ import org.icpc.tools.contest.model.IStartStatus;
 import org.icpc.tools.contest.model.IState;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.ITeamMember;
 import org.icpc.tools.contest.model.Status;
 import org.icpc.tools.contest.model.util.AwardUtil;
 
@@ -56,7 +56,7 @@ public class Contest implements IContest {
 	private IGroup[] groups;
 	private IOrganization[] organizations;
 	private ITeam[] teams;
-	private ITeamMember[] members;
+	private IPerson[] persons;
 	private ISubmission[] submissions;
 	private IJudgement[] judgements;
 	private IClarification[] clars;
@@ -191,7 +191,7 @@ public class Contest implements IContest {
 			awards = null;
 			pauses = null;
 			startStatus = null;
-			members = null;
+			persons = null;
 			runs = null;
 			clars = null;
 			commentary = null;
@@ -291,8 +291,8 @@ public class Contest implements IContest {
 			submissionJudgementTypes = null;
 			recentActivity = null;
 			fts = null;
-		} else if (type == ContestType.TEAM_MEMBER) {
-			members = null;
+		} else if (type == ContestType.PERSON) {
+			persons = null;
 		} else if (type == ContestType.START_STATUS) {
 			startStatus = null;
 		} else if (type == ContestType.ACCOUNT) {
@@ -792,42 +792,42 @@ public class Contest implements IContest {
 	}
 
 	@Override
-	public ITeamMember[] getTeamMembers() {
-		ITeamMember[] temp = members;
+	public IPerson[] getPersons() {
+		IPerson[] temp = persons;
 		if (temp != null)
 			return temp;
 
 		synchronized (data) {
-			if (members != null)
-				return members;
+			if (persons != null)
+				return persons;
 
-			members = data.getByType(ITeamMember.class, ContestType.TEAM_MEMBER);
-			return members;
+			persons = data.getByType(IPerson.class, ContestType.PERSON);
+			return persons;
 		}
 	}
 
 	@Override
-	public ITeamMember[] getTeamMembersByTeamId(String id) {
-		ITeamMember[] temp = getTeamMembers();
-		List<ITeamMember> list = new ArrayList<>();
-		for (ITeamMember m : temp) {
+	public IPerson[] getPersonsByTeamId(String id) {
+		IPerson[] temp = getPersons();
+		List<IPerson> list = new ArrayList<>();
+		for (IPerson m : temp) {
 			if (id.equals(m.getTeamId()))
 				list.add(m);
 		}
 		if (list.isEmpty())
 			return null;
 
-		ITeamMember[] tempMembers = list.toArray(new ITeamMember[0]);
+		IPerson[] tempPersons = list.toArray(new IPerson[0]);
 
 		// default sort: by last name with coaches to bottom
-		Arrays.sort(tempMembers, (o1, o2) -> {
+		Arrays.sort(tempPersons, (o1, o2) -> {
 			if (o1.getRole() != null && o2.getRole() != null && !o1.getRole().equals(o2.getRole()))
 				return -o1.getRole().compareTo(o2.getRole());
 			if (o1.getName() != null && o2.getName() != null)
 				return collator.compare(o1.getName(), o2.getName());
 			return 0;
 		});
-		return tempMembers;
+		return tempPersons;
 	}
 
 	@Override
@@ -1349,13 +1349,13 @@ public class Contest implements IContest {
 	}
 
 	@Override
-	public int getNumTeamMembers() {
+	public int getNumPersons() {
 		return getTeams().length;
 	}
 
 	@Override
-	public ITeamMember getTeamMemberById(String id) {
-		return (ITeamMember) data.getById(id, ContestType.TEAM_MEMBER);
+	public IPerson getPersonById(String id) {
+		return (IPerson) data.getById(id, ContestType.PERSON);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
@@ -598,7 +598,7 @@ public class ContestData implements Iterable<IContestObject> {
 		ContestType type = obj.getType();
 		return (type == ContestType.CONTEST || type == ContestType.PROBLEM || type == ContestType.GROUP
 				|| type == ContestType.LANGUAGE || type == ContestType.JUDGEMENT_TYPE || type == ContestType.TEAM
-				|| type == ContestType.TEAM_MEMBER || type == ContestType.ORGANIZATION || type == ContestType.STATE);
+				|| type == ContestType.PERSON || type == ContestType.ORGANIZATION || type == ContestType.STATE);
 	}
 
 	public IContestObject[] toArray() {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/MergingContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/MergingContest.java
@@ -42,6 +42,6 @@ public class MergingContest extends Contest {
 		ContestType type = obj.getType();
 		return (type == ContestType.CONTEST || type == ContestType.PROBLEM || type == ContestType.GROUP
 				|| type == ContestType.LANGUAGE || type == ContestType.JUDGEMENT_TYPE || type == ContestType.TEAM
-				|| type == ContestType.TEAM_MEMBER || type == ContestType.ORGANIZATION);
+				|| type == ContestType.PERSON || type == ContestType.ORGANIZATION);
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -8,10 +8,10 @@ import java.util.Map;
 
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
-import org.icpc.tools.contest.model.ITeamMember;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 
-public class TeamMember extends ContestObject implements ITeamMember {
+public class Person extends ContestObject implements IPerson {
 	private static final String ICPC_ID = "icpc_id";
 	private static final String TEAM_ID = "team_id";
 	private static final String FIRST_NAME = "first_name";
@@ -48,7 +48,7 @@ public class TeamMember extends ContestObject implements ITeamMember {
 
 	@Override
 	public ContestType getType() {
-		return ContestType.TEAM_MEMBER;
+		return ContestType.PERSON;
 	}
 
 	@Override
@@ -294,18 +294,18 @@ public class TeamMember extends ContestObject implements ITeamMember {
 
 	@Override
 	public IContestObject clone() {
-		TeamMember t = new TeamMember();
-		t.id = id;
-		t.photo = photo;
-		t.icpcId = icpcId;
-		t.firstName = firstName;
-		t.lastName = lastName;
-		t.name = name;
-		t.email = email;
-		t.sex = sex;
-		t.teamId = teamId;
-		t.role = role;
-		return t;
+		Person p = new Person();
+		p.id = id;
+		p.photo = photo;
+		p.icpcId = icpcId;
+		p.firstName = firstName;
+		p.lastName = lastName;
+		p.name = name;
+		p.email = email;
+		p.sex = sex;
+		p.teamId = teamId;
+		p.role = role;
+		return p;
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -14,13 +14,13 @@ public class Submission extends TimedEvent implements ISubmission {
 	private static final String PROBLEM_ID = "problem_id";
 	private static final String LANGUAGE_ID = "language_id";
 	private static final String TEAM_ID = "team_id";
-	private static final String TEAM_MEMBER_ID = "team_member_id";
+	private static final String PERSON_ID = "person_id";
 	private static final String ENTRY_POINT = "entry_point";
 	private static final String FILES = "files";
 	private static final String REACTION = "reaction";
 
 	private String teamId;
-	private String teamMemberId;
+	private String personId;
 	private String problemId;
 	private String languageId;
 	private String entryPoint;
@@ -38,8 +38,8 @@ public class Submission extends TimedEvent implements ISubmission {
 	}
 
 	@Override
-	public String getTeamMemberId() {
-		return teamMemberId;
+	public String getPersonId() {
+		return personId;
 	}
 
 	@Override
@@ -121,6 +121,7 @@ public class Submission extends TimedEvent implements ISubmission {
 		s.entryPoint = entryPoint;
 		s.contestTime = contestTime;
 		s.time = time;
+		s.personId = personId;
 		return s;
 	}
 
@@ -129,8 +130,8 @@ public class Submission extends TimedEvent implements ISubmission {
 		if (TEAM_ID.equals(name)) {
 			teamId = (String) value;
 			return true;
-		} else if (TEAM_MEMBER_ID.equals(name)) {
-			teamMemberId = (String) value;
+		} else if (PERSON_ID.equals(name)) {
+			personId = (String) value;
 			return true;
 		} else if (PROBLEM_ID.equals(name)) {
 			problemId = (String) value;
@@ -156,8 +157,8 @@ public class Submission extends TimedEvent implements ISubmission {
 		super.getPropertiesImpl(props);
 		props.put(PROBLEM_ID, problemId);
 		props.put(TEAM_ID, teamId);
-		if (teamMemberId != null)
-			props.put(TEAM_MEMBER_ID, teamMemberId);
+		if (personId != null)
+			props.put(PERSON_ID, personId);
 		props.put(LANGUAGE_ID, languageId);
 		props.put(ENTRY_POINT, entryPoint);
 		props.put(FILES, files);
@@ -169,8 +170,8 @@ public class Submission extends TimedEvent implements ISubmission {
 		je.encode(ID, id);
 		je.encode(PROBLEM_ID, problemId);
 		je.encode(TEAM_ID, teamId);
-		if (teamMemberId != null)
-			je.encode(TEAM_MEMBER_ID, teamMemberId);
+		if (personId != null)
+			je.encode(PERSON_ID, personId);
 		je.encode(LANGUAGE_ID, languageId);
 		if (entryPoint != null)
 			je.encode(ENTRY_POINT, entryPoint);
@@ -198,8 +199,8 @@ public class Submission extends TimedEvent implements ISubmission {
 				errors.add("Submission occured before the contest started");
 		}
 
-		if (teamMemberId != null && c.getTeamMemberById(teamMemberId) == null)
-			errors.add("Invalid team member " + teamMemberId);
+		if (personId != null && c.getPersonById(personId) == null)
+			errors.add("Invalid person " + personId);
 
 		if (errors.isEmpty())
 			return null;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -8,11 +8,11 @@ import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IJudgement;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IState;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.ITeamMember;
 import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
 
@@ -97,11 +97,11 @@ public class PublicContest extends Contest {
 				super.add(account);
 				return;
 			}
-			case TEAM_MEMBER: {
-				ITeamMember member = (ITeamMember) obj;
-				ITeam team = getTeamById(member.getTeamId());
+			case PERSON: {
+				IPerson person = (IPerson) obj;
+				ITeam team = getTeamById(person.getTeamId());
 				if (!isTeamHidden(team))
-					super.add(member);
+					super.add(person);
 				return;
 			}
 			case SUBMISSION: {

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -761,7 +761,7 @@ public class ResolverLogic {
 		types.add(ContestType.CONTEST);
 		types.add(ContestType.STATE);
 		types.add(ContestType.TEAM);
-		types.add(ContestType.TEAM_MEMBER);
+		types.add(ContestType.PERSON);
 		types.add(ContestType.ORGANIZATION);
 		types.add(ContestType.GROUP);
 		types.add(ContestType.PROBLEM);

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -18,8 +18,8 @@ import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.Group;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.Organization;
+import org.icpc.tools.contest.model.internal.Person;
 import org.icpc.tools.contest.model.internal.Team;
-import org.icpc.tools.contest.model.internal.TeamMember;
 import org.icpc.tools.contest.util.cms.CMSDownloadHelper.ContestInfo;
 
 /**
@@ -53,7 +53,7 @@ public class JsonToTSVConverter {
 	protected static List<Group> groupList = new ArrayList<>();
 	protected static List<Organization> orgList = new ArrayList<>();
 	protected static List<Team> teamList = new ArrayList<>();
-	protected static List<TeamMember> memberList = new ArrayList<>();
+	protected static List<Person> personList = new ArrayList<>();
 	protected static List<CMSStaffMember> staffMemberList = new ArrayList<>();
 	protected static List<CMSWinner> winnerList = new ArrayList<>();
 	protected static List<String> contestIdList = new ArrayList<>();
@@ -114,7 +114,7 @@ public class JsonToTSVConverter {
 		groupList = new ArrayList<>();
 		orgList = new ArrayList<>();
 		teamList = new ArrayList<>();
-		memberList = new ArrayList<>();
+		personList = new ArrayList<>();
 		winnerList = new ArrayList<>();
 		contestIdList = new ArrayList<>();
 
@@ -139,7 +139,7 @@ public class JsonToTSVConverter {
 		groupList = new ArrayList<>();
 		orgList = new ArrayList<>();
 		teamList = new ArrayList<>();
-		memberList = new ArrayList<>();
+		personList = new ArrayList<>();
 		staffMemberList = new ArrayList<>();
 
 		try {
@@ -156,7 +156,7 @@ public class JsonToTSVConverter {
 					return false;
 				}
 			});
-			
+
 			System.out.println("Loading " + files.length + " institutions");
 			for (File f : files) {
 				readInstitution(f);
@@ -171,7 +171,7 @@ public class JsonToTSVConverter {
 			TSVImporter.importGroups(groupList, cmsClicsRoot);
 			TSVImporter.importInstitutions(orgList, cmsClicsRoot);
 			TSVImporter.importTeams(teamList, cmsClicsRoot, AUTO_ASSIGN_TEAM_IDS);
-			TSVImporter.importTeamMembers(memberList, cmsClicsRoot);
+			TSVImporter.importTeamMembers(personList, cmsClicsRoot);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -190,7 +190,7 @@ public class JsonToTSVConverter {
 
 		try {
 			System.out.println("Reading CMS team members: " + cmsContestRoot);
-			TSVImporter.importTeamMembersTab(memberList, teamList, cmsContestRoot);
+			TSVImporter.importPersonsTab(personList, teamList, cmsContestRoot);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -248,7 +248,7 @@ public class JsonToTSVConverter {
 		try {
 			System.out.println("Cleaning and sorting");
 			teamList.removeIf(t -> t.getId() == null);
-			memberList.removeIf(m -> m.getTeamId() == null);
+			personList.removeIf(m -> m.getTeamId() == null);
 
 			if (FINALS_NAMING) {
 				for (Team t : teamList) {
@@ -281,7 +281,7 @@ public class JsonToTSVConverter {
 			groupList.sort((g1, g2) -> compare(g1.getId(), g2.getId()));
 			teamList.sort((t1, t2) -> compare(t1.getId(), t2.getId()));
 			orgList.sort((i1, i2) -> compare(i1.getId(), i2.getId()));
-			memberList.sort((m1, m2) -> compare(m1.getTeamId(), m2.getTeamId()));
+			personList.sort((m1, m2) -> compare(m1.getTeamId(), m2.getTeamId()));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -306,7 +306,7 @@ public class JsonToTSVConverter {
 			writeTeamsTSV(teamList, configFolder, true);
 			writeInstitutionsTSV(orgList, configFolder, false);
 			writeInstitutionsTSV(orgList, configFolder, true);
-			writeMembersTSV(memberList, configFolder);
+			writeMembersTSV(personList, configFolder);
 			writeStaffMembersTSV(staffMemberList, configFolder);
 
 			writeContestJSON(info, configFolder);
@@ -314,7 +314,7 @@ public class JsonToTSVConverter {
 			writeJSON(new File(contestRoot, "groups.json"), groupList);
 			writeJSON(new File(contestRoot, "organizations.json"), orgList);
 			writeJSON(new File(contestRoot, "teams.json"), teamList);
-			writeJSON(new File(contestRoot, "team-members.json"), memberList);
+			writeJSON(new File(contestRoot, "persons.json"), personList);
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -500,11 +500,11 @@ public class JsonToTSVConverter {
 		fw.write("\"" + name + "\":" + "" + value + "");
 	}
 
-	protected static void writeMembersTSV(List<TeamMember> members, File folder) throws Exception {
+	protected static void writeMembersTSV(List<Person> members, File folder) throws Exception {
 		File f = new File(folder, "members.tsv");
 		FileWriter fw = new FileWriter(f);
 		fw.write("File_Version\t1\n");
-		for (TeamMember member : members) {
+		for (Person member : members) {
 			fw.write(member.getTeamId());
 			fw.write("\t");
 			fw.write(member.getRole().substring(0, 1).toUpperCase());
@@ -561,7 +561,7 @@ public class JsonToTSVConverter {
 				for (Object personObj : persons) {
 					JsonObject person = (JsonObject) personObj;
 					String pId = person.getInt("personId") + "";
-					TeamMember m = getMemberByICPCId(pId);
+					Person m = getMemberByICPCId(pId);
 					m.add("team_id", team.getInt("workstationId") + "");
 					m.add("first_name", person.getString("firstname"));
 					m.add("last_name", person.getString("lastname"));
@@ -604,13 +604,13 @@ public class JsonToTSVConverter {
 		for (JsonObject result : arr.getValuesAs(JsonObject.class)) {
 			// String name = team.getString("name");
 			// String cId = result.getInt("externalContestId") + "";
-		
+
 			// String rank = result.getInt("rank") + "";
 			// String problemssolved = result.getInt("problemssolved") + "";
 			// String totaltime = result.getInt("totaltime") + "";
 			// String lastproblemtime = result.getInt("lastproblemtime") + "";
 			// CMSTeam t = getTeam(tId);
-		
+
 			// System.out.println(id + " " + cId + " " + rank + " " + contestIdList.contains(cId));
 		}*/
 	}
@@ -755,7 +755,7 @@ public class JsonToTSVConverter {
 				for (JsonObject member : teamMembers.getValuesAs(JsonObject.class)) {
 					String firstName = member.getString("firstName");
 					String lastName = member.getString("lastName");
-				
+
 					CMSMember m = getMember(firstName, lastName);
 					m.role = member.getString("teamRole");
 					m.team = t;
@@ -836,16 +836,16 @@ public class JsonToTSVConverter {
 		return m;
 	}
 
-	private static TeamMember getMemberByICPCId(String id) {
-		for (TeamMember m : memberList) {
+	private static Person getMemberByICPCId(String id) {
+		for (Person m : personList) {
 			if (m.getICPCId().equals(id))
 				return m;
 		}
 
-		TeamMember m = new TeamMember();
+		Person m = new Person();
 		m.add("id", id);
 		m.add("icpc_id", id);
-		memberList.add(m);
+		personList.add(m);
 		return m;
 	}
 }

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/TSVImporter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/TSVImporter.java
@@ -13,7 +13,7 @@ import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.Group;
 import org.icpc.tools.contest.model.internal.Organization;
 import org.icpc.tools.contest.model.internal.Team;
-import org.icpc.tools.contest.model.internal.TeamMember;
+import org.icpc.tools.contest.model.internal.Person;
 
 public class TSVImporter {
 	private static final String ID = "id";
@@ -177,7 +177,7 @@ public class TSVImporter {
 		}
 	}
 
-	public static void importTeamMembers(List<TeamMember> list, File f) throws IOException {
+	public static void importTeamMembers(List<Person> list, File f) throws IOException {
 		int id = 1;
 		try (BufferedReader br = new BufferedReader(new FileReader(new File(f, "members.tsv")))) {
 			// read header
@@ -187,7 +187,7 @@ public class TSVImporter {
 			while (s != null) {
 				String[] st = s.split("\\t");
 				if (st != null && st.length > 0) {
-					TeamMember p = new TeamMember();
+					Person p = new Person();
 					add(p, ID, id + "");
 					id++;
 					add(p, TEAM_ID, st[0]);
@@ -215,8 +215,8 @@ public class TSVImporter {
 		}
 	}
 
-	public static void importTeamMembersTab(List<TeamMember> list, List<Team> teams, File f) throws IOException {
-		List<TeamMember> temp = new ArrayList<>();
+	public static void importPersonsTab(List<Person> list, List<Team> teams, File f) throws IOException {
+		List<Person> temp = new ArrayList<>();
 		try (BufferedReader br = new BufferedReader(new FileReader(new File(f, "Person.tab")))) {
 			// read header
 			br.readLine();
@@ -225,7 +225,7 @@ public class TSVImporter {
 			while (s != null) {
 				String[] st = s.split("\\t");
 				if (st != null && st.length > 0) {
-					TeamMember p = new TeamMember();
+					Person p = new Person();
 					add(p, ID, st[0]);
 					add(p, ICPC_ID, st[0]);
 					// add(p, TEAM_ID, st[0]);
@@ -255,8 +255,8 @@ public class TSVImporter {
 				if (st != null && st.length > 0) {
 					String id = st[0];
 
-					TeamMember p = null;
-					for (TeamMember tm : temp)
+					Person p = null;
+					for (Person tm : temp)
 						if (id.equals(tm.getICPCId()))
 							p = tm;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
@@ -24,10 +24,10 @@ import org.icpc.tools.contest.model.IAward.DisplayMode;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IOrganization;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IStanding;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.ITeamMember;
 import org.icpc.tools.contest.model.internal.Award;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.AwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
@@ -50,7 +50,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 		private boolean mergedAwards;
 
 		private String[] name;
-		private String[] members;
+		private String[] persons;
 	}
 
 	private Cache[] cache;
@@ -58,7 +58,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 	private Cache currentCache;
 	private Font teamFont;
 	private Font groupFont;
-	private Font memberFont;
+	private Font personFont;
 	private BufferedImage logo;
 	private boolean showInfo;
 
@@ -70,7 +70,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 		float inch = height * 72f / dpi / 10f;
 		teamFont = ICPCFont.deriveFont(Font.BOLD, inch * 0.9f);
 		groupFont = ICPCFont.deriveFont(Font.BOLD, inch * 0.7f);
-		memberFont = ICPCFont.deriveFont(Font.BOLD, inch * 0.3f);
+		personFont = ICPCFont.deriveFont(Font.BOLD, inch * 0.3f);
 	}
 
 	@Override
@@ -147,11 +147,11 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 
 		mergeAwards();
 
-		ITeamMember[] members = getContest().getTeamMembersByTeamId(currentCache.teamId);
-		if (members != null) {
-			Arrays.sort(members, new Comparator<ITeamMember>() {
+		IPerson[] persons = getContest().getPersonsByTeamId(currentCache.teamId);
+		if (persons != null) {
+			Arrays.sort(persons, new Comparator<IPerson>() {
 				@Override
-				public int compare(ITeamMember m1, ITeamMember m2) {
+				public int compare(IPerson m1, IPerson m2) {
 					String r1 = m1.getRole();
 					String r2 = m2.getRole();
 					if (r1 == null || r2 == null)
@@ -160,16 +160,16 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 				}
 			});
 		}
-		if (members == null)
-			currentCache.members = new String[0];
+		if (persons == null)
+			currentCache.persons = new String[0];
 		else {
-			int size = members.length;
-			currentCache.members = new String[size];
+			int size = persons.length;
+			currentCache.persons = new String[size];
 			for (int i = 0; i < size; i++) {
-				String s = members[i].getName();
-				if (!"contestant".equals(members[i].getRole().toLowerCase()))
-					s += " (" + members[i].getRole() + ")";
-				currentCache.members[i] = s;
+				String s = persons[i].getName();
+				if (!"contestant".equals(persons[i].getRole().toLowerCase()))
+					s += " (" + persons[i].getRole() + ")";
+				currentCache.persons[i] = s;
 			}
 		}
 
@@ -348,14 +348,14 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			}
 		}
 
-		if (showInfo && c.members.length > 0) {
+		if (showInfo && c.persons.length > 0) {
 			g.setComposite(AlphaComposite.SrcOver.derive(0.5f));
 			g.setColor(Color.BLACK);
-			int size = c.members.length;
+			int size = c.persons.length;
 			fm = g.getFontMetrics();
 			int wid = 0;
 			for (int i = 0; i < size; i++) {
-				wid = Math.max(wid, fm.stringWidth(c.members[i]));
+				wid = Math.max(wid, fm.stringWidth(c.persons[i]));
 			}
 			g.fillRect(0, height - h - BORDER - fm.getHeight() * size - BORDER * 2, wid + BORDER * 2,
 					fm.getHeight() * size + BORDER * 2);
@@ -365,10 +365,10 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 
 			g.setComposite(AlphaComposite.SrcOver);
 			g.setColor(Color.WHITE);
-			g.setFont(memberFont);
+			g.setFont(personFont);
 
 			for (int i = 0; i < size; i++) {
-				g.drawString(c.members[i], BORDER, height - h - BORDER - fm.getHeight() * (size - i));
+				g.drawString(c.persons[i], BORDER, height - h - BORDER - fm.getHeight() * (size - i));
 			}
 
 			IStanding st = contest.getStanding(team);


### PR DESCRIPTION
Renames team members to persons as per the spec change. Leaves the /team-members endpoint redirected to /persons so simple queries still work.

TSV importer gains ability to import accounts since I was already working on that class.