### PR TITLE
Remove --fps and add Ctrl-D

### DIFF
--- a/PresContest/README.md
+++ b/PresContest/README.md
@@ -107,7 +107,8 @@ The final parameter must be a "--p" option followed by a set of presentation nam
 separated by spaces; for example, "2 4 clock" (which requests a presentation sequence
 consisting of presentation number 2, then number 4, then the presentation named "clock").
  
-To terminate a running presentation, press Ctrl-Q.
+To terminate a running presentation, press Ctrl-Q. To see debug information including the
+the current presentation and frame rate, use Ctrl-D.
 
 #### Admin-Control Mode
 
@@ -203,11 +204,6 @@ displays. The format of the parameter is "position @ width x height", where widt
 height are the number of displays horizontally and vertically, and position starts at
 1 in the top left and is incremented horizontally. For example, use \"2@3x2\" to
 indicate this client is position 2 (top middle) in a 3x2 grid.
-
-```
---fps
-```
-Shows the frame rate on screen.
 
 ```
 --light

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -37,8 +37,6 @@ public class ClientLauncher {
 		System.out.println("     --multi-display p@wxh");
 		System.out.println("         Stretch the presentation across multiple clients. Use \"2@3x2\"");
 		System.out.println("         to indicate this client is position 2 (top middle) in a 3x2 grid");
-		System.out.println("     --fps");
-		System.out.println("         Show the frame rate on screen");
 		System.out.println("     --light");
 		System.out.println("         Use light mode");
 		System.out.println("     --help");
@@ -54,7 +52,6 @@ public class ClientLauncher {
 		String[] nameStr = new String[1];
 		String[] displayStr = new String[2];
 		String[] displayName = new String[1];
-		boolean[] showFPS = new boolean[1];
 		boolean[] lightMode = new boolean[1];
 		ContestSource contestSource = ArgumentParser.parse(args, new OptionParser() {
 			@Override
@@ -70,9 +67,6 @@ public class ClientLauncher {
 				} else if ("--multi-display".equals(option)) {
 					ArgumentParser.expectOptions(option, options, "p@wxh:string");
 					displayStr[1] = (String) options.get(0);
-					return true;
-				} else if ("--fps".equals(option)) {
-					showFPS[0] = true;
 					return true;
 				} else if ("--light".equals(option)) {
 					lightMode[0] = true;
@@ -117,7 +111,7 @@ public class ClientLauncher {
 		instance = client;
 
 		// open window
-		createWindow(client, true, showFPS[0]);
+		createWindow(client, true);
 		Trace.trace(Trace.INFO, client + " connecting to " + cdsSource);
 		final PresentationClient client2 = client;
 
@@ -142,7 +136,7 @@ public class ClientLauncher {
 		client.connect(false);
 	}
 
-	protected static void createWindow(final PresentationClient client, final boolean sendthumbnails, boolean showFPS) {
+	protected static void createWindow(final PresentationClient client, final boolean sendthumbnails) {
 		if (client.window != null)
 			return;
 
@@ -155,6 +149,5 @@ public class ClientLauncher {
 					client.writeInfoUpdate(image);
 				}
 			});
-		windowImpl.showFPS(showFPS);
 	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -38,7 +38,6 @@ public class StandaloneLauncher {
 		String[] displayStr = new String[2];
 		String[] displayName = new String[1];
 		String[] accountType = new String[1];
-		boolean[] showFPS = new boolean[1];
 		boolean[] lightMode = new boolean[1];
 		ContestSource source = ArgumentParser.parse(args, new OptionParser() {
 			@Override
@@ -55,9 +54,6 @@ public class StandaloneLauncher {
 				} else if ("--multi-display".equals(option)) {
 					ArgumentParser.expectOptions(option, options, "p@wxh:string");
 					displayStr[1] = (String) options.get(0);
-					return true;
-				} else if ("--fps".equals(option)) {
-					showFPS[0] = true;
 					return true;
 				} else if ("--light".equals(option)) {
 					lightMode[0] = true;
@@ -114,7 +110,7 @@ public class StandaloneLauncher {
 
 		source.outputValidation();
 
-		launch(pres, displayStr, showFPS[0], lightMode[0]);
+		launch(pres, displayStr, lightMode[0]);
 	}
 
 	protected static void showHelp(List<PresentationInfo> presentations) {
@@ -135,8 +131,6 @@ public class StandaloneLauncher {
 		System.out.println("     --multi-display p@wxh");
 		System.out.println("         Stretch the presentation across multiple clients. Use \"2@3x2\"");
 		System.out.println("         to indicate this client is position 2 (top middle) in a 3x2 grid");
-		System.out.println("     --fps");
-		System.out.println("         Show the frame rate on screen");
 		System.out.println("     --help");
 		System.out.println("         Shows this message");
 		System.out.println("     --account <type>");
@@ -291,7 +285,7 @@ public class StandaloneLauncher {
 		return null;
 	}
 
-	protected static void launch(PresentationInfo[] pres, String[] displayStr, boolean showFPS, boolean lightMode) {
+	protected static void launch(PresentationInfo[] pres, String[] displayStr, boolean lightMode) {
 		Trace.trace(Trace.INFO, "Launching presentation");
 		Trace.trace(Trace.INFO, "Source: " + ContestSource.getInstance());
 		Trace.trace(Trace.INFO, "Presentations:");
@@ -320,6 +314,5 @@ public class StandaloneLauncher {
 		if (lightMode)
 			((PresentationWindowImpl) window).setLightMode(true);
 		window.setPresentations(0, presentation, null);
-		((PresentationWindowImpl) window).showFPS(showFPS);
 	}
 }

--- a/PresCore/src/org/icpc/tools/presentation/core/PresentationWindow.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/PresentationWindow.java
@@ -78,6 +78,9 @@ public abstract class PresentationWindow extends Frame implements IPresentationH
 						&& (e.isControlDown() || e.isShiftDown()))
 					System.exit(0);
 
+				if (KeyEvent.VK_D == e.getKeyCode() && (e.isControlDown() || e.isShiftDown()))
+					toggleDebug();
+
 				if (currentPresentation != null)
 					currentPresentation.fireKeyEvent(e, Presentation.KEY_PRESSED);
 			}
@@ -159,4 +162,6 @@ public abstract class PresentationWindow extends Frame implements IPresentationH
 	 * Turn light mode on or off.
 	 */
 	public abstract void setLightMode(boolean light);
+
+	public abstract void toggleDebug();
 }


### PR DESCRIPTION
Remove the --fps command line arg and add a Ctrl-D to toggle debug mode instead, which shows fps, resolution, and presentation plan.

Why this change? Slightly simplifies the command line, provides more info, and (most importantly) can be turned on and off dynamically.

The presentation admin can already see all of this info, so I haven't added any ability to see the client debug state or control it from the admin. When an admin is being used I'm assuming we'll either continue to get the information there, or if we're directly at a machine just toggle debug mode on and off again. If that's not the case we could add this.