### PR TITLE
Access to event feed cache

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -150,6 +150,10 @@ public class RESTContestSource extends DiskContestSource {
 		Trace.trace(Trace.INFO, "  Base URL: " + baseUrl);
 	}
 
+	public File getFeedCache() {
+		return feedCacheFile;
+	}
+
 	public static RESTContestSource ensureContestAPI(ContestSource source) {
 		if (source == null || !(source instanceof RESTContestSource)) {
 			Trace.trace(Trace.ERROR, "Source argument must be a Contest API");


### PR DESCRIPTION
At past contests we've had cases where we needed to look at the event feed/cache coming from the CCS, and to do that we had to log into the CDS and find the cache file. This change adds an admin-only endpoint <contest>/log so you can access the cache from anywhere. It isn't exposed through the UI for now, will try it out at NAC before deciding how to expose (likely on the admin page).