### PR TITLE
Assume unknown teams were hidden

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1078,7 +1078,7 @@ public class Contest implements IContest {
 	@Override
 	public boolean isTeamHidden(ITeam team) {
 		if (team == null)
-			return false;
+			return true;
 
 		if (team.isHidden())
 			return true;


### PR DESCRIPTION
If a submission ever appeared in the feed before the team that submitted it, the submission would be lost, but that isn't allowed by the spec and seems pretty unlikely anyway.