### PR TITLE
Fix event feed parsing for new format for contest type.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
@@ -37,6 +37,10 @@ public interface IContestObject {
 	}
 
 	static ContestType getTypeByName(String typeName) {
+		// new event feed format uses contest instead of contests
+		if (typeName.equals("contest")) {
+			typeName = "contests";
+		}
 		for (int i = 0; i < ContestTypeNames.length; i++) {
 			if (ContestTypeNames[i].equals(typeName))
 				return ContestType.values()[i];

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
@@ -118,10 +118,6 @@ public class NDJSONFeedParser implements Closeable {
 		String id = obj.getString("id");
 		Object data = obj.get("data");
 
-		// new event feed format uses contest instead of contests
-		if ("contest".equals(type))
-			type = "contests";
-
 		IContestObject.ContestType cType = IContestObject.getTypeByName(type);
 		if (cType == null) {
 			Trace.trace(Trace.WARNING, "Unrecognized (ignored) type in event feed: " + type);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedWriter.java
@@ -34,6 +34,10 @@ public class NDJSONFeedWriter {
 		je.open();
 
 		String type = IContestObject.getTypeName(obj.getType());
+		// New feed format uses single contest type
+		if (!isOldFeed && type.equals("contests")) {
+			type = "contest";
+		}
 		je.encode("type", type);
 
 		if (isOldFeed) {


### PR DESCRIPTION
@deboer-tim this seems to be the easiest way to expose `contests` as `contest` in the new feed format AND still have all tools work internally; I moved the check for 'incoming' messages to the generic spot and that seems to work.