### PR TITLE
CLICS Specs are currently hosted at github.io

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/errorPage.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/errorPage.jsp
@@ -16,7 +16,7 @@
                    <pre><%= HttpHelper.sanitize(pageContext.getErrorData().getThrowable().getMessage()) %></pre>
 
                    <p>Please visit <a href="https://tools.icpc.global" target="_blank">tools.icpc.global</a> for help or go to
-                   <a href="https://ccs-specs.icpc.io" target="_blank">clics.ecs.baylor.edu</a> for more info on the Contest API.</p>
+                   <a href="https://ccs-specs.icpc.io" target="_blank">CLICS spec</a> for more info on the Contest API.</p>
                 </div>
             </div>
         </div>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ references that the feed refers to. If your CCS correctly supports the event fee
 work even if the rest of the API is not implemented. The one exception to this is the CDS' and contest utility support
 for comparing scoreboards - to compare a scoreboard, the CCS must have one, of course!
 
-The CDS also retains support for the deprecated [XML Event Feed](https://clics.ecs.baylor.edu/index.php?title=Event_Feed_2016).
+The CDS also retains support for the deprecated [XML Event Feed](https://clics.ecs.baylor.edu/index.php?title=Event_Feed_2016), [Mirror](https://web.archive.org/web/20160601232618/https://clics.ecs.baylor.edu/index.php/Event_Feed_2016).
 If your CCS supports this feed as specified then the tools should still work with a CDS in the middle, albeit with some missing function.
 
 The most popular CCSs that have been tested and successfully used at multiple contests with the ICPC Tools are listed here:


### PR DESCRIPTION
There are more mentions of the site at baylor, will that server be recovered?