### PR TITLE
Improve wording when Contest API found

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -106,9 +106,13 @@ public class ContestAPIHelper {
 				String content = getContent(testURL, user, password, 0);
 				Info[] infos = readContests(content, testURL);
 
-				Trace.trace(Trace.USER, "No contest found at the given URL, but I found these instead:");
-				for (Info info : infos)
-					Trace.trace(Trace.USER, "  " + listContest(getChildURL(testURL, info.getId()), info));
+				Trace.trace(Trace.USER, "URL invalid, but Contest API found at: " + testURL);
+				if (infos == null || infos.length == 0)
+					Trace.trace(Trace.USER, "  No contests");
+				else {
+					for (Info info : infos)
+						Trace.trace(Trace.USER, "  " + listContest(getChildURL(testURL, info.getId()), info));
+				}
 
 				break;
 			} catch (Exception e) {


### PR DESCRIPTION
At NAC I started a presentation client with a url like "https://cds", which - as I had literally just 'improved' a couple months ago - told me the URL was wrong and listed the contests it found under https://cds/api/contests. In my head it looked like auto-connection to the current contest wasn't working and I was confused.

Changing the wording from:
  No contest found at the given URL, but I found these instead:
     https://cds/api/contests/dress - Dress rehearsal starting at ...
     https://cds/api/contests/finals - World finals starting at ...

To be a bit more clear and include the Contest API url:
  URL invalid, but Contest API found at: https://cds/api/contests
     https://cds/api/contests/dress - Dress rehearsal starting at ...
     https://cds/api/contests/finals - World finals starting at ...