### PR TITLE
Fix event feed parsing for new format for contest type.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
@@ -117,6 +117,11 @@ public class NDJSONFeedParser implements Closeable {
 		String type = obj.getString("type");
 		String id = obj.getString("id");
 		Object data = obj.get("data");
+
+		// new event feed format uses contest instead of contests
+		if ("contest".equals(type))
+			type = "contests";
+
 		IContestObject.ContestType cType = IContestObject.getTypeByName(type);
 		if (cType == null) {
 			Trace.trace(Trace.WARNING, "Unrecognized (ignored) type in event feed: " + type);


### PR DESCRIPTION
@deboer-tim the new format broke as found out by @meisterT on the CDS we set up for the Dhaka test. After reproducing it locally it seems to be this issue.