### PR TITLE
Contest API provider and endpoints

### DIFF
--- a/CDS/src/org/icpc/tools/cds/AccessService.java
+++ b/CDS/src/org/icpc/tools/cds/AccessService.java
@@ -3,6 +3,7 @@ package org.icpc.tools.cds;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -56,9 +57,9 @@ public class AccessService {
 		// write endpoints
 		je.writeSeparator();
 		je.openChildArray("endpoints");
-		List<String>[] allKnownProperties = cc.getContestByRole(request).getKnownProperties();
+		Set<String>[] allKnownProperties = cc.getContestByRole(request).getKnownProperties();
 		for (IContestObject.ContestType ct : IContestObject.ContestType.values()) {
-			List<String> properties = allKnownProperties[ct.ordinal()];
+			Set<String> properties = allKnownProperties[ct.ordinal()];
 			if (properties != null) {
 				je.writeSeparator();
 				je.open();

--- a/CDS/src/org/icpc/tools/cds/AccessService.java
+++ b/CDS/src/org/icpc/tools/cds/AccessService.java
@@ -9,6 +9,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.icpc.tools.cds.CDSConfig.Auth;
 import org.icpc.tools.contest.model.IAccount;
+import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 
 /**
@@ -25,6 +26,7 @@ public class AccessService {
 
 		IAccount account = cc.getAccount(request.getRemoteUser());
 
+		// write capabilities
 		if (account != null) {
 			String type = account.getAccountType();
 			if ("team".equals(type)) {
@@ -51,15 +53,23 @@ public class AccessService {
 		else
 			je.encodePrimitive("capabilities", "[\"" + String.join("\",\"", caps) + "\"]");
 
-		/*je.encodePrimitive("endpoints", "x" + contest.getId());
-		
-		{
-			je.open();
-			IContestObject.ContestType ct = null;
-			je.encode("type", IContestObject.getTypeName(ct));
-			je.encodePrimitive("properties", "x");
-			je.close();
-		}*/
+		// write endpoints
+		je.writeSeparator();
+		je.openChildArray("endpoints");
+		List<String>[] allKnownProperties = cc.getContestByRole(request).getKnownProperties();
+		for (IContestObject.ContestType ct : IContestObject.ContestType.values()) {
+			List<String> properties = allKnownProperties[ct.ordinal()];
+			if (properties != null) {
+				je.writeSeparator();
+				je.open();
+				je.encode("type", IContestObject.getTypeName(ct));
+
+				String s = String.join("\",\"", properties);
+				je.encodePrimitive("properties", "[\"" + s + "\"]");
+				je.close();
+			}
+		}
+		je.closeArray();
 
 		je.close();
 	}

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -282,6 +282,9 @@ public class ContestRESTService extends HttpServlet {
 		response.setContentType("application/json");
 		JSONEncoder je = new JSONEncoder(response.getWriter());
 		je.open();
+		je.encode("name", "Contest Data Server");
+		je.encodePrimitive("logo", "[{\"href\":\"/cdsIcon.png\",\"filename\":\"logo.png\","
+				+ "\"mime\":\"image/png\",\"width\":512,\"height\":512}]");
 		je.encode("version", "2021-11");
 		je.encode("version_url", "https://ccs-specs.icpc.io/2021-11/contest_api");
 		je.close();

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
@@ -84,7 +85,7 @@ public class Contest implements IContest {
 
 	// map of known properties for each contest type
 	@SuppressWarnings("unchecked")
-	protected List<String>[] allKnownProperties = new List[ContestType.values().length];
+	protected Set<String>[] allKnownProperties = new Set[ContestType.values().length];
 
 	public Contest() {
 		this(true);
@@ -154,9 +155,9 @@ public class Contest implements IContest {
 
 		// update known properties
 		int ord = obj.getType().ordinal();
-		List<String> knownProps = allKnownProperties[ord];
+		Set<String> knownProps = allKnownProperties[ord];
 		if (knownProps == null) {
-			knownProps = new ArrayList<String>();
+			knownProps = new SimpleSet();
 			allKnownProperties[ord] = knownProps;
 		}
 
@@ -477,7 +478,7 @@ public class Contest implements IContest {
 		}
 	}
 
-	public List<String>[] getKnownProperties() {
+	public Set<String>[] getKnownProperties() {
 		return allKnownProperties;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -8,6 +8,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
@@ -81,6 +82,10 @@ public class Contest implements IContest {
 	private IContestObject lastTimedEvent;
 	private int lastTimedEventIndex;
 
+	// map of known properties for each contest type
+	@SuppressWarnings("unchecked")
+	protected List<String>[] allKnownProperties = new List[ContestType.values().length];
+
 	public Contest() {
 		this(true);
 	}
@@ -146,6 +151,19 @@ public class Contest implements IContest {
 			lastTimedEvent = obj;
 			lastTimedEventIndex = data.size();
 		}
+
+		// update known properties
+		int ord = obj.getType().ordinal();
+		List<String> knownProps = allKnownProperties[ord];
+		if (knownProps == null) {
+			knownProps = new ArrayList<String>();
+			allKnownProperties[ord] = knownProps;
+		}
+
+		Map<String, Object> props = obj.getProperties();
+		for (String name : props.keySet())
+			if (!knownProps.contains(name))
+				knownProps.add(name);
 	}
 
 	private void updateTime(int time) {
@@ -457,6 +475,10 @@ public class Contest implements IContest {
 			data.iterate(this, listener);
 			addListener(listener);
 		}
+	}
+
+	public List<String>[] getKnownProperties() {
+		return allKnownProperties;
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -205,12 +205,14 @@ public abstract class ContestObject implements IContestObject {
 		getProperties(new Properties() {
 			@Override
 			public void addString(String key, String value) {
-				props.put(key, value);
+				if (value != null)
+					props.put(key, value);
 			}
 
 			@Override
 			public void addLiteralString(String key, String value) {
-				props.put(key, value);
+				if (value != null)
+					props.put(key, value);
 			}
 
 			@Override
@@ -225,22 +227,26 @@ public abstract class ContestObject implements IContestObject {
 
 			@Override
 			public void add(String key, Object value) {
-				props.put(key, value);
+				if (value != null)
+					props.put(key, value);
 			}
 
 			@Override
 			public void addFileRef(String key, FileReferenceList value) {
-				props.put(key, value);
+				if (value != null)
+					props.put(key, value);
 			}
 
 			@Override
 			public void addFileRefSubs(String key, FileReferenceList value) {
-				props.put(key, value);
+				if (value != null)
+					props.put(key, value);
 			}
 
 			@Override
 			public void addArray(String key, String[] value) {
-				props.put(key, value);
+				if (value != null)
+					props.put(key, value);
 			}
 		});
 		return props;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/SimpleSet.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/SimpleSet.java
@@ -1,0 +1,112 @@
+package org.icpc.tools.contest.model.internal;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * A simple String set backed by an array, which automatically ignores (doesn't add) null keys.
+ */
+public class SimpleSet implements Set<String> {
+	private static final int INITIAL_SIZE = 8;
+	private static final int GROW = 4;
+	private String[] values = new String[INITIAL_SIZE];
+	private int size = 0;
+
+	@Override
+	public int size() {
+		return size;
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return size == 0;
+	}
+
+	@Override
+	public boolean contains(Object o) {
+		if (o == null)
+			return false;
+
+		for (String v : values)
+			if (o.equals(v))
+				return true;
+
+		return false;
+	}
+
+	@Override
+	public boolean add(String value) {
+		if (value == null)
+			return false;
+
+		int arrSize = values.length;
+		if (size == arrSize) {
+			// time to grow
+			String[] newValues = new String[arrSize + GROW];
+			System.arraycopy(values, 0, newValues, 0, arrSize);
+			values = newValues;
+		}
+		values[size] = value;
+		size++;
+		return true;
+	}
+
+	@Override
+	public boolean remove(Object key) {
+		throw new IllegalArgumentException("Not supported");
+	}
+
+	@Override
+	public void clear() {
+		values = new String[INITIAL_SIZE];
+		size = 0;
+	}
+
+	@Override
+	public Iterator<String> iterator() {
+		return new Iterator<String>() {
+			int count = 0;
+
+			@Override
+			public boolean hasNext() {
+				return count < size - 1;
+			}
+
+			@Override
+			public String next() {
+				return values[count++];
+			}
+		};
+	}
+
+	@Override
+	public Object[] toArray() {
+		throw new IllegalArgumentException("Not supported");
+	}
+
+	@Override
+	public <T> T[] toArray(T[] a) {
+		throw new IllegalArgumentException("Not supported");
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c) {
+		throw new IllegalArgumentException("Not supported");
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends String> c) {
+		throw new IllegalArgumentException("Not supported");
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> c) {
+		throw new IllegalArgumentException("Not supported");
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> c) {
+		throw new IllegalArgumentException("Not supported");
+	}
+}


### PR DESCRIPTION
Finished /api implementation and added endpoints to /access. With this change the CDS is now compliant with the current Contest API spec and will give correct results based on the user's role, with one major caveat: endpoints are calculated by building a list of objects and properties as they are added to the contest for each role. This means that /access is correct by the end of a contest, but during a contest endpoints are missing if we haven't seen them yet (e.g. problems or submissions before the start of a contest) or individual properties might be missing if something hasn't happened yet (e.g. clarifications won't have 'to_team_id' if nobody has replied directly to a team yet).

This is still worth releasing since it as good as we can do until there are CCSs that provide an /access endpoint, and the core mechanism delivered here and AccessService won't need to change. To fix this when connected to a CCS we'll have to call its /access endpoint on startup and inject this info into the properties based on role. When reading from disk we'll have to pre-read the full contest. Once this is done we may not need to check the properties of each individual object added to the contest, but I expect that's still useful to leave in for some backwards compatibility.

`/api` - Added provider name and logo
`/api/<contest>/access` - Added endpoints and properties