### PR TITLE
Ogg support

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -230,6 +230,7 @@ public class PlaybackContest extends Contest {
 		if (in == null || in.isEmpty())
 			return null;
 
+		String mimeType = VideoAggregator.getMimeType();
 		FileReferenceList list = new FileReferenceList();
 		for (Integer i : in) {
 			FileReference ref = new FileReference();
@@ -237,8 +238,8 @@ public class PlaybackContest extends Contest {
 			if (ConnectionMode.DIRECT.equals(vs.getMode()))
 				ref.href = vs.getURL();
 			else
-				ref.href = "http://<host>/stream/" + i;
-			ref.mime = "application/m2ts";
+				ref.href = "https://<host>/stream/" + i;
+			ref.mime = mimeType;
 			list.add(ref);
 		}
 		return list;

--- a/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
@@ -2,7 +2,6 @@ package org.icpc.tools.cds.video;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
 public abstract class VideoHandler {
 	public interface IStreamListener {
@@ -15,14 +14,25 @@ public abstract class VideoHandler {
 		boolean isDone();
 	}
 
-	protected abstract String getFormat();
+	protected abstract String getFileExtension();
+
+	protected abstract String getMimeType();
+
+	/**
+	 * Return true if the stream is valid for this handler. Return false if it isn't.
+	 *
+	 * @param in
+	 * @return
+	 * @throws IOException
+	 */
+	protected abstract boolean validate(InputStream in) throws IOException;
 
 	/**
 	 * Write header/cached information for the given stream.
 	 *
 	 * @throws IOException
 	 */
-	protected void writeHeader(OutputStream out, Object stream) throws IOException {
+	protected void writeHeader(Object stream, IStreamListener listener) throws IOException {
 		// ignore
 	}
 

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -181,15 +181,15 @@ public class VideoServlet extends HttpServlet {
 			final int stream, boolean channel, boolean trusted) throws IOException {
 
 		response.setHeader("Cache-Control", "no-cache");
-		response.setContentType("application/octet");
+		response.setContentType(VideoAggregator.handler.getMimeType());
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		response.setHeader("X-Accel-Buffering", "no");
 
 		OutputStream out = response.getOutputStream();
-		va.handler.writeHeader(out, stream);
 		final VideoStreamListener listener = new VideoStreamListener(out, trusted);
+		va.writeHeader(stream, listener);
 
-		String format = va.handler.getFormat();
+		String format = VideoAggregator.handler.getFileExtension();
 		response.setHeader("Content-Disposition", "inline; filename=\"" + filename + "." + format + "\"");
 		if (!channel)
 			va.addStreamListener(stream, listener);

--- a/CDS/src/org/icpc/tools/cds/video/containers/FLVHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/FLVHandler.java
@@ -1,10 +1,8 @@
 package org.icpc.tools.cds.video.containers;
 
 import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,17 +12,40 @@ public class FLVHandler extends VideoHandler {
 	private Map<Object, FLVReader> readers = new HashMap<>();
 
 	@Override
-	protected String getFormat() {
+	protected String getFileExtension() {
 		return "flv";
 	}
 
 	@Override
-	protected void writeHeader(OutputStream out, Object stream) throws IOException {
-		FLVWriter.writeHeader(new DataOutputStream(out));
+	protected String getMimeType() {
+		return "video/x-flv";
+	}
+
+	@Override
+	protected boolean validate(InputStream in) throws IOException {
+		// read the first 3 bytes
+		int n = 0;
+		byte[] b = new byte[3];
+		while (n < b.length) {
+			n += in.read(b, n, b.length - n);
+			if (n == -1)
+				throw new IOException("Invalid stream");
+		}
+
+		// confirm FLV header 70.76.86 = FLV
+		if (b[0] != 70 || b[1] != 76 || b[2] != 86)
+			return false;
+		return true;
+	}
+
+	@Override
+	protected void writeHeader(Object stream, IStreamListener listener) throws IOException {
+		// TODO
+		/*FLVWriter.writeHeader(new DataOutputStream(out));
 
 		FLVReader r = readers.get(stream);
 		if (r != null)
-			r.sendCache(out);
+			r.sendCache(out);*/
 	}
 
 	@Override

--- a/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
@@ -14,8 +14,26 @@ public class MPEGTSHandler extends VideoHandler {
 	private static final int PACKET_LEN = 188;
 
 	@Override
-	protected String getFormat() {
+	protected String getFileExtension() {
 		return "m2ts";
+	}
+
+	@Override
+	protected String getMimeType() {
+		return "video/m2ts";
+	}
+
+	@Override
+	protected boolean validate(InputStream in) throws IOException {
+		// read the first byte
+		int b = in.read();
+		if (b == -1)
+			throw new IOException("Invalid stream");
+
+		// confirm mpegg-ts packet 71 = G
+		if (b != 71)
+			return false;
+		return true;
 	}
 
 	@Override

--- a/CDS/src/org/icpc/tools/cds/video/containers/OggHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/OggHandler.java
@@ -1,0 +1,122 @@
+package org.icpc.tools.cds.video.containers;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.icpc.tools.cds.video.VideoHandler;
+
+/**
+ * Ogg container handler.
+ */
+public class OggHandler extends VideoHandler {
+	private Map<Object, List<byte[]>> headers = new HashMap<>();
+
+	@Override
+	protected String getFileExtension() {
+		return "ogg";
+	}
+
+	@Override
+	protected String getMimeType() {
+		return "video/ogg";
+	}
+
+	@Override
+	protected void writeHeader(Object stream, IStreamListener listener) throws IOException {
+		List<byte[]> hdr = headers.get(stream);
+		if (hdr == null)
+			return;
+
+		for (byte[] b : hdr)
+			listener.write(b);
+	}
+
+	@Override
+	protected void clearCache(Object stream) {
+		headers.remove(stream);
+	}
+
+	@Override
+	protected boolean validate(InputStream in) throws IOException {
+		// read the first 4 bytes
+		int n = 0;
+		byte[] b = new byte[4];
+		while (n < b.length) {
+			n += in.read(b, n, b.length - n);
+			if (n == -1)
+				throw new IOException("Invalid stream");
+		}
+
+		// confirm ogg packet 79.103.103.83 = OggS
+		if (b[0] != 79 || b[1] != 103 || b[2] != 103 || b[3] != 83)
+			return false;
+		return true;
+	}
+
+	@Override
+	protected void createReader(InputStream in, Object stream, IStreamListener listener) throws IOException {
+		byte[] b = new byte[27];
+
+		while (!listener.isDone()) {
+			// read the first 27 bytes
+			int n = 0;
+			while (n < b.length) {
+				n += in.read(b, n, b.length - n);
+				if (n == -1)
+					return;
+			}
+
+			// confirm ogg packet 79.103.103.83 = OggS
+			if (b[0] != 79 || b[1] != 103 || b[2] != 103 || b[3] != 83)
+				throw new IOException("Failed checksum");
+
+			// byte 26 is the # of segments. read segment sizes next
+			int numSegments = Byte.toUnsignedInt(b[26]);
+			byte[] bb = new byte[numSegments];
+			n = 0;
+			while (n < numSegments)
+				n += in.read(bb, n, bb.length - n);
+
+			// total segments
+			int segmentLength = 0;
+			for (int i = 0; i < bb.length; i++)
+				segmentLength += Byte.toUnsignedInt(bb[i]);
+
+			// read all segments
+			byte[] d = new byte[segmentLength];
+			n = 0;
+			while (n < segmentLength)
+				n += in.read(d, n, d.length - n);
+
+			// output page
+			listener.write(b);
+			listener.write(bb);
+			listener.write(d);
+
+			// if granule position (bytes 6 - 13) is all 0s, this is a header packet
+			boolean isHeader = true;
+			for (int i = 6; i < 14; i++) {
+				if (Byte.toUnsignedInt(b[i]) != 0)
+					isHeader = false;
+			}
+			if (isHeader) {
+				// save headers for next client
+				byte[] hdr2 = new byte[b.length + bb.length + d.length];
+				System.arraycopy(b, 0, hdr2, 0, b.length);
+				System.arraycopy(bb, 0, hdr2, b.length, bb.length);
+				System.arraycopy(d, 0, hdr2, b.length + bb.length, d.length);
+
+				List<byte[]> hdr = headers.get(stream);
+				if (hdr == null) {
+					hdr = new ArrayList<byte[]>(8);
+					headers.put(stream, hdr);
+				}
+				hdr.add(hdr2);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added Ogg support to CDS:
- Fixed an issue where a different object was being passed to writeHeader() and createReader(), which meant that headers weren't sent for any format.
- Updated video handler, FLV, and MPEG handlers so that we can get the mime type, file extension, and validate a stream. The latter is unused for now, but would allow us to either validate that the CDS/incoming video stream is configured properly, or potentially even auto-detect and support all three formats at once.
- Updated places where the mime type or file extension was hard-coded (playback contest, video servlet).
- Added Ogg handler. Basic for now; can add capability to renumber packets as necessary.
- For now, only one format is active for all streams. MPEG remains the default, Ogg is triggered by setting ICPC_OGG system property to 'true'.