### PR TITLE
CMS config generation fixes

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -321,6 +321,7 @@ public class Person extends ContestObject implements IPerson {
 		p.email = email;
 		p.sex = sex;
 		p.teamId = teamId;
+		p.teamIds = teamIds;
 		p.role = role;
 		p.title = title;
 		return p;
@@ -337,6 +338,7 @@ public class Person extends ContestObject implements IPerson {
 		props.addString(EMAIL, email);
 		props.addLiteralString(SEX, sex);
 		props.addLiteralString(TEAM_ID, teamId);
+		props.addArray(TEAM_IDS, teamIds);
 		props.addLiteralString(ROLE, role);
 		props.addFileRef(PHOTO, photo);
 		props.addFileRefSubs(DESKTOP, desktop);

--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -120,14 +120,14 @@ public class ImagesGenerator {
 				File from = new File(args[0], "images" + File.separator + "logo" + File.separator + t.getId() + ".png");
 				File to = new File(args[0],
 						"images" + File.separator + "logo" + File.separator + t.getOrganizationId() + ".png");
-		
+
 				if (from.exists())
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
-		
+
 				from = new File(args[0], "images" + File.separator + "tile" + File.separator + t.getId() + ".png");
 				to = new File(args[0],
 						"images" + File.separator + "tile" + File.separator + t.getOrganizationId() + ".png");
-		
+
 				if (from.exists())
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
 			}
@@ -551,19 +551,12 @@ public class ImagesGenerator {
 					else
 						ImageIO.write(scImg, "jpg", file);
 					file.setLastModified(mod);
-					if (!file.exists())
-						System.err.println("What??");
 				}
 
-				/*BufferedImage scImg = ImageScaler.scaleImage(img, ICON.width, ICON.height);
-				double aspect = scImg.getWidth() / (double) scImg.getHeight();
-				if (aspect < 1.0 - FUDGE || aspect > 1.0 + FUDGE)
-					writePhotoWithSize(scImg, personFolder, mod);*/
-
-				BufferedImage scImg = ImageScaler.scaleImage(img, TILE.width, TILE.height);
-				double aspect = scImg.getWidth() / (double) scImg.getHeight();
-				if (aspect < 1.0 - FUDGE || aspect > 1.0 + FUDGE)
+				if (img.getWidth() > TILE.width || img.getHeight() > TILE.height) {
+					BufferedImage scImg = ImageScaler.scaleImage(img, TILE.width, TILE.height);
 					writePhotoWithSize(scImg, personFolder, mod);
+				}
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error generating image: " + imgFile.getAbsolutePath(), e);
 			}

--- a/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/cms/JsonToTSVConverter.java
@@ -109,7 +109,7 @@ public class JsonToTSVConverter {
 					return false;
 				}
 			});
-			
+
 			System.out.println("Loading " + files.length + " institutions");
 			for (File f : files) {
 				readInstitution(f);
@@ -184,7 +184,7 @@ public class JsonToTSVConverter {
 			groupList.sort((g1, g2) -> compare(g1.getId(), g2.getId()));
 			teamList.sort((t1, t2) -> compare(t1.getId(), t2.getId()));
 			orgList.sort((i1, i2) -> compare(i1.getId(), i2.getId()));
-			personList.sort((m1, m2) -> compare(m1.getTeamId(), m2.getTeamId()));
+			personList.sort((m1, m2) -> compare(m1.getId(), m2.getId()));
 		} catch (Exception e) {
 			e.printStackTrace();
 		}


### PR DESCRIPTION
- Fix person to output team_ids property.
- Image generation fix for tile (160x160px) images.
- Sort persons.json by id (sorting by team was causing more diffs).
- TSV importer fix for persons with multiple teams.