### PR TITLE
FIX: encodeValue(string) didn't quote the string

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
@@ -234,7 +234,7 @@ public class JSONEncoder {
 			pw.write(",");
 		else
 			first = false;
-		pw.write(value);
+		pw.write("\"" + escape(value) + "\"");
 	}
 
 	public void encodeNull() {


### PR DESCRIPTION
The JSON messages sent to presenter clients are not correct in the contest.ids field (some values are omitted):

```
{"type":"clients","clients":[
   {"name":"...","uid":"...","width":1920,"height":1080,
   "contest.ids":[TestContest/],
   "version":"2.5.795","client.type":"presentation",
   "displays":[...]}
]}
```
The JSON encoder do not quote the id in the array (note the TestContest/ string).
