### PR TITLE
Further simplify contest object output

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
@@ -4,7 +4,6 @@ import java.io.PrintWriter;
 import java.text.NumberFormat;
 import java.util.Locale;
 
-import org.icpc.tools.contest.model.internal.FileReferenceList;
 import org.icpc.tools.contest.model.internal.NetworkUtil;
 
 public class JSONEncoder {
@@ -211,42 +210,15 @@ public class JSONEncoder {
 		pw.write("\"" + name + "\":" + value);
 	}
 
-	public void encode(String name, FileReferenceList refList, boolean force) {
-		if (!force && (refList == null || refList.isEmpty()))
-			return;
-
-		if (!first)
-			pw.write(",");
-		else
-			first = false;
-		if (refList == null)
-			pw.write("\"" + name + "\":[]");
-		else
-			pw.write("\"" + name + "\":" + refList.getJSON());
-	}
-
 	public static void setThreadHost(String host) {
 		local.set(host);
 	}
 
-	public void encodeSubs(String name, FileReferenceList refList, boolean force) {
-		if (!force && (refList == null || refList.isEmpty()))
-			return;
-
-		if (!first)
-			pw.write(",");
-		else
-			first = false;
-		if (refList == null)
-			pw.write("\"" + name + "\":[]");
-		else {
-			String s = refList.getJSON();
-			String host = local.get();
-			if (host == null)
-				host = DEFAULT_HOST;
-			s = s.replace("<host>", host);
-			pw.write("\"" + name + "\":" + s);
-		}
+	public String replace(String s) {
+		String host = local.get();
+		if (host == null)
+			host = DEFAULT_HOST;
+		return s.replace("<host>", host);
 	}
 
 	public void encodeValue(int value) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Account.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Account.java
@@ -105,18 +105,12 @@ public class Account extends ContestObject implements IAccount {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (username != null)
-			props.addString(USERNAME, username);
-		if (password != null)
-			props.addString(PASSWORD, password);
-		if (type != null)
-			props.addLiteralString(TYPE, type);
-		if (ip != null)
-			props.addLiteralString(IP, ip);
-		if (teamId != null)
-			props.addLiteralString(TEAM_ID, teamId);
-		if (personId != null)
-			props.addLiteralString(PERSON_ID, personId);
+		props.addString(USERNAME, username);
+		props.addString(PASSWORD, password);
+		props.addLiteralString(TYPE, type);
+		props.addLiteralString(IP, ip);
+		props.addLiteralString(TEAM_ID, teamId);
+		props.addLiteralString(PERSON_ID, personId);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
@@ -150,17 +150,11 @@ public class Award extends ContestObject implements IAward {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (teamIds != null) {
-			if (teamIds.length == 0)
-				props.add(TEAM_IDS, "[]");
-			else
-				props.add(TEAM_IDS, "[\"" + String.join("\",\"", teamIds) + "\"]");
-		}
+		props.addArray(TEAM_IDS, teamIds);
 		props.addString(CITATION, citation);
 		if (mode != null && mode != DisplayMode.DETAIL)
 			props.addLiteralString(DISPLAY_MODE, mode.name().toLowerCase());
-		if (parameter != null)
-			props.addLiteralString(PARAMETER, parameter);
+		props.addLiteralString(PARAMETER, parameter);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Commentary.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Commentary.java
@@ -73,18 +73,8 @@ public class Commentary extends TimedEvent implements ICommentary {
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
 		props.addString(MESSAGE, message);
-		if (teamIds != null) {
-			if (teamIds.length == 0)
-				props.add(TEAM_IDS, "[]");
-			else
-				props.add(TEAM_IDS, "[\"" + String.join("\",\"", teamIds) + "\"]");
-		}
-		if (problemIds != null) {
-			if (problemIds.length == 0)
-				props.add(PROBLEM_IDS, "[]");
-			else
-				props.add(PROBLEM_IDS, "[\"" + String.join("\",\"", problemIds) + "\"]");
-		}
+		props.addArray(TEAM_IDS, teamIds);
+		props.addArray(PROBLEM_IDS, problemIds);
 		super.getProperties(props);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
@@ -93,16 +93,13 @@ public class FileReferenceList implements Iterable<FileReference> {
 		return hrefs;
 	}
 
-	public String getJSON() {
-		StringBuilder sb = new StringBuilder();
-		for (FileReference ref : refs) {
-			if (ref != null) {
-				if (sb.length() != 0)
-					sb.append(",");
-				sb.append(ref.getJSON());
-			}
+	public String[] getRefs() {
+		int size = refs.size();
+		String[] s = new String[size];
+		for (int i = 0; i < size; i++) {
+			s[i] = refs.get(i).getJSON();
 		}
-		return "[" + sb.toString() + "]";
+		return s;
 	}
 
 	public static Object resolve(String url, FileReferenceList... lists) {
@@ -118,6 +115,6 @@ public class FileReferenceList implements Iterable<FileReference> {
 
 	@Override
 	public String toString() {
-		return getJSON();
+		return "File Reference List [" + refs.size() + "]";
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -133,12 +133,9 @@ public class Group extends ContestObject implements IGroup {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (icpcId != null)
-			props.addLiteralString(ICPC_ID, icpcId);
-		if (name != null)
-			props.addString(NAME, name);
-		if (type != null)
-			props.addLiteralString(TYPE, type);
+		props.addLiteralString(ICPC_ID, icpcId);
+		props.addString(NAME, name);
+		props.addLiteralString(TYPE, type);
 		if (isHidden)
 			props.add(HIDDEN, "true");
 		if (location != null)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -245,8 +245,7 @@ public class Info extends ContestObject implements IInfo {
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
 		props.addString(NAME, name);
-		if (formalName != null)
-			props.addString(FORMAL_NAME, formalName);
+		props.addString(FORMAL_NAME, formalName);
 
 		if (startTime != null)
 			props.addLiteralString(START_TIME, Timestamp.format(startTime.longValue()));

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Language.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Language.java
@@ -121,15 +121,9 @@ public class Language extends ContestObject implements ILanguage {
 		props.addLiteralString(ID, id);
 		props.addString(NAME, name);
 		props.add(ENTRY_POINT_REQUIRED, entryPointRequired);
-		if (entryPointName != null)
-			props.addString(ENTRY_POINT_NAME, entryPointName);
+		props.addString(ENTRY_POINT_NAME, entryPointName);
+		props.addArray(EXTENSIONS, extensions);
 
-		if (extensions != null) {
-			if (extensions.length == 0)
-				props.add(EXTENSIONS, "[]");
-			else
-				props.add(EXTENSIONS, "[\"" + String.join("\",\"", extensions) + "\"]");
-		}
 		if (compiler != null)
 			props.add(COMPILER, compiler.getJSON());
 		if (runner != null)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -191,20 +191,13 @@ public class Organization extends ContestObject implements IOrganization {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (icpcId != null)
-			props.addLiteralString(ICPC_ID, icpcId);
-		if (name != null)
-			props.addString(NAME, name);
-		if (formalName != null)
-			props.addString(FORMAL_NAME, formalName);
-		if (country != null)
-			props.addString(COUNTRY, country);
-		if (countryFlag != null)
-			props.addFileRef(COUNTRY_FLAG, countryFlag);
-		if (url != null)
-			props.addString(URL, url);
-		if (hashtag != null)
-			props.addString(HASHTAG, hashtag);
+		props.addLiteralString(ICPC_ID, icpcId);
+		props.addString(NAME, name);
+		props.addString(FORMAL_NAME, formalName);
+		props.addString(COUNTRY, country);
+		props.addFileRef(COUNTRY_FLAG, countryFlag);
+		props.addString(URL, url);
+		props.addString(HASHTAG, hashtag);
 		if (location != null)
 			props.add(LOCATION, location.getJSON());
 		props.addFileRef(LOGO, logo);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -309,18 +309,12 @@ public class Person extends ContestObject implements IPerson {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (icpcId != null)
-			props.addLiteralString(ICPC_ID, icpcId);
-		if (firstName != null)
-			props.addString(FIRST_NAME, firstName);
-		if (lastName != null)
-			props.addString(LAST_NAME, lastName);
-		if (name != null)
-			props.addString(NAME, name);
-		if (title != null)
-			props.addLiteralString(TITLE, title);
-		if (email != null)
-			props.addString(EMAIL, email);
+		props.addLiteralString(ICPC_ID, icpcId);
+		props.addString(FIRST_NAME, firstName);
+		props.addString(LAST_NAME, lastName);
+		props.addString(NAME, name);
+		props.addLiteralString(TITLE, title);
+		props.addString(EMAIL, email);
 		props.addLiteralString(SEX, sex);
 		props.addLiteralString(TEAM_ID, teamId);
 		props.addLiteralString(ROLE, role);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -246,18 +246,13 @@ public class Problem extends ContestObject implements IProblem {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (label != null)
-			props.addString(LABEL, label);
-		if (name != null)
-			props.addString(NAME, name);
-		if (uuid != null)
-			props.addString(UUID, uuid);
+		props.addString(LABEL, label);
+		props.addString(NAME, name);
+		props.addString(UUID, uuid);
 		if (ordinal != Integer.MIN_VALUE)
 			props.addInt(ORDINAL, ordinal);
-		if (color != null)
-			props.addString(COLOR, color);
-		if (rgb != null)
-			props.addLiteralString(RGB, rgb);
+		props.addString(COLOR, color);
+		props.addLiteralString(RGB, rgb);
 		if (testDataCount != Integer.MIN_VALUE)
 			props.addInt(TEST_DATA_COUNT, testDataCount);
 		if (timeLimit > 0)
@@ -274,10 +269,8 @@ public class Problem extends ContestObject implements IProblem {
 			props.add(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
 
-		if (package_ != null)
-			props.addFileRef(PACKAGE, package_);
-		if (statement != null)
-			props.addFileRef(STATEMENT, statement);
+		props.addFileRef(PACKAGE, package_);
+		props.addFileRef(STATEMENT, statement);
 	}
 
 	private static double round(double d) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/State.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/State.java
@@ -114,7 +114,6 @@ public class State extends ContestObject implements IState {
 
 	@Override
 	protected void getProperties(Properties props) {
-		// super.getPropertiesImpl(props);
 		if (started != null)
 			props.addLiteralString(STARTED, Timestamp.format(started));
 		if (ended != null)
@@ -128,30 +127,6 @@ public class State extends ContestObject implements IState {
 		if (endOfUpdates != null)
 			props.addLiteralString(END_OF_UPDATES, Timestamp.format(endOfUpdates));
 	}
-
-	/*@Override
-	public void writeBody(JSONEncoder je) {
-		if (started != null)
-			je.encodeString(STARTED, Timestamp.format(started));
-		else
-			je.encode(STARTED);
-		if (ended != null)
-			je.encodeString(ENDED, Timestamp.format(ended));
-		else
-			je.encode(ENDED);
-		if (frozen != null)
-			je.encodeString(FROZEN, Timestamp.format(frozen));
-		if (thawed != null)
-			je.encodeString(THAWED, Timestamp.format(thawed));
-		if (finalized != null)
-			je.encodeString(FINALIZED, Timestamp.format(finalized));
-		else
-			je.encode(FINALIZED);
-		if (endOfUpdates != null)
-			je.encodeString(END_OF_UPDATES, Timestamp.format(endOfUpdates));
-		else
-			je.encode(END_OF_UPDATES);
-	}*/
 
 	@Override
 	public boolean isRunning() {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -155,11 +155,9 @@ public class Submission extends TimedEvent implements ISubmission {
 		props.addLiteralString(ID, id);
 		props.addLiteralString(PROBLEM_ID, problemId);
 		props.addLiteralString(TEAM_ID, teamId);
-		if (personId != null)
-			props.addLiteralString(PERSON_ID, personId);
+		props.addLiteralString(PERSON_ID, personId);
 		props.addLiteralString(LANGUAGE_ID, languageId);
-		if (entryPoint != null)
-			props.addLiteralString(ENTRY_POINT, entryPoint);
+		props.addLiteralString(ENTRY_POINT, entryPoint);
 		props.addFileRef(FILES, files);
 		props.addFileRef(REACTION, reaction);
 		super.getProperties(props);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -393,32 +393,19 @@ public class Team extends ContestObject implements ITeam {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
-		if (name != null)
-			props.addString(NAME, name);
-		if (displayName != null)
-			props.addString(DISPLAY_NAME, displayName);
-		if (icpcId != null)
-			props.addLiteralString(ICPC_ID, icpcId);
-		if (groupIds != null)
-			props.add(GROUP_IDS, "[\"" + String.join("\",\"", groupIds) + "\"]");
-		if (organizationId != null)
-			props.addLiteralString(ORGANIZATION_ID, organizationId);
-		if (photo != null)
-			props.addFileRef(PHOTO, photo);
-		if (video != null)
-			props.addFileRef(VIDEO, video);
-		if (backup != null)
-			props.addFileRef(BACKUP, backup);
-		if (keylog != null)
-			props.addFileRef(KEY_LOG, keylog);
-		if (tooldata != null)
-			props.addFileRef(TOOL_DATA, tooldata);
-		if (desktop != null)
-			props.addFileRefSubs(DESKTOP, desktop);
-		if (webcam != null)
-			props.addFileRefSubs(WEBCAM, webcam);
-		if (audio != null)
-			props.addFileRefSubs(AUDIO, audio);
+		props.addString(NAME, name);
+		props.addString(DISPLAY_NAME, displayName);
+		props.addLiteralString(ICPC_ID, icpcId);
+		props.addArray(GROUP_IDS, groupIds);
+		props.addLiteralString(ORGANIZATION_ID, organizationId);
+		props.addFileRef(PHOTO, photo);
+		props.addFileRef(VIDEO, video);
+		props.addFileRef(BACKUP, backup);
+		props.addFileRef(KEY_LOG, keylog);
+		props.addFileRef(TOOL_DATA, tooldata);
+		props.addFileRefSubs(DESKTOP, desktop);
+		props.addFileRefSubs(WEBCAM, webcam);
+		props.addFileRefSubs(AUDIO, audio);
 		if (!Double.isNaN(x) || !Double.isNaN(y) || !Double.isNaN(rotation)) {
 			List<String> attrs = new ArrayList<>(3);
 			if (!Double.isNaN(x))
@@ -430,7 +417,7 @@ public class Team extends ContestObject implements ITeam {
 			props.add(LOCATION, "{" + String.join(",", attrs) + "}");
 		}
 		if (isHidden)
-			props.add(HIDDEN, true);
+			props.add(HIDDEN, "true");
 	}
 
 	private static double round(double d) {


### PR DESCRIPTION
Adds helper addArray() method to simplify output of string (typically id) arrays.
Simplifies contest objects by automatically not outputting null values.
Cleans up JSONEncoder so that it doesn't know about FileReferences.