### PR TITLE
Config updates

### DIFF
--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -371,8 +371,6 @@ public class CoachView extends Panel {
 		IOrganization org = contest.getOrganizationById(team.getOrganizationId());
 		if (org != null) {
 			int BORDER = 15;
-			if (logoImg != null)
-				g.drawImage(logoImg, d.width - logoImg.getWidth() - BORDER, BORDER, null);
 
 			y = drawLine(g, y, "Organization", org.getActualFormalName());
 			y = drawLine(g, y, null, "(" + org.getName() + ")");
@@ -382,7 +380,10 @@ public class CoachView extends Panel {
 			if (country != null)
 				y = drawLine(g, y, "Country", country);
 			y = drawLine(g, y, "URL", org.getURL());
-			y = drawLine(g, y, "Hashtag", org.getHashtag());
+			y = drawLine(g, y, "Hashtag", org.getTwitterHashtag());
+
+			if (logoImg != null)
+				g.drawImage(logoImg, d.width - logoImg.getWidth() - BORDER, BORDER, null);
 		}
 
 		IPerson[] persons = contest.getPersonsByTeamId(team.getId());

--- a/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
@@ -74,11 +74,18 @@ public interface IOrganization extends IContestObject {
 	String getURL();
 
 	/**
-	 * The hashtag of the organization.
+	 * The twitter hashtag of the organization.
 	 *
 	 * @return the hashtag
 	 */
-	String getHashtag();
+	String getTwitterHashtag();
+
+	/**
+	 * The twitter account of the organization.
+	 *
+	 * @return the account
+	 */
+	String getTwitterAccount();
 
 	/**
 	 * The latitude of the organization.

--- a/ContestModel/src/org/icpc/tools/contest/model/TSVImporter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/TSVImporter.java
@@ -22,7 +22,8 @@ public class TSVImporter {
 	private static final String ORGANIZATION_ID = "organization_id";
 	private static final String FORMAL_NAME = "formal_name";
 	private static final String URL = "url";
-	private static final String HASHTAG = "twitter_hashtag";
+	private static final String TWIT_HASHTAG = "twitter_hashtag";
+	private static final String TWIT_ACCOUNT = "twitter_account";
 	private static final String GROUP_IDS = "group_ids";
 	private static final String COUNTRY = "country";
 	private static final String LOCATION = "location";
@@ -149,13 +150,8 @@ public class TSVImporter {
 					if (st.length > 5)
 						add(org, URL, st[5]);
 					if (st.length > 6)
-						add(org, HASHTAG, st[6]);
+						add(org, TWIT_HASHTAG, st[6]);
 					if (st.length > 8) {
-						if (st.length == 10) {
-							// assume CMS extra column issue, move things for now
-							System.arraycopy(st, 8, st, 7, st.length - 8);
-						}
-
 						JsonObject obj = new JsonObject();
 						if (st[7] != null && !st[7].trim().isEmpty() && !"null".equals(st[7]))
 							obj.props.put("latitude", st[7]);
@@ -164,6 +160,8 @@ public class TSVImporter {
 						if (obj.containsKey("latitude") && obj.containsKey("longitude"))
 							org.add(LOCATION, obj);
 					}
+					if (st.length > 9)
+						add(org, TWIT_ACCOUNT, st[9]);
 
 					contest.add(org);
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -15,6 +15,7 @@ public class Organization extends ContestObject implements IOrganization {
 	private static final String COUNTRY = "country";
 	private static final String URL = "url";
 	private static final String HASHTAG = "twitter_hashtag";
+	private static final String ACCOUNT = "twitter_account";
 	private static final String LOCATION = "location";
 	private static final String LOGO = "logo";
 	private static final String COUNTRY_FLAG = "country_flag";
@@ -25,6 +26,7 @@ public class Organization extends ContestObject implements IOrganization {
 	private String country;
 	private String url;
 	private String hashtag;
+	private String account;
 	private Location location;
 	private FileReferenceList logo;
 	private FileReferenceList countryFlag;
@@ -67,8 +69,13 @@ public class Organization extends ContestObject implements IOrganization {
 	}
 
 	@Override
-	public String getHashtag() {
+	public String getTwitterHashtag() {
 		return hashtag;
+	}
+
+	@Override
+	public String getTwitterAccount() {
+		return account;
 	}
 
 	@Override
@@ -155,6 +162,10 @@ public class Organization extends ContestObject implements IOrganization {
 				hashtag = (String) value;
 				return true;
 			}
+			case ACCOUNT: {
+				account = (String) value;
+				return true;
+			}
 			case LOCATION: {
 				location = new Location(value);
 				return true;
@@ -184,6 +195,7 @@ public class Organization extends ContestObject implements IOrganization {
 		o.countryFlag = countryFlag;
 		o.url = url;
 		o.hashtag = hashtag;
+		o.account = account;
 		o.location = location;
 		return o;
 	}
@@ -198,6 +210,7 @@ public class Organization extends ContestObject implements IOrganization {
 		props.addFileRef(COUNTRY_FLAG, countryFlag);
 		props.addString(URL, url);
 		props.addString(HASHTAG, hashtag);
+		props.addString(ACCOUNT, account);
 		if (location != null)
 			props.add(LOCATION, location.getJSON());
 		props.addFileRef(LOGO, logo);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -322,6 +322,7 @@ public class Person extends ContestObject implements IPerson {
 		p.sex = sex;
 		p.teamId = teamId;
 		p.role = role;
+		p.title = title;
 		return p;
 	}
 
@@ -350,7 +351,7 @@ public class Person extends ContestObject implements IPerson {
 	public List<String> validate(IContest c) {
 		List<String> errors = new ArrayList<>();
 
-		if (c.getTeamById(teamId) == null)
+		if ("contestant".equals(role) && c.getTeamById(teamId) == null)
 			errors.add("Invalid team " + teamId);
 
 		if (getName() == null || getName().isEmpty())

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/GoogleMapsGeocoder.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/GoogleMapsGeocoder.java
@@ -26,6 +26,9 @@ public class GoogleMapsGeocoder {
 		try {
 			String address = org.getFormalName() + " " + org.getCountry();
 			Object[] results = geocodeResultsFor(address);
+			if (results == null)
+				return;
+
 			if (results.length > 1) {
 				System.err
 						.println("Geocode for '" + address + "' returned " + results.length + " results, using first one");

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -109,7 +109,7 @@ public class JsonToTSVConverter {
 					return false;
 				}
 			});
-
+			
 			System.out.println("Loading " + files.length + " institutions");
 			for (File f : files) {
 				readInstitution(f);
@@ -283,7 +283,7 @@ public class JsonToTSVConverter {
 		fw.close();
 	}
 
-	protected static void writeInstitutionsTSV(List<Organization> teams, File folder, boolean two) throws Exception {
+	protected static void writeInstitutionsTSV(List<Organization> orgs, File folder, boolean two) throws Exception {
 		File f = new File(folder, "institutions.tsv");
 		if (two)
 			f = new File(folder, "institutions2.tsv");
@@ -291,50 +291,53 @@ public class JsonToTSVConverter {
 		fw.write("File_Version\t0.5\n");
 		int hashCount = 0;
 		int locCount = 0;
-		for (Organization inst : teams) {
-			fw.write("INST-U-" + inst.getId());
+		for (Organization org : orgs) {
+			fw.write("INST-U-" + org.getId());
 			fw.write("\t");
-			if (inst.getFormalName() != null)
-				fw.write(inst.getFormalName());
+			if (org.getFormalName() != null)
+				fw.write(org.getFormalName());
 			fw.write("\t");
-			if (inst.getName() != null)
-				fw.write(inst.getName());
+			if (org.getName() != null)
+				fw.write(org.getName());
 			fw.write("\t");
-			Team team = getTeamFromOrganization(inst.getId());
+			Team team = getTeamFromOrganization(org.getId());
 			if (team != null && team.getGroupIds() != null && team.getGroupIds().length > 0)
 				fw.write(team.getGroupIds()[0]);
 			else
-				System.err.println("Institution not in a group: " + inst.getFormalName());
+				System.err.println("Institution not in a group: " + org.getFormalName());
 			fw.write("\t");
-			if (inst.getCountry() != null)
-				fw.write(inst.getCountry());
+			if (org.getCountry() != null)
+				fw.write(org.getCountry());
 			else
-				System.err.println("Institution not in a country: " + inst.getFormalName());
+				System.err.println("Institution not in a country: " + org.getFormalName());
 			if (two) {
 				fw.write("\t");
-				if (inst.getURL() != null && !inst.getURL().isEmpty())
-					fw.write(inst.getURL());
+				if (org.getURL() != null && !org.getURL().isEmpty())
+					fw.write(org.getURL());
 				// else
 				// System.err.println("No URL: " + inst.id + " - " + inst.name);
 				fw.write("\t");
-				if (inst.getHashtag() != null && !inst.getHashtag().isEmpty())
-					fw.write(inst.getHashtag());
+				if (org.getTwitterHashtag() != null && !org.getTwitterHashtag().isEmpty())
+					fw.write(org.getTwitterHashtag());
 				else {
 					if (OUTPUT_MISSING_NAMES)
-						System.out.println("No hashtag: " + inst.getId() + " - " + inst.getFormalName());
+						System.out.println("No hashtag: " + org.getId() + " - " + org.getFormalName());
 					hashCount++;
 				}
 				fw.write("\t");
-				if (!Double.isNaN(inst.getLatitude()))
-					fw.write(inst.getLatitude() + "");
+				if (!Double.isNaN(org.getLatitude()))
+					fw.write(org.getLatitude() + "");
 				fw.write("\t");
-				if (!Double.isNaN(inst.getLongitude()))
-					fw.write(inst.getLongitude() + "");
-				if (Double.isNaN(inst.getLatitude()) || Double.isNaN(inst.getLongitude())) {
+				if (!Double.isNaN(org.getLongitude()))
+					fw.write(org.getLongitude() + "");
+				if (Double.isNaN(org.getLatitude()) || Double.isNaN(org.getLongitude())) {
 					if (OUTPUT_MISSING_NAMES)
-						System.out.println("No location: " + inst.getId() + " - " + inst.getFormalName());
+						System.out.println("No location: " + org.getId() + " - " + org.getFormalName());
 					locCount++;
 				}
+				fw.write("\t");
+				if (org.getTwitterAccount() != null && !org.getTwitterAccount().isEmpty())
+					fw.write(org.getTwitterAccount());
 			}
 			fw.write("\n");
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/TSVImporter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/TSVImporter.java
@@ -22,7 +22,8 @@ public class TSVImporter {
 	private static final String ORGANIZATION_ID = "organization_id";
 	private static final String FORMAL_NAME = "formal_name";
 	private static final String URL = "url";
-	private static final String HASHTAG = "twitter_hashtag";
+	private static final String TWIT_HASHTAG = "twitter_hashtag";
+	private static final String TWIT_ACCOUNT = "twitter_account";
 	private static final String GROUP_IDS = "group_ids";
 	private static final String COUNTRY = "country";
 	private static final String LOCATION = "location";
@@ -171,13 +172,8 @@ public class TSVImporter {
 					if (st.length > 5)
 						add(org, URL, st[5]);
 					if (st.length > 6)
-						add(org, HASHTAG, st[6]);
+						add(org, TWIT_HASHTAG, st[6]);
 					if (st.length > 8) {
-						if (st.length == 10) {
-							// assume CMS extra column issue, move things for now
-							System.arraycopy(st, 8, st, 7, st.length - 8);
-						}
-
 						JsonObject obj = new JsonObject();
 						if (st[7] != null && !st[7].trim().isEmpty() && !"null".equals(st[7]))
 							obj.props.put("latitude", st[7]);
@@ -186,6 +182,8 @@ public class TSVImporter {
 						if (obj.containsKey("latitude") && obj.containsKey("longitude"))
 							org.add(LOCATION, obj);
 					}
+					if (st.length > 9)
+						add(org, TWIT_ACCOUNT, st[9]);
 
 					list.add(org);
 				}


### PR DESCRIPTION
Downloaded the latest config from CMS, which required several fixes. Since these touched files where I had already added minor support or fixed bugs while testing it I've grouped them together:
- Fixes to both TSVImporter classes b/c the CMS column reordering is fixed.
- Added new "twitter_account" property to organization and started reading it from institutions2.tsv (it's now a new column).
- Renamed getHashtag() to getTwitterHashtag() so the two Twitter properties are clear and match.
- Fixed coach view org logo so it's always over top of text.
- Fix to geocoder, b/c Nicky didn't test his code on a plane with no internet :) .
- Added support for reading person photos from CMS, cleaning them up, and putting them in the right contest package folders.
- Fixed bug in person where copies wouldn't have the same title. Caused non-existent comparison issues.
- Fixed bug in person validation: only contestants need a team id according to the spec.
- Renamed teams>orgs and inst>org in JsonToTSVConverter for cleanup.