### PR TITLE
Assorted minor fixes

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/CDSUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/CDSUtil.java
@@ -280,6 +280,8 @@ public class CDSUtil {
 				for (String f : files) {
 					if (f.startsWith(prefix) && f.endsWith(".zip")) {
 						String version = f.substring(prefix.length(), f.length() - 4);
+						if (version.startsWith("v"))
+							version = version.substring(1);
 						presVersions.add(new Version(version));
 					}
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
@@ -55,7 +55,7 @@ public class Ranking {
 						else if (si.getLastSolutionTime() == sj.getLastSolutionTime()) {
 							String tin = teams[order[i]].getActualDisplayName();
 							String tjn = teams[order[j]].getActualDisplayName();
-							if (collator.compare(tin, tjn) > 0)
+							if (tin != null && tjn != null && collator.compare(tin, tjn) > 0)
 								swap = true;
 						}
 					}

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
@@ -21,6 +21,17 @@ import org.icpc.tools.contest.model.util.ArgumentParser.Source;
 import org.icpc.tools.contest.model.util.Taskbar;
 
 public class Admin {
+	protected static void showHelp() {
+		System.out.println();
+		System.out.println("Usage: presAdmin.bat/sh cdsURL user password [options]");
+		System.out.println();
+		System.out.println("  Options:");
+		System.out.println("     --help");
+		System.out.println("         Shows this message");
+		System.out.println("     --version");
+		System.out.println("         Displays version information");
+	}
+
 	public static void main(String[] args) {
 		Trace.init("ICPC Presentation Admin", "presAdmin", args);
 
@@ -32,16 +43,14 @@ public class Admin {
 
 			@Override
 			public void showHelp() {
-				System.out.println();
-				System.out.println("Usage: presAdmin.bat/sh cdsURL user password [options]");
-				System.out.println();
-				System.out.println("  Options:");
-				System.out.println("     --help");
-				System.out.println("         Shows this message");
-				System.out.println("     --version");
-				System.out.println("         Displays version information");
+				Admin.showHelp();
 			}
 		});
+
+		if (source == null) {
+			showHelp();
+			return;
+		}
 
 		String url = source.src[0];
 


### PR DESCRIPTION
A few minor fixes that I found either at or testing for NAC:

- NPE when ranking if teams are tied and have no name. Unlikely in any real contest, but I hit it in testing.
- Presentation admin fails when there are no args, should output help.
- Older builds of the tools had 'v' in the version string, causes an error if they are on the CDS and we don't strip it from the version.