### PR TITLE
Remove after event id

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -146,12 +146,6 @@ public class ContestRESTService extends HttpServlet {
 				ContestFeedService.doStream(request, filter, pw, contest, ind, cc);
 				return;
 			} else if ("scoreboard".equals(segments[1])) {
-				int ind = getAfterEventIndex(request, contest);
-				if (ind == -2) {
-					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid event id");
-					return;
-				}
-				contest = Scoreboard.getScoreboard(contest, ind);
 				cc.incrementScoreboard();
 				response.setContentType("application/json");
 				Scoreboard.writeScoreboard(response.getWriter(), contest);
@@ -161,23 +155,11 @@ public class ContestRESTService extends HttpServlet {
 				AccessService.write(request, response, cc);
 				return;
 			} else if ("projectedScoreboard".equals(segments[1])) {
-				int ind = getAfterEventIndex(request, contest);
-				if (ind == -2) {
-					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid event id");
-					return;
-				}
-				contest = Scoreboard.getScoreboard(contest, ind);
 				cc.incrementScoreboard();
 				response.setContentType("application/json");
 				ProjectionScoreboardService.writeScoreboard(response.getWriter(), contest);
 				return;
 			} else if ("optimisticScoreboard".equals(segments[1])) {
-				int ind = getAfterEventIndex(request, contest);
-				if (ind == -2) {
-					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid event id");
-					return;
-				}
-				contest = Scoreboard.getScoreboard(contest, ind);
 				cc.incrementScoreboard();
 				response.setContentType("application/json");
 				OptimisticScoreboardService.beOptimistic(contest);
@@ -288,10 +270,6 @@ public class ContestRESTService extends HttpServlet {
 		je.encode("version", "2021-11");
 		je.encode("version_url", "https://ccs-specs.icpc.io/2021-11/contest_api");
 		je.close();
-	}
-
-	protected static int getAfterEventIndex(HttpServletRequest request, IContest contest) {
-		return getEventIndexFromParameter(request, contest, "after_event_id");
 	}
 
 	/**

--- a/CDS/src/org/icpc/tools/cds/service/ProjectionScoreboardService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ProjectionScoreboardService.java
@@ -9,7 +9,6 @@ import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IResult;
 import org.icpc.tools.contest.model.IStanding;
 import org.icpc.tools.contest.model.ITeam;
-import org.icpc.tools.contest.model.Scoreboard;
 import org.icpc.tools.contest.model.Status;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 import org.icpc.tools.contest.model.feed.RelativeTime;
@@ -21,16 +20,14 @@ import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.internal.Submission;
 
 public class ProjectionScoreboardService {
-	public static void writeScoreboard(PrintWriter pw, Contest contest2) {
+	public static void writeScoreboard(PrintWriter pw, Contest contest) {
 		// figure out which judgement type is the solved one
 		IJudgementType solvedJT = null;
 
-		for (IJudgementType type : contest2.getJudgementTypes()) {
+		for (IJudgementType type : contest.getJudgementTypes()) {
 			if (type.isSolved())
 				solvedJT = type;
 		}
-
-		Contest contest = Scoreboard.getScoreboard(contest2, contest2.getNumObjects() - 28000);
 
 		ITeam[] teams = contest.getOrderedTeams();
 		int numProblems = contest.getNumProblems();

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -6,32 +6,10 @@ import org.icpc.tools.contest.model.IContest.ScoreboardType;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 import org.icpc.tools.contest.model.feed.RelativeTime;
 import org.icpc.tools.contest.model.feed.Timestamp;
-import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.State;
 
 public class Scoreboard {
-	/**
-	 * Get the contest immediately after the given event id.
-	 */
-	public static Contest getScoreboard(Contest contest, int eventIndex) {
-		// if the index wasn't specified or is past the current event, output the current scoreboard
-		if (eventIndex <= 0 || eventIndex >= contest.getNumObjects())
-			return contest;
-
-		return contest.clone(true, new IContestObjectFilter() {
-			private int count = 1;
-
-			@Override
-			public IContestObject filter(IContestObject obj) {
-				if (count >= eventIndex)
-					return null;
-				count++;
-				return obj;
-			}
-		});
-	}
-
 	private static double round(double d) {
 		return Math.round(d * 100000.0) / 100000.0;
 	}


### PR DESCRIPTION
Remove support for after_event_id, which was removed in the 2022_07 spec and is no longer required. Just removes dead code and makes things a little shorter and easier to read.