### PR TITLE
Per-account start-status control

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -234,9 +234,9 @@
 <script type="text/html" id="start-status-template">
   <td>{{{label}}}</td>
   <td><div class="btn-group">
-    <button type="button" class="btn btn-sm btn-flat btn-{{a}}" onclick="updateStartStatus('{{{id}}}',0)">No</button>
-    <button type="button" class="btn btn-sm btn-{{b}}" onclick="updateStartStatus('{{{id}}}',1)">Unknown</button>
-    <button type="button" class="btn btn-sm btn-{{c}}" onclick="updateStartStatus('{{{id}}}',2)">Yes</button>
+    <button type="button" class="btn btn-sm btn-{{#a}}danger{{/a}}{{^a}}default{{/a}}" onclick="updateStartStatus('{{{id}}}',0)">No</button>
+    <button type="button" class="btn btn-sm btn-{{#b}}warning{{/b}}{{^b}}default{{/b}}" onclick="updateStartStatus('{{{id}}}',1)">Unknown</button>
+    <button type="button" class="btn btn-sm btn-{{#c}}success{{/c}}{{^c}}default{{/c}}" onclick="updateStartStatus('{{{id}}}',2)">Yes</button>
   </div>&nbsp; &nbsp;<button type="button" class="btn btn-sm btn-danger" onclick="removeStartStatus('{{{id}}}')">Remove</button></td>
 </script>
 <script>

--- a/CDS/WebContent/WEB-INF/jsps/details.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/details.jsp
@@ -1,6 +1,7 @@
 <% request.setAttribute("title", "Details"); %>
 <%@ include file="layout/head.jsp" %>
 <script src="${pageContext.request.contextPath}/js/contest.js"></script>
+<script src="${pageContext.request.contextPath}/js/cds.js"></script>
 <script src="${pageContext.request.contextPath}/js/model.js"></script>
 <script src="${pageContext.request.contextPath}/js/luxon.min.js"></script>
 <script src="${pageContext.request.contextPath}/js/ui.js"></script>
@@ -12,11 +13,11 @@ updateContestClock(contest, "contest-time");
 </script>
 <div class="container-fluid">
     <div class="row">
-        <div class="col-7"><%@ include file="details/problems.html" %></div>
-        <div class="col-5"><%@ include file="details/contest.html" %><%@ include file="details/languages.html" %></div>
-    </div>
-    <div class="row">
-        <div class="col-7"><%@ include file="details/judgementTypes.html" %></div>
+        <div class="col-7"><%@ include file="details/problems.html" %>
+          <%@ include file="details/judgementTypes.html" %></div>
+        <div class="col-5"><%@ include file="details/contest.html" %>
+          <%@ include file="details/languages.html" %>
+          <%@ include file="details/startStatus.html" %></div>
     </div>
 </div>
 <%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/details/startStatus.html
+++ b/CDS/WebContent/WEB-INF/jsps/details/startStatus.html
@@ -1,0 +1,69 @@
+
+<div class="card">
+   <div class="card-header">
+     <h4 class="card-title">Start Status</h4>
+        <div class="card-tools">
+            <span id="start-status-count" title="?" class="badge bg-primary">?</span>
+        </div>
+   </div>
+<div class="card-body p-0">
+   <table id="start-status-table" class="table table-sm table-hover table-striped table-head-fixed">
+     <thead>
+       <tr>
+         <th>Label</th>
+         <th class="text-center">Status</th>
+       </tr>
+     </thead>
+     <tbody>
+     </tbody>
+   </table>
+</div>
+</div>
+<script type="text/html" id="start-status-template">
+<td>{{{label}}}</td>
+<td class="text-center">
+  {{^edit}}
+    {{#a}}<span class="badge badge-danger"><i class="fas fa-times"></i></span>{{/a}}
+    {{#b}}<span class="badge badge-warning"><i class="fas fa-question"></i></span>{{/b}}
+    {{#c}}<span class="badge badge-success"><i class="fas fa-check"></i></span>{{/c}}
+  {{/edit}}{{#edit}}
+    <div class="btn-group">
+      <button type="button" class="btn btn-sm btn-flat btn-{{#a}}danger{{/a}}{{^a}}default{{/a}}" onclick="updateStartStatus('{{{id}}}',0)" {{^edit}}disabled{{/edit}}>No</button>
+      <button type="button" class="btn btn-sm btn-flat btn-{{#b}}warning{{/b}}{{^b}}default{{/b}}" onclick="updateStartStatus('{{{id}}}',1)" {{^edit}}disabled{{/edit}}>Unknown</button>
+      <button type="button" class="btn btn-sm btn-flat btn-{{#c}}success{{/c}}{{^c}}default{{/c}}" onclick="updateStartStatus('{{{id}}}',2)" {{^edit}}disabled{{/edit}}>Yes</button>
+    </div>
+  {{/edit}}
+</td>
+</script>
+<script>
+registerContestObjectTable("start-status");
+cds.setContestId("<%= cc.getId() %>");
+
+$(document).ready(function () {
+    updateStartStatusTable(); 
+    setInterval(updateStartStatusTable, 10000);
+});
+
+function updateStartStatus(id, status) {
+	cds.doPatch("start-status", id, '{"id":"' + id + '","status":"' + status + '"}', function() { updateStartStatusTable(); });
+}
+
+function updateStartStatusTable() {
+	contest.clear();
+	$.when(contest.loadStartStatus(),contest.loadAccess()).done(function () {
+		// modify object if the user has access to change it
+		var access = contest.getAccess();
+		contest.getStartStatus().forEach(ss => {
+			access.capabilities.forEach(cap => {
+ 	            if (cap.startsWith("start-status/" + ss.id)) {
+ 				    ss.edit = true;
+ 	            }
+ 			});
+		});
+
+        fillContestObjectTable("start-status", contest.getStartStatus());
+    }).fail(function (result) {
+        console.log("Error loading start-status: " + result);
+    });
+}
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -77,7 +77,7 @@ function logout() {
       <ul class="navbar-nav ml-auto">
         <li class="nav-item dropdown theme-menu">
           <a class="nav-link" data-toggle="dropdown" href="#">
-            <i class="fas fa-user"></i>&nbsp;&nbsp;
+            <i class="fas fa-adjust"></i>&nbsp;&nbsp;
             Theme
           </a>
           <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
@@ -166,7 +166,6 @@ function logout() {
                 </li>
                 <% } %>
               </ul>
-
             </li>
             <% } } %>
             

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -259,14 +259,12 @@ function awardsTd(award) {
 }
 
 function startstatusTd(startStatus) {
-	var a = 'default';
-	var b = 'default';
-	var c = 'default';
+	var s = { label: startStatus.label, id: startStatus.id, edit: startStatus.edit };
 	if (startStatus.status == 0)
-		a = 'danger';
+		s.a = 'danger';
 	else if (startStatus.status == 1)
-		b = 'warning';
+		s.b = 'warning';
 	else if (startStatus.status == 2)
-		c = 'success';
-	return { label: startStatus.label, id: startStatus.id, a: a, b: b, c: c };
+		s.c = 'success';
+	return s;
 }

--- a/CDS/src/org/icpc/tools/cds/AccessService.java
+++ b/CDS/src/org/icpc/tools/cds/AccessService.java
@@ -7,6 +7,7 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.icpc.tools.cds.CDSConfig.Auth;
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 
@@ -25,16 +26,25 @@ public class AccessService {
 		IAccount account = cc.getAccount(request.getRemoteUser());
 
 		if (account != null) {
-			if ("team".equals(account.getAccountType())) {
+			String type = account.getAccountType();
+			if ("team".equals(type)) {
 				caps.add("team_submit");
 				caps.add("team_clar");
 			}
-			if ("admin".equals(account.getAccountType())) {
+			if ("admin".equals(type)) {
 				caps.add("contest_start");
 				caps.add("admin_submit");
 				caps.add("admin_clar");
 			}
 		}
+		String user = request.getRemoteUser();
+		if (user != null)
+			for (Auth a : CDSConfig.getInstance().getAuths()) {
+				if (user.equals(a.getUsername())) {
+					if (a.getContestId() == null || cc.getContest().getId().equals(a.getContestId()))
+						caps.add(a.getType() + "/" + a.getId());
+				}
+			}
 
 		if (caps.isEmpty())
 			je.encodePrimitive("capabilities", "[]");

--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -88,10 +88,40 @@ public class CDSConfig {
 		}
 	}
 
+	public static class Auth {
+		private Element auth;
+
+		protected Auth(Element e) {
+			auth = e;
+		}
+
+		public String getUsername() {
+			return getString(auth, "username");
+		}
+
+		public String getContestId() {
+			return getString(auth, "contestId");
+		}
+
+		public String getType() {
+			return getString(auth, "type");
+		}
+
+		public String getId() {
+			return getString(auth, "id");
+		}
+
+		@Override
+		public String toString() {
+			return "Auth [" + getUsername() + ":" + getContestId() + "," + getType() + "," + getId() + "]";
+		}
+	}
+
 	private ConfiguredContest[] contests;
 	private long[] contestHashes;
 	private Domain[] domains;
 	private String[] hosts;
+	private Auth[] auths = new Auth[0];
 	private File file;
 	private long lastModified;
 	private List<IAccount> userAccounts = new ArrayList<IAccount>();
@@ -274,6 +304,15 @@ public class CDSConfig {
 
 			hosts = temp;
 		}
+
+		children = getChildren(e, "auth");
+		if (children != null) {
+			auths = new Auth[children.length];
+			for (int i = 0; i < children.length; i++) {
+				auths[i] = new Auth(children[i]);
+			}
+		} else
+			auths = new Auth[0];
 	}
 
 	private void loadAccounts(File f) throws IOException {
@@ -317,6 +356,10 @@ public class CDSConfig {
 
 	public Domain[] getDomains() {
 		return domains;
+	}
+
+	public Auth[] getAuths() {
+		return auths;
 	}
 
 	/**


### PR DESCRIPTION
Adds the ability to configure patch access for accounts to change individual contest objects, and a web UI to change the start-status when you have access.

On the server side, you can add CDS config to allow an account access to patch, e.g.:
  <auth username="x" contestId="test" type="start-status" id="Sysops"/>
Individual attributes can be left out to specify "all", e.g. leave out contestId to allow patching on any contest. This is not documented until we get a little feedback and use at NAC.

/access is updated to include a "type/id" capability when you have access to patch something.

On the client side, start status items is now visible on the Details page. If the user has access (via the "start-status/<id>" capability) then the status is replaced by three buttons, just like the existing admin controls.

Also changed the Theme icon to fa-adjust.

Screencap, because I know Tobi likes them:
<img width="735" alt="Screen Shot 2022-04-26 at 8 27 29 AM" src="https://user-images.githubusercontent.com/19958075/165301496-f2c7f023-abe0-49f9-83e2-1227839fe390.png">