### PR TITLE
Fix auto-update for coach view and balloon util

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
@@ -56,6 +56,7 @@ import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IState;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.ContestSource.ConnectionState;
 import org.icpc.tools.contest.model.feed.ContestSource.ContestSourceListener;
@@ -1071,7 +1072,7 @@ public class BalloonUtility {
 		contestSource.outputValidation();
 		if (contestSource instanceof RESTContestSource) {
 			RESTContestSource restSource = (RESTContestSource) contestSource;
-			if (restSource.isCDS())
+			if (ContestAPIHelper.isCDS())
 				restSource.checkForUpdates("balloonUtil-");
 		}
 

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -58,6 +58,7 @@ import org.icpc.tools.contest.model.IStanding;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.Status;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.util.ArgumentParser;
@@ -940,7 +941,7 @@ public class CoachView extends Panel {
 
 		RESTContestSource restSource = RESTContestSource.ensureContestAPI(contestSource);
 		restSource.outputValidation();
-		if (restSource.isCDS())
+		if (ContestAPIHelper.isCDS())
 			restSource.checkForUpdates("coachview-");
 
 		CoachView cv = new CoachView();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -14,6 +14,8 @@ import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.Info;
 
 public class ContestAPIHelper {
+	protected static boolean isCDS;
+
 	private static String listContest(URL url, Info info) {
 		return url.toExternalForm() + " - " + info.getName() + " starting at "
 				+ ContestUtil.formatStartTime(info.getStartTime());
@@ -135,6 +137,9 @@ public class ContestAPIHelper {
 		}
 
 		int response = conn.getResponseCode();
+
+		if ("CDS".equals(conn.getHeaderField("ICPC-Tools")))
+			isCDS = true;
 
 		if (response == HttpURLConnection.HTTP_UNAUTHORIZED)
 			throw new IllegalArgumentException("Invalid user or password (401)");
@@ -321,5 +326,9 @@ public class ContestAPIHelper {
 			return null;
 		}
 		return previous;
+	}
+
+	public static boolean isCDS() {
+		return isCDS;
 	}
 }


### PR DESCRIPTION
REST source hasn't touched the CDS yet so the flag isn't set. I don't like using ContestAPIHelper directly, but that's the only thing that's pinging the CDS.