### PR TITLE
Fix admin pause time

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -242,41 +242,7 @@
 <script>
     contest = new Contest("/api", "<%= cc.getId() %>");
 	cds.setContestId("<%= cc.getId() %>");
-    var targetTime = 50.0;
-
-    function toString(seconds_left) {
-        var days = parseInt(seconds_left / 86400);
-        seconds_left = seconds_left % 86400;
-
-        var hours = parseInt(seconds_left / 3600);
-        seconds_left = seconds_left % 3600;
-
-        var minutes = parseInt(seconds_left / 60);
-        var seconds = parseInt(seconds_left % 60);
-
-        var text = "";
-        if (days > 0)
-            text = days + "d ";
-
-        if (hours < 10)
-            text += "0" + hours;
-        else
-            text += hours;
-
-        text += ":";
-        if (minutes < 10)
-            text += "0" + minutes;
-        else
-            text += minutes;
-
-        text += ":";
-        if (seconds < 10)
-            text += "0" + seconds;
-        else
-            text += seconds;
-
-        return text;
-    }
+    var targetTime = 0.0;
 
     // update the tag with id "countdown" every 300ms
     setInterval(function () {
@@ -285,18 +251,17 @@
             countdown.innerHTML = "undefined";
             return;
         } else if (targetTime < 0) {
-            countdown.innerHTML = toString(-targetTime) + " (paused)";
+            countdown.innerHTML = formatContestTime(targetTime, true) + " (paused)";
             return;
         }
         // find the amount of "seconds" between now and target
-        var current_date = new Date().getTime() / 1000.0;
-        var seconds_left = (targetTime - current_date);
+        var now = new Date().getTime();
+        var seconds_left = now - targetTime;
 
-        if (seconds_left < 0) {
+        if (seconds_left > 0)
             countdown.innerHTML = "Contest is started";
-        } else {
-            countdown.innerHTML = toString(seconds_left);
-        }
+        else
+            countdown.innerHTML = formatContestTime(seconds_left, true);
     }, 300);
 
     function sendCommand(id, command) {
@@ -314,7 +279,7 @@
                     if (resp == null || resp.trim().length == 0)
                         targetTime = null;
                     else
-                        targetTime = parseInt(resp) / 1000.0;
+                        targetTime = parseInt(resp);
                     document.getElementById("status").innerHTML = "Request successful";
                 } else
                     document.getElementById("status").innerHTML = resp;
@@ -339,7 +304,7 @@
                     if (resp == null || resp.trim().length == 0)
                         targetTime = null;
                     else
-                        targetTime = parseInt(resp) / 1000.0;
+                        targetTime = parseInt(resp);
                     document.getElementById("bg-status").innerHTML = "";
                 } else
                     document.getElementById("bg-status").innerHTML = "Error updating: " + resp;

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -285,14 +285,14 @@ class Contest {
 			if (this.info.countdown_pause_time == null)
 				return "Contest not scheduled";
 			else
-				return "Countdown paused: " + formatContestTime(parseTime(this.info.countdown_pause_time) * m);
+				return "Countdown paused: " + formatContestTime(-parseTime(this.info.countdown_pause_time) * m, true);
 		}
 
 		var d = new Date(this.info.start_time);
 
 		var time = (Date.now() - d.getTime()) * m - this.getTimeDelta();
 		if (time < 0)
-			return "Countdown: " + formatContestTime(-time);
+			return "Countdown: " + formatContestTime(time);
 		if (time > parseTime(this.info.duration))
 			return "Contest is over";
 		

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -203,44 +203,40 @@ function formatTime(time2) {
 	return sb.join("");
 }
 
-function formatContestTime(time) {
-	if (time == null)
-		return "";
-
-	if (time >= 0 && time < 1000)
-		return "0";
-
+function formatContestTime(time, floor) {
 	var sb = [];
-	if (time < 0) {
+	if (time < 0)
 		sb.push("-");
-		time = -time;
-	}
-	time2 = Math.floor(time / 1000);
+	
+	if (floor)
+		ss = Math.abs(Math.floor(time / 1000.0));
+	else
+		ss = Math.abs(Math.ceil(time / 1000.0));
 
-	days = Math.floor(time2 / 86400.0);
-	if (days > 0)
-		sb.push(days + "d ");
+    var days = Math.floor(ss / 86400.0);
 
-	sb.push(Math.floor(time2 / 3600.0) % 24);
+    if (days > 0)
+        sb.push(days + "d ");
 
-	sb.push(':');
-	mins = Math.floor(time2 / 60.0) % 60;
-	if (mins < 10)
-		sb.push('0');
-	sb.push(mins);
+    var hours = Math.floor(ss / 3600.0) % 24;
+    sb.push(hours + ":");
 
-	sb.push(':');
-	secs = time2 % 60;
-	if (secs < 10)
-		sb.push('0');
-	sb.push(secs);
-	return sb.join("");
+    var minutes = Math.floor(ss / 60) % 60;
+    if (minutes < 10)
+        sb.push("0");
+    sb.push(minutes + ":");
+
+    var seconds = ss % 60;
+    if (seconds < 10)
+        sb.push("0");
+    sb.push(seconds);
+    return sb.join("");
 }
 
-function formatTimestamp(time2) {
-	if (time2 == null)
+function formatTimestamp(time) {
+	if (time == null)
 		return "";
-	var d = luxon.DateTime.fromISO(time2);
+	var d = luxon.DateTime.fromISO(time);
 	var now = luxon.DateTime.now();
 	if (d.hasSame(now, 'year') && d.hasSame(now, 'month') && d.hasSame(now, 'day'))
 		return d.toLocaleString(luxon.DateTime.TIME_WITH_SECONDS);


### PR DESCRIPTION
Changes the CDS admin page to use the same formatting of contest time as the rest of the UI (including countdown presentations) so that the time always matches, especially at pauses. This was noticed by Tobi at SWERC where it looked like the admin and live view were 1s different.