### PR TITLE
Handle deletes in new contest filters

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -2,6 +2,7 @@ package org.icpc.tools.contest.model.internal.account;
 
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
+import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IRun;
 
@@ -20,8 +21,12 @@ public class AnalystContest extends PublicContest {
 
 	@Override
 	public void add(IContestObject obj) {
-		IContestObject.ContestType cType = obj.getType();
+		if (obj instanceof IDelete) {
+			addIt(obj);
+			return;
+		}
 
+		IContestObject.ContestType cType = obj.getType();
 		switch (cType) {
 			case RUN: {
 				IRun run = (IRun) obj;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/BalloonContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/BalloonContest.java
@@ -3,6 +3,7 @@ package org.icpc.tools.contest.model.internal.account;
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IContestObject.ContestType;
+import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
@@ -21,6 +22,11 @@ public class BalloonContest extends PublicContest {
 
 	@Override
 	public void add(IContestObject obj) {
+		if (obj instanceof IDelete) {
+			addIt(obj);
+			return;
+		}
+
 		IContestObject.ContestType cType = obj.getType();
 		if (cType == ContestType.JUDGEMENT) {
 			IJudgement j = (IJudgement) obj;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContestObject;
+import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IPerson;
@@ -44,6 +45,20 @@ public class PublicContest extends Contest {
 	@Override
 	public void add(IContestObject obj) {
 		IContestObject.ContestType cType = obj.getType();
+		if (obj instanceof IDelete) {
+			if (cType.equals(IContestObject.ContestType.PROBLEM) && !problems.isEmpty()) {
+				IProblem remove = null;
+				for (IProblem p : problems) {
+					if (p.getId().equals(obj.getId()))
+						remove = p;
+				}
+				if (remove != null)
+					problems.remove(remove);
+				return;
+			}
+			super.add(obj);
+			return;
+		}
 
 		switch (cType) {
 			// all of these are fully public
@@ -71,6 +86,7 @@ public class PublicContest extends Contest {
 					for (IProblem p : problems) {
 						super.add(p);
 					}
+					problems.clear();
 				}
 				return;
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/StaffContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/StaffContest.java
@@ -2,6 +2,7 @@ package org.icpc.tools.contest.model.internal.account;
 
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
+import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
 
@@ -15,6 +16,11 @@ public class StaffContest extends Contest {
 
 	@Override
 	public void add(IContestObject obj) {
+		if (obj instanceof IDelete) {
+			super.add(obj);
+			return;
+		}
+
 		IContestObject.ContestType cType = obj.getType();
 
 		if (cType == IContestObject.ContestType.ACCOUNT) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
@@ -3,6 +3,7 @@ package org.icpc.tools.contest.model.internal.account;
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContestObject;
+import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.ISubmission;
 
@@ -26,6 +27,11 @@ public class TeamContest extends PublicContest {
 
 	@Override
 	public void add(IContestObject obj) {
+		if (obj instanceof IDelete) {
+			addIt(obj);
+			return;
+		}
+
 		IContestObject.ContestType cType = obj.getType();
 
 		switch (cType) {


### PR DESCRIPTION
The new contest filters weren't handling deletes correctly and causing NPEs. Deletions are special objects that can't be cast to a type.

The easy solution is just to pass through all delete events, since deleting objects that don't exist is ignored. One special case, the public contest needs to remove deleted problems from its pre-contest cache.