### PR TITLE
Revert streams to http

### DIFF
--- a/CDS/WebContent/WEB-INF/web.xml
+++ b/CDS/WebContent/WEB-INF/web.xml
@@ -16,8 +16,20 @@
   </welcome-file-list>
   <security-constraint>
     <web-resource-collection>
-        <web-resource-name>Everything</web-resource-name>
-        <url-pattern>/*</url-pattern>
+        <web-resource-name>Everything but streams</web-resource-name>
+        <url-pattern>/</url-pattern>
+        <url-pattern>/api/*</url-pattern>
+        <url-pattern>/web/*</url-pattern>
+        <url-pattern>/presentation/*</url-pattern>
+        <url-pattern>/contests/*</url-pattern>
+        <url-pattern>/about</url-pattern>
+        <url-pattern>/error</url-pattern>
+        <url-pattern>/login</url-pattern>
+        <url-pattern>/logout</url-pattern>
+        <url-pattern>/search/*</url-pattern>
+        <url-pattern>/focus/*</url-pattern>
+        <url-pattern>/video/*</url-pattern>
+        <url-pattern>/welcome</url-pattern>
     </web-resource-collection>
     <user-data-constraint>
         <transport-guarantee>CONFIDENTIAL</transport-guarantee>


### PR DESCRIPTION
Changes I made in the last year to simplify auth have inadvertently moved video streams to https. We have no reason to believe this would be a problem... but also no proof that it isn't a lot of overhead like the last time we tried this >5 years ago, nor any good way to test before Dhaka. As per decision on sysops call I am reverting streams, hopefully not at the expense of anything else.