### PR TITLE
Minor fixes

### DIFF
--- a/CDS/src/org/icpc/tools/cds/presentations/WebSocketConfig.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/WebSocketConfig.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.cds.presentations;
 
+import java.security.Principal;
+
 import javax.websocket.HandshakeResponse;
 import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpointConfig;
@@ -16,7 +18,11 @@ public class WebSocketConfig extends ServerEndpointConfig.Configurator {
 
 	@Override
 	public void modifyHandshake(ServerEndpointConfig config, HandshakeRequest request, HandshakeResponse response) {
-		String user = request.getUserPrincipal().getName();
+		Principal principal = request.getUserPrincipal();
+		if (principal == null)
+			return;
+
+		String user = principal.getName();
 		if (config.getUserProperties().containsKey(user))
 			return;
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/CDSUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/CDSUtil.java
@@ -47,7 +47,7 @@ public class CDSUtil {
 			if (version == null)
 				throw new IllegalArgumentException("Version can not be null");
 			if (!version.matches("[0-9]+(\\.[0-9]+)*"))
-				throw new IllegalArgumentException("Invalid version format");
+				throw new IllegalArgumentException("Invalid version format '" + version + "'");
 			this.version = version;
 		}
 


### PR DESCRIPTION
Two minor fixes:
- When checking the CDS for updates, output the version string if it's invalid
- Avoid NPE in web socket if the user isn't logged in