### PR TITLE
Limit height of message banner

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/MessagePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/MessagePresentation.java
@@ -23,7 +23,7 @@ public class MessagePresentation extends AbstractICPCPresentation {
 
 		final float dpi = 96;
 		font = ICPCFont.deriveFont(Font.BOLD, height * 36f / 3f / dpi);
-		image = getContest().getBannerImage((int) (width * 0.8), (int) (height * 0.3), true, true);
+		image = getContest().getBannerImage((int) (width * 0.8), (int) (height * 0.25), true, true);
 
 		text = null;
 	}


### PR DESCRIPTION
The contest banner for this year is not as wide as previous years, so it takes up too much of the messages presentation. Setting a lower limit on the vertical height so that it doesn't scale as big.