### PR TITLE
Hide runs of submissions outside of the contest for analysts.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -5,6 +5,7 @@ import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IRun;
+import org.icpc.tools.contest.model.ISubmission;
 
 /**
  * Filter that adds things analysts can see compared to public:
@@ -32,13 +33,25 @@ public class AnalystContest extends PublicContest {
 				IRun run = (IRun) obj;
 
 				IJudgement j = getJudgementById(run.getJudgementId());
+				if (j == null)
+					return;
+
 				if (isJudgementHidden(j))
 					return;
 
-				// hide runs after freeze
+				ISubmission s = getSubmissionById(j.getSubmissionId());
+				if (s == null)
+					return;
+
+				// hide runs for submissions outside the contest time
+				int time = s.getContestTime();
+				if (time < 0 || time >= getDuration())
+					return;
+
+				// hide runs for submissions after freeze
 				if (getFreezeDuration() != null) {
 					int freezeTime = getDuration() - getFreezeDuration();
-					if (run.getContestTime() >= freezeTime)
+					if (s.getContestTime() >= freezeTime)
 						return;
 				}
 


### PR DESCRIPTION
Also change hiding of runs during freeze to be based on submission time.
And add null check for judgement

@deboer-tim Lidia from Live asked why she got a run without a judgemenet and it turns it she never should've gotten the run because the submission of that judgement was outside of contest time. So I added that check to the filter.

Turned out we didn't return any runs that happened during the freeze, while we should return them if the submission itself was before the freeze, so I also fixed that. Finally there was a possible null pointer exception that is now fixed.