### PR TITLE
Use image sizes in file reference names

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -332,6 +332,7 @@ public class DiskContestSource extends ContestSource {
 		String name = null;
 		String ext = null;
 		if (fileRef != null) {
+			// use existing filename if there is one
 			if (fileRef.filename != null) {
 				int ind = fileRef.filename.lastIndexOf(".");
 				if (ind > 0) {
@@ -340,6 +341,13 @@ public class DiskContestSource extends ContestSource {
 						ext = fileRef.filename.substring(ind + 1);
 				} else
 					name = fileRef.filename;
+			} else {
+				// otherwise, add size if is exists
+				if (fileRef.width > 0) {
+					name = pattern.name + fileRef.width;
+					if (fileRef.height > 0)
+						name += "x" + fileRef.height;
+				}
 			}
 			if (ext == null && fileRef.mime != null)
 				ext = getExtension(fileRef.mime);


### PR DESCRIPTION
If the provider has a filename, the tools attempt to use it locally. Otherwise, we are just using the property name, e.g. logo.png, logo2.png.
This switches it to append the image size if it exists, e.g. logo56x56.png, logo160x160.png.