### PR TITLE
Commentary and message upgrade

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/MessagePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/MessagePresentation.java
@@ -3,12 +3,9 @@ package org.icpc.tools.presentation.contest.internal.presentations;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
-import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
@@ -17,7 +14,7 @@ import org.icpc.tools.presentation.contest.internal.TextHelper;
 public class MessagePresentation extends AbstractICPCPresentation {
 	private Font font;
 	private static String message = null;
-	private static List<String> messageList = null;
+	private TextHelper text;
 	private BufferedImage image;
 
 	@Override
@@ -28,54 +25,13 @@ public class MessagePresentation extends AbstractICPCPresentation {
 		font = ICPCFont.deriveFont(Font.BOLD, height * 36f / 3f / dpi);
 		image = getContest().getBannerImage((int) (width * 0.8), (int) (height * 0.3), true, true);
 
-		messageList = null;
+		text = null;
 	}
 
 	@Override
 	public long getDelayTimeMs() {
 		// paint twice a second, whether we need to or not
 		return 500;
-	}
-
-	protected List<String> wrapText(String s, FontMetrics fm, int w) {
-		List<String> list = new ArrayList<>();
-		if (s == null || s.trim().length() == 0 || w < 10)
-			return list;
-
-		String ss = s;
-		while (fm.stringWidth(ss) > w) {
-			// find last space
-			String t = ss;
-			int ind = -1;
-			do {
-				ind = t.lastIndexOf(" ");
-				if (ind <= 0) {
-					// no space, just cut string wherever it lands and insert "-"
-					ind = t.length() - 1;
-					while (ind > 0 && fm.stringWidth(t.substring(0, ind) + "-") > w) {
-						ind--;
-					}
-					// add dash
-					ss = ss.substring(0, ind) + "-" + ss.substring(ind);
-					ind++;
-				} else {
-					// try cutting at the space and see if it fits. if it doesn't, try the first part of
-					// the string again
-					t = t.substring(0, ind);
-					if (fm.stringWidth(t) > w) {
-						ind = -1;
-					}
-				}
-			} while (ind < 0);
-
-			// add first line into list and keep what's left
-			list.add(ss.substring(0, ind));
-			ss = ss.substring(ind).trim();
-		}
-
-		// add final line and return
-		list.add(ss);
-		return list;
 	}
 
 	@Override
@@ -90,20 +46,22 @@ public class MessagePresentation extends AbstractICPCPresentation {
 		}
 
 		g.setFont(font);
-		FontMetrics fm = g.getFontMetrics();
-		synchronized (this) {
-			if (messageList == null)
-				messageList = wrapText(message, fm, (int) (width * 0.9));
-		}
-
-		int y = (int) ((height - h - 20f) / 2f - (fm.getHeight() + 10) * messageList.size() / 2f) + fm.getAscent();
-
 		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
-		for (String s : messageList) {
-			TextHelper text = new TextHelper(g, s);
-			text.draw((width - text.getWidth()) / 2, y);
-			y += text.getHeight() + 10;
+		TextHelper curText = text;
+		if (curText == null) {
+			curText = new TextHelper(g, false);
+			curText.addICPCString(getContest(), message);
+
+			TextHelper.Layout layout = new TextHelper.Layout();
+			layout.align = TextHelper.Alignment.CENTER;
+			layout.wrapWidth = (int) (width * 0.9);
+			curText.layout(layout);
+			text = curText;
 		}
+
+		int y = (int) ((height - h - text.getHeight()) / 2f) - 10;
+		curText.setGraphics(g);
+		curText.draw((int) (width * 0.05), y);
 	}
 
 	@Override
@@ -114,7 +72,7 @@ public class MessagePresentation extends AbstractICPCPresentation {
 
 		synchronized (this) {
 			message = value;
-			messageList = null;
+			text = null;
 		}
 	}
 }


### PR DESCRIPTION
Upgraded the text helper to support "contest object" items and multiple lines, and put it in use for the commentary and message presentations. This means both presentations can now support the proposed {type:id} format, so far including teams, organizations, problems, and persons. The drawing of each item has been improved (e.g. teams and orgs include logos, persons include photos, problem label is prettier), as well as multi-line layout, improved string splitting (if there's no \n), and support for many layouts (alignment, indentation, etc). Any of these things could probably be useful elsewhere too, we'll figure that out later.

Messages or commentary can now be things like "Has anyone seen {persons:bill_poucher}?\nHe was last seen near {teams:43}, who were working on {problems:D}".