### PR TITLE
Reaction support for Ogg

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -230,7 +230,6 @@ public class PlaybackContest extends Contest {
 		if (in == null || in.isEmpty())
 			return null;
 
-		String mimeType = VideoAggregator.getMimeType();
 		FileReferenceList list = new FileReferenceList();
 		for (Integer i : in) {
 			FileReference ref = new FileReference();
@@ -239,7 +238,7 @@ public class PlaybackContest extends Contest {
 				ref.href = vs.getURL();
 			else
 				ref.href = "http://<host>/stream/" + i;
-			ref.mime = mimeType;
+			ref.mime = vs.getMimeType();
 			list.add(ref);
 		}
 		return list;

--- a/CDS/src/org/icpc/tools/cds/video/VideoAggregator.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoAggregator.java
@@ -127,10 +127,6 @@ public class VideoAggregator {
 		return videoStreams;
 	}
 
-	public static String getMimeType() {
-		return handler.getMimeType();
-	}
-
 	public int addReservation(String name, String url, StreamType type, ConnectionMode mode) {
 		return addReservation(name, url, mode, type, null);
 	}
@@ -158,7 +154,7 @@ public class VideoAggregator {
 		return channels[channel].stream;
 	}
 
-	public boolean setChannel(int channel, int stream) {
+	public boolean setChannel(int channel, int stream) throws IOException {
 		if (channel < 0 || channel >= MAX_CHANNELS)
 			return false;
 
@@ -188,7 +184,7 @@ public class VideoAggregator {
 		return true;
 	}
 
-	public void addChannelListener(int channel, VideoStreamListener listener) {
+	public void addChannelListener(int channel, VideoStreamListener listener) throws IOException {
 		if (channel < 0 || channel >= MAX_CHANNELS || listener == null)
 			return;
 
@@ -219,20 +215,6 @@ public class VideoAggregator {
 			return null;
 
 		return videoStreams.get(stream).getType();
-	}
-
-	public void writeHeader(int stream, VideoStreamListener listener) throws IOException {
-		if (stream < 0 || stream >= videoStreams.size())
-			return;
-
-		videoStreams.get(stream).writeHeader(listener);
-	}
-
-	public void addStreamListener(int stream, VideoStreamListener listener) {
-		if (stream < 0 || stream >= videoStreams.size() || listener == null)
-			return;
-
-		videoStreams.get(stream).addListener(listener);
 	}
 
 	public static ConnectionMode getConnectionMode(String s) {

--- a/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
@@ -14,6 +14,16 @@ public abstract class VideoHandler {
 		boolean isDone();
 	}
 
+	/**
+	 * Interface to set and get a stream-specific object, most commonly used to store header
+	 * information.
+	 */
+	public interface IStore {
+		void setObject(Object obj);
+
+		Object getObject();
+	}
+
 	protected abstract String getFileExtension();
 
 	protected abstract String getMimeType();
@@ -32,13 +42,9 @@ public abstract class VideoHandler {
 	 *
 	 * @throws IOException
 	 */
-	protected void writeHeader(Object stream, IStreamListener listener) throws IOException {
-		// ignore
+	protected void writeHeader(IStore store, IStreamListener listener) throws IOException {
+		// default no-op
 	}
 
-	protected void clearCache(Object stream) {
-		// ignore
-	}
-
-	protected abstract void createReader(InputStream in, Object stream, IStreamListener listener) throws IOException;
+	protected abstract void createReader(InputStream in, IStore store, IStreamListener listener) throws IOException;
 }

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -181,18 +181,17 @@ public class VideoServlet extends HttpServlet {
 			final int stream, boolean channel, boolean trusted) throws IOException {
 
 		response.setHeader("Cache-Control", "no-cache");
-		response.setContentType(VideoAggregator.handler.getMimeType());
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		response.setHeader("X-Accel-Buffering", "no");
 
+		VideoStream vs = va.getStream(stream);
+		response.setContentType(vs.getMimeType());
+		response.setHeader("Content-Disposition", "inline; filename=\"" + filename + "." + vs.getFileExtension() + "\"");
+
 		OutputStream out = response.getOutputStream();
 		final VideoStreamListener listener = new VideoStreamListener(out, trusted);
-		va.writeHeader(stream, listener);
-
-		String format = VideoAggregator.handler.getFileExtension();
-		response.setHeader("Content-Disposition", "inline; filename=\"" + filename + "." + format + "\"");
 		if (!channel)
-			va.addStreamListener(stream, listener);
+			vs.addListener(listener);
 		else
 			va.addChannelListener(stream, listener);
 
@@ -201,7 +200,7 @@ public class VideoServlet extends HttpServlet {
 			@Override
 			public void onComplete(AsyncEvent asyncEvent) throws IOException {
 				if (!channel)
-					va.removeStreamListener(stream, listener);
+					vs.removeListener(listener);
 				else
 					va.removeChannelListener(stream, listener);
 			}

--- a/CDS/src/org/icpc/tools/cds/video/containers/FLVHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/FLVHandler.java
@@ -3,14 +3,10 @@ package org.icpc.tools.cds.video.containers;
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.icpc.tools.cds.video.VideoHandler;
 
 public class FLVHandler extends VideoHandler {
-	private Map<Object, FLVReader> readers = new HashMap<>();
-
 	@Override
 	protected String getFileExtension() {
 		return "flv";
@@ -39,7 +35,7 @@ public class FLVHandler extends VideoHandler {
 	}
 
 	@Override
-	protected void writeHeader(Object stream, IStreamListener listener) throws IOException {
+	protected void writeHeader(IStore store, IStreamListener listener) throws IOException {
 		// TODO
 		/*FLVWriter.writeHeader(new DataOutputStream(out));
 
@@ -49,17 +45,12 @@ public class FLVHandler extends VideoHandler {
 	}
 
 	@Override
-	protected void clearCache(Object stream) {
-		readers.remove(stream);
-	}
-
-	@Override
-	protected void createReader(InputStream in, Object stream, IStreamListener listener) throws IOException {
+	protected void createReader(InputStream in, IStore store, IStreamListener listener) throws IOException {
 		final DataInputStream din = new DataInputStream(in);
-		FLVReader r = readers.get(stream);
+		FLVReader r = (FLVReader) store.getObject();
 		if (r == null) {
 			r = new FLVReader();
-			readers.put(stream, r);
+			store.setObject(r);
 		}
 
 		r.read(din, listener);

--- a/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
@@ -37,7 +37,7 @@ public class MPEGTSHandler extends VideoHandler {
 	}
 
 	@Override
-	protected void createReader(InputStream in, Object stream, IStreamListener listener) throws IOException {
+	protected void createReader(InputStream in, IStore stream, IStreamListener listener) throws IOException {
 		byte[] b = new byte[PACKET_LEN * 500]; // a little over 90K
 		int offset = 0;
 		int len = 0;

--- a/CDS/src/org/icpc/tools/cds/video/containers/OggHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/OggHandler.java
@@ -3,9 +3,7 @@ package org.icpc.tools.cds.video.containers;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.icpc.tools.cds.video.VideoHandler;
 
@@ -13,8 +11,6 @@ import org.icpc.tools.cds.video.VideoHandler;
  * Ogg container handler.
  */
 public class OggHandler extends VideoHandler {
-	private Map<Object, List<byte[]>> headers = new HashMap<>();
-
 	@Override
 	protected String getFileExtension() {
 		return "ogg";
@@ -26,18 +22,14 @@ public class OggHandler extends VideoHandler {
 	}
 
 	@Override
-	protected void writeHeader(Object stream, IStreamListener listener) throws IOException {
-		List<byte[]> hdr = headers.get(stream);
+	protected void writeHeader(IStore store, IStreamListener listener) throws IOException {
+		@SuppressWarnings("unchecked")
+		List<byte[]> hdr = (List<byte[]>) store.getObject();
 		if (hdr == null)
 			return;
 
 		for (byte[] b : hdr)
 			listener.write(b);
-	}
-
-	@Override
-	protected void clearCache(Object stream) {
-		headers.remove(stream);
 	}
 
 	@Override
@@ -58,7 +50,7 @@ public class OggHandler extends VideoHandler {
 	}
 
 	@Override
-	protected void createReader(InputStream in, Object stream, IStreamListener listener) throws IOException {
+	protected void createReader(InputStream in, IStore store, IStreamListener listener) throws IOException {
 		byte[] b = new byte[27];
 
 		while (!listener.isDone()) {
@@ -110,10 +102,11 @@ public class OggHandler extends VideoHandler {
 				System.arraycopy(bb, 0, hdr2, b.length, bb.length);
 				System.arraycopy(d, 0, hdr2, b.length + bb.length, d.length);
 
-				List<byte[]> hdr = headers.get(stream);
+				@SuppressWarnings("unchecked")
+				List<byte[]> hdr = (List<byte[]>) store.getObject();
 				if (hdr == null) {
 					hdr = new ArrayList<byte[]>(8);
-					headers.put(stream, hdr);
+					store.setObject(hdr);
 				}
 				hdr.add(hdr2);
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -66,6 +66,7 @@ public class DiskContestSource extends ContestSource {
 
 	private static final String[] LOGO_EXTENSIONS = new String[] { "png", "svg", "jpg", "jpeg" };
 	private static final String[] PHOTO_EXTENSIONS = new String[] { "jpg", "jpeg", "png", "svg" };
+	private static final String[] VIDEO_EXTENSIONS = new String[] { "m2ts", "ogg", "flv", };
 
 	protected File eventFeedFile;
 	private File root;
@@ -619,6 +620,12 @@ public class DiskContestSource extends ContestSource {
 		return ref;
 	}
 
+	/**
+	 * Return mime-type based on filename.
+	 *
+	 * @param name
+	 * @return
+	 */
 	private static String getMimeType(String name) {
 		if (name.endsWith(".zip"))
 			return "application/zip";
@@ -629,7 +636,11 @@ public class DiskContestSource extends ContestSource {
 		else if (name.endsWith(".svg"))
 			return "image/svg+xml";
 		else if (name.endsWith(".m2ts"))
-			return "video/MP2T";
+			return "video/m2ts";
+		else if (name.endsWith(".ogg"))
+			return "video/ogg";
+		else if (name.endsWith(".flv"))
+			return "video/x-flv";
 		else if (name.endsWith(".txt"))
 			return "text/plain";
 		else if (name.endsWith(".log"))
@@ -637,6 +648,12 @@ public class DiskContestSource extends ContestSource {
 		return null;
 	}
 
+	/**
+	 * Return filename based on mime-type.
+	 *
+	 * @param mimeType
+	 * @return
+	 */
 	private static String getExtension(String mimeType) {
 		if (mimeType == null)
 			return null;
@@ -649,8 +666,12 @@ public class DiskContestSource extends ContestSource {
 			return "jpg";
 		else if (mimeType.equals("image/svg+xml"))
 			return "svg";
-		else if (mimeType.equals("video/MP2T"))
+		else if (mimeType.equals("video/MP2T") || mimeType.equals("video/m2ts"))
 			return "m2ts";
+		else if (mimeType.equals("video/ogg"))
+			return "ogg";
+		else if (mimeType.equals("video/x-flv"))
+			return "flv";
 		else if (mimeType.equals("text/plain"))
 			return "txt";
 		return null;
@@ -827,7 +848,7 @@ public class DiskContestSource extends ContestSource {
 			if (PHOTO.equals(property))
 				return new FilePattern(type, id, property, PHOTO_EXTENSIONS);
 			if (VIDEO.equals(property))
-				return new FilePattern(type, id, property, "m2ts");
+				return new FilePattern(type, id, property, VIDEO_EXTENSIONS);
 			if (BACKUP.equals(property))
 				return new FilePattern(type, id, property, "zip");
 			if (KEY_LOG.equals(property))
@@ -846,7 +867,7 @@ public class DiskContestSource extends ContestSource {
 			if (FILES.equals(property))
 				return new FilePattern(type, id, property, "zip");
 			if (REACTION.equals(property))
-				return new FilePattern(type, id, property, "m2ts");
+				return new FilePattern(type, id, property, VIDEO_EXTENSIONS);
 		} else if (type == ContestType.GROUP) {
 			if (LOGO.equals(property))
 				return new FilePattern(type, id, property, LOGO_EXTENSIONS);


### PR DESCRIPTION
When I tested Ogg video support I forgot to test reaction videos. Doh! It had a hard-coded MPEG extension, filename, & mime type. This PR:
- Adds support to the ReactionVideoRecorder for recording reactions using the default video handler.
- Adds DiskContestSource support (for reloading after restart or on secondary CDSs) for loading reaction videos in any of the three formats.

While I was at it I did my typical thing and made a number of other improvements:
- Moved outputting the video header (applicable for OGG/FLV, not MPEG-TS) to when a listener is added, so that it doesn't need to be called from each client (e.g. didn't need to be added to the reaction video recorder in this case).
- Video handlers with headers were storing a map from video stream to header info. i switched this around via the IStore interface so that the handlers store the object directly on the stream. No map, and no potential memory leak.
- Doing this allowed removing the handler's clearCache() method, this can just be done by the stream clearing the object.
- The VideoStream now validates the stream (when possible) before trying to read it. This should make it much more obvious if you configure OGG but point to MPEG-TS or vice-versa.
- Removed some methods (getMimeType(),writeHeader(), addStreamListener()) from the aggregator since these can be done directly on the stream, and changed VideoServlet to use these instead. This is part of my long term goal to stop having a single global video handler and either auto-detect and use the right handler, or at least allow desktop and webcam to use different formats.