### PR TITLE
Simplify keyboard/mouse binding

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -8,11 +8,8 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.Stroke;
-import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
-import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseMotionAdapter;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
@@ -64,25 +61,14 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 		}
 	}
 
-	public TeamDisplayPresentation() {
-		addMouseMotionListener(new MouseMotionAdapter() {
-			@Override
-			public void mouseMoved(MouseEvent e) {
-				touched("mouse");
-			}
-		});
-		addKeyListener(new KeyAdapter() {
-			@Override
-			public void keyPressed(KeyEvent e) {
-				touched("keyboard");
-			}
-		});
-		addMouseListener(new MouseAdapter() {
-			@Override
-			public void mousePressed(MouseEvent e) {
-				touched("mouse");
-			}
-		});
+	@Override
+	protected void mouseEvent(MouseEvent e, int type) {
+		touched("mouse");
+	}
+
+	@Override
+	protected void keyEvent(KeyEvent e, int type) {
+		touched("keyboard");
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
@@ -50,7 +50,8 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 			else
 				page--;
 			setScrollToRow(page * teamsPerScreen);
-		}
+		} else if ('r' == c)
+			setScrollToRow(null);
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
@@ -2,6 +2,7 @@ package org.icpc.tools.presentation.contest.internal.scoreboard;
 
 import java.awt.AlphaComposite;
 import java.awt.Graphics2D;
+import java.awt.event.KeyEvent;
 
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.presentation.contest.internal.Animator;
@@ -34,6 +35,22 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 			return 0;
 
 		return MS_PER_PAGE * getNumPages() + INITIAL_DELAY_MS + FADE_OUT_MS;
+	}
+
+	@Override
+	public void keyEvent(KeyEvent e, int type) {
+		if (type != KeyEvent.KEY_TYPED)
+			return;
+
+		char c = e.getKeyChar();
+		if (Character.isDigit(c)) {
+			int page = Integer.parseInt(c + "");
+			if (page == 0)
+				page = 9;
+			else
+				page--;
+			setScrollToRow(page * teamsPerScreen);
+		}
 	}
 
 	@Override

--- a/PresCore/src/org/icpc/tools/presentation/core/Presentation.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/Presentation.java
@@ -6,31 +6,13 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
-import java.awt.event.MouseMotionListener;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * The abstract presentation (renderer) class. All presentations displayed on-screen subclass this
  * class.
  */
 public abstract class Presentation {
-	protected static final byte MOUSE_ENTERED = 1;
-	protected static final byte MOUSE_EXITED = 2;
-	protected static final byte MOUSE_CLICKED = 3;
-	protected static final byte MOUSE_PRESSED = 4;
-	protected static final byte MOUSE_RELEASED = 5;
-
-	protected static final byte MOUSE_MOTION_MOVED = 1;
-	protected static final byte MOUSE_MOTION_DRAGGED = 2;
-
-	protected static final byte KEY_PRESSED = 1;
-	protected static final byte KEY_RELEASED = 2;
-	protected static final byte KEY_TYPED = 3;
-
 	protected int width;
 	protected int height;
 
@@ -39,10 +21,6 @@ public abstract class Presentation {
 
 	private String previousPresentationId;
 	private String nextPresentationId;
-
-	private List<KeyListener> keyListeners;
-	private List<MouseListener> mouseListeners;
-	private List<MouseMotionListener> mouseMotionListeners;
 
 	private boolean lightMode;
 
@@ -205,104 +183,12 @@ public abstract class Presentation {
 		// do nothing, subclasses will override
 	}
 
-	public void addKeyListener(KeyListener listener) {
-		if (keyListeners == null)
-			keyListeners = new ArrayList<>();
-		if (!keyListeners.contains(listener))
-			keyListeners.add(listener);
+	protected void keyEvent(KeyEvent e, int type) {
+		// do nothing by default
 	}
 
-	public void addMouseListener(MouseListener listener) {
-		if (mouseListeners == null)
-			mouseListeners = new ArrayList<>();
-		if (!mouseListeners.contains(listener))
-			mouseListeners.add(listener);
-	}
-
-	public void addMouseMotionListener(MouseMotionListener listener) {
-		if (mouseMotionListeners == null)
-			mouseMotionListeners = new ArrayList<>();
-		if (!mouseMotionListeners.contains(listener))
-			mouseMotionListeners.add(listener);
-	}
-
-	public void removeKeyListener(KeyListener listener) {
-		if (keyListeners == null)
-			return;
-		keyListeners.remove(listener);
-	}
-
-	public void removeMouseListener(MouseListener listener) {
-		if (mouseListeners == null)
-			return;
-		mouseListeners.remove(listener);
-	}
-
-	public void removeMouseMotionListener(MouseMotionListener listener) {
-		if (mouseMotionListeners == null)
-			return;
-		mouseMotionListeners.remove(listener);
-	}
-
-	protected final void fireMouseEvent(MouseEvent e, byte type) {
-		if (mouseListeners == null)
-			return;
-
-		MouseListener[] list;
-		synchronized (mouseListeners) {
-			list = new MouseListener[mouseListeners.size()];
-			mouseListeners.toArray(list);
-		}
-
-		int size = list.length;
-		for (int i = 0; i < size; i++) {
-			if (type == MOUSE_CLICKED)
-				list[i].mouseClicked(e);
-			else if (type == MOUSE_ENTERED)
-				list[i].mouseEntered(e);
-			else if (type == MOUSE_EXITED)
-				list[i].mouseExited(e);
-		}
-	}
-
-	protected final void fireMouseMotionEvent(MouseEvent e, byte type) {
-		if (mouseMotionListeners == null)
-			return;
-
-		MouseMotionListener[] list;
-		synchronized (mouseMotionListeners) {
-			list = new MouseMotionListener[mouseMotionListeners.size()];
-			mouseMotionListeners.toArray(list);
-		}
-
-		int size = list.length;
-		for (int i = 0; i < size; i++) {
-			if (type == MOUSE_MOTION_MOVED)
-				list[i].mouseMoved(e);
-			else if (type == MOUSE_MOTION_DRAGGED)
-				list[i].mouseDragged(e);
-		}
-	}
-
-	protected final void fireKeyEvent(KeyEvent e, byte type) {
-		if (keyListeners == null)
-			return;
-
-		KeyListener[] list;
-		synchronized (keyListeners) {
-			list = new KeyListener[keyListeners.size()];
-			keyListeners.toArray(list);
-		}
-
-		int size = list.length;
-		for (int i = 0; i < size; i++) {
-			if (type == KEY_PRESSED)
-				list[i].keyPressed(e);
-			else if (type == KEY_RELEASED)
-				list[i].keyReleased(e);
-			else if (type == KEY_TYPED)
-				list[i].keyTyped(e);
-		}
+	protected void mouseEvent(MouseEvent e, int type) {
+		// do nothing by default
 	}
 
 	public interface Job {

--- a/PresCore/src/org/icpc/tools/presentation/core/PresentationWindow.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/PresentationWindow.java
@@ -9,6 +9,8 @@ import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
+import java.awt.event.MouseWheelEvent;
+import java.awt.event.MouseWheelListener;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
 
@@ -31,44 +33,51 @@ public abstract class PresentationWindow extends Frame implements IPresentationH
 			@Override
 			public void mouseClicked(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseEvent(e, Presentation.MOUSE_CLICKED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_CLICKED);
 			}
 
 			@Override
 			public void mouseEntered(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseEvent(e, Presentation.MOUSE_ENTERED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_ENTERED);
 			}
 
 			@Override
 			public void mouseExited(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseEvent(e, Presentation.MOUSE_EXITED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_EXITED);
 			}
 
 			@Override
 			public void mousePressed(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseEvent(e, Presentation.MOUSE_PRESSED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_PRESSED);
 			}
 
 			@Override
 			public void mouseReleased(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseEvent(e, Presentation.MOUSE_RELEASED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_RELEASED);
 			}
 		});
 		addMouseMotionListener(new MouseMotionListener() {
 			@Override
 			public void mouseDragged(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseMotionEvent(e, Presentation.MOUSE_MOTION_DRAGGED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_DRAGGED);
 			}
 
 			@Override
 			public void mouseMoved(MouseEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireMouseMotionEvent(e, Presentation.MOUSE_MOTION_MOVED);
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_MOVED);
+			}
+		});
+		addMouseWheelListener(new MouseWheelListener() {
+			@Override
+			public void mouseWheelMoved(MouseWheelEvent e) {
+				if (currentPresentation != null)
+					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_WHEEL);
 			}
 		});
 		addKeyListener(new KeyListener() {
@@ -82,19 +91,19 @@ public abstract class PresentationWindow extends Frame implements IPresentationH
 					toggleDebug();
 
 				if (currentPresentation != null)
-					currentPresentation.fireKeyEvent(e, Presentation.KEY_PRESSED);
+					currentPresentation.keyEvent(e, KeyEvent.KEY_PRESSED);
 			}
 
 			@Override
 			public void keyReleased(KeyEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireKeyEvent(e, Presentation.KEY_RELEASED);
+					currentPresentation.keyEvent(e, KeyEvent.KEY_RELEASED);
 			}
 
 			@Override
 			public void keyTyped(KeyEvent e) {
 				if (currentPresentation != null)
-					currentPresentation.fireKeyEvent(e, Presentation.KEY_TYPED);
+					currentPresentation.keyEvent(e, KeyEvent.KEY_TYPED);
 			}
 		});
 	}

--- a/PresCore/src/org/icpc/tools/presentation/core/PresentationWindow.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/PresentationWindow.java
@@ -25,61 +25,62 @@ public abstract class PresentationWindow extends Frame implements IPresentationH
 	private static final long serialVersionUID = 1L;
 
 	protected Presentation currentPresentation = null;
+	protected boolean control = true;
 
 	protected PresentationWindow(String title) {
+		this(title, true);
+	}
+
+	protected PresentationWindow(String title, boolean control) {
 		super(title);
 
-		addMouseListener(new MouseListener() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_CLICKED);
-			}
+		if (control)
+			addMouseListener(new MouseListener() {
+				@Override
+				public void mouseClicked(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_CLICKED);
+				}
 
-			@Override
-			public void mouseEntered(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_ENTERED);
-			}
+				@Override
+				public void mouseEntered(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_ENTERED);
+				}
 
-			@Override
-			public void mouseExited(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_EXITED);
-			}
+				@Override
+				public void mouseExited(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_EXITED);
+				}
 
-			@Override
-			public void mousePressed(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_PRESSED);
-			}
+				@Override
+				public void mousePressed(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_PRESSED);
+				}
 
-			@Override
-			public void mouseReleased(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_RELEASED);
-			}
-		});
-		addMouseMotionListener(new MouseMotionListener() {
-			@Override
-			public void mouseDragged(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_DRAGGED);
-			}
+				@Override
+				public void mouseReleased(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_RELEASED);
+				}
+			});
+		if (control)
+			addMouseMotionListener(new MouseMotionListener() {
+				@Override
+				public void mouseDragged(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_DRAGGED);
+				}
 
-			@Override
-			public void mouseMoved(MouseEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_MOVED);
-			}
-		});
-		addMouseWheelListener(new MouseWheelListener() {
-			@Override
-			public void mouseWheelMoved(MouseWheelEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.mouseEvent(e, MouseEvent.MOUSE_WHEEL);
-			}
-		});
+				@Override
+				public void mouseMoved(MouseEvent e) {
+					mouseEvent(e, MouseEvent.MOUSE_MOVED);
+				}
+			});
+		if (control)
+			addMouseWheelListener(new MouseWheelListener() {
+				@Override
+				public void mouseWheelMoved(MouseWheelEvent e) {
+					if (currentPresentation != null)
+						currentPresentation.mouseEvent(e, MouseEvent.MOUSE_WHEEL);
+				}
+			});
 		addKeyListener(new KeyListener() {
 			@Override
 			public void keyPressed(KeyEvent e) {
@@ -90,22 +91,33 @@ public abstract class PresentationWindow extends Frame implements IPresentationH
 				if (KeyEvent.VK_D == e.getKeyCode() && (e.isControlDown() || e.isShiftDown()))
 					toggleDebug();
 
-				if (currentPresentation != null)
-					currentPresentation.keyEvent(e, KeyEvent.KEY_PRESSED);
+				keyEvent(e, KeyEvent.KEY_PRESSED);
 			}
 
 			@Override
 			public void keyReleased(KeyEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.keyEvent(e, KeyEvent.KEY_RELEASED);
+				keyEvent(e, KeyEvent.KEY_RELEASED);
 			}
 
 			@Override
 			public void keyTyped(KeyEvent e) {
-				if (currentPresentation != null)
-					currentPresentation.keyEvent(e, KeyEvent.KEY_TYPED);
+				keyEvent(e, KeyEvent.KEY_TYPED);
 			}
 		});
+	}
+
+	public void setControlable(boolean b) {
+		control = b;
+	}
+
+	protected void keyEvent(KeyEvent e, int type) {
+		if (currentPresentation != null && control)
+			currentPresentation.keyEvent(e, type);
+	}
+
+	protected void mouseEvent(MouseEvent e, int type) {
+		if (currentPresentation != null && control)
+			currentPresentation.mouseEvent(e, type);
 	}
 
 	public static PresentationWindow create(String title, Image iconImage) {

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -243,35 +243,24 @@ public class ResolverUI {
 				processAction(Action.FORWARD);
 			}
 		});
-
-		MouseAdapter nullMouse = new MouseAdapter() {
-			@Override
-			public void mouseClicked(MouseEvent e) {
-				// ignore
-			}
-		};
+		window.setControlable(false);
 
 		if (screen == Screen.TEAM || screen == Screen.SIDE || screen == Screen.ORG) {
 			logoPresentation = new StaticLogoPresentation();
-			logoPresentation.addMouseListener(nullMouse);
 			splashPresentation = logoPresentation;
 
 			if (screen == Screen.SIDE) {
 				teamLogoPresentation = new TeamLogoPresentation();
-				teamLogoPresentation.addMouseListener(nullMouse);
 
 				messagePresentation = new MessagePresentation();
-				messagePresentation.addMouseListener(nullMouse);
 			}
 			if (screen == Screen.ORG) {
 				orgPresentation = new OrgsPresentation();
 				orgPresentation.setContest(contest);
-				orgPresentation.addMouseListener(nullMouse);
 			}
 		} else {
 			splashPresentation = new SplashPresentation();
 			splashPresentation.setContest(contest);
-			splashPresentation.addMouseListener(nullMouse);
 		}
 
 		scoreboardPresentation = new ScoreboardPresentation() {
@@ -292,7 +281,6 @@ public class ResolverUI {
 			scoreboardPresentation.setShowSubmissionInfo(true);
 		scoreboardPresentation.setProperty("clockOff");
 		scoreboardPresentation.setContest(contest);
-		scoreboardPresentation.addMouseListener(nullMouse);
 
 		judgePresentation = new JudgePresentation2() {
 			@Override
@@ -301,7 +289,6 @@ public class ResolverUI {
 				paintHook(g);
 			}
 		};
-		judgePresentation.addMouseListener(nullMouse);
 
 		awardPresentation = new TeamAwardPresentation() {
 			@Override
@@ -312,7 +299,6 @@ public class ResolverUI {
 		};
 		awardPresentation.setSize(window.getSize());
 		awardPresentation.cacheAwards(steps);
-		awardPresentation.addMouseListener(nullMouse);
 		awardPresentation.setShowInfo(showInfo);
 
 		teamListPresentation = new TeamListPresentation() {
@@ -323,7 +309,6 @@ public class ResolverUI {
 			}
 		};
 		teamListPresentation.setSize(window.getSize());
-		teamListPresentation.addMouseListener(nullMouse);
 		teamListPresentation.setContest(contest);
 
 		final float dpi = 96;


### PR DESCRIPTION
Prior to this change you could add a listener to any presentation to register for key or mouse events. However, this was overly complicated and only one presentation (the team client display) actually added a listener - to itself. I'm simplifying this pattern to (only) allow presentations to easily listen to their own key & mouse events.

While I'm at it I added paging support to the scrolling scoreboard presentations. Using keys 1-9 and 0 (for 10) you can select which page of the scoreboard to scroll to. This allows a human user to control the scoreboard, e.g. for streaming while discussing the contest. This is just a teaser; we'll likely want to add more controls to the scoreboard (including a 'reset' option) or other presentations in the future.