### PR TITLE
Avoid downstream effect of "Null file ref"

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
+++ b/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
@@ -73,6 +73,7 @@ public class ReactionVideoRecorder {
 		if (dir == null)
 			return;
 
+		// TODO - wrong folder, need to remove or do deep scan on submissions folder
 		File reactDir = new File(dir, "video" + File.separator + "reactions");
 		if (!reactDir.exists())
 			return;
@@ -124,7 +125,7 @@ public class ReactionVideoRecorder {
 				for (File f : files) {
 					FileReference ref = new FileReference();
 					ref.filename = f.getName();
-					String name = f.getName().substring(0, f.getName().length() - 5);
+					String name = f.getName().substring(0, f.getName().length() - extension.length() - 1);
 					ref.href = "contests/" + cc.getId() + "/submissions/" + submissionId + "/" + name;
 					ref.mime = handler.getMimeType();
 					ref.file = f;
@@ -198,7 +199,7 @@ public class ReactionVideoRecorder {
 
 			VideoStream stream = VideoAggregator.getInstance().getStream(info.stream[0]);
 			FileReference ref = new FileReference();
-			String name = file.getName().substring(0, file.getName().length() - 5);
+			String name = file.getName().substring(0, file.getName().length() - extension.length() - 1);
 			ref.href = "contests/" + cc.getId() + "/submissions/" + submissionId + "/" + name;
 			ref.mime = stream.getMimeType();
 			ref.file = file;
@@ -246,8 +247,9 @@ public class ReactionVideoRecorder {
 							info.tempFile[i].delete();
 
 						if (info.file[i].exists() && info.file[i].length() == 0) {
-							Trace.trace(Trace.WARNING, "No video received for submission. Stream: " + info.stream);
-							info.file[i].delete();
+							Trace.trace(Trace.WARNING, "No video received for submission: " + info.file[i].toString());
+							// TODO - not safe to delete if another CDS has picked it up already
+							// info.file[i].delete();
 						}
 					}
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -613,10 +613,15 @@ public class DiskContestSource extends ContestSource {
 
 	protected FileReference getMetadata(String href, File file) {
 		FileReference ref = getFileRef(file);
-		if (ref == null)
+		if (ref == null) {
 			Trace.trace(Trace.ERROR, "Null file ref! " + href + " - " + file + " - " + file.exists());
-		else
-			ref.href = "contests/" + contestId + "/" + href;
+			ref = getFileRef(file);
+			if (ref == null) {
+				Trace.trace(Trace.ERROR, "Not found second pass");
+				return null;
+			}
+		}
+		ref.href = "contests/" + contestId + "/" + href;
 		return ref;
 	}
 
@@ -827,7 +832,9 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					refList.add(getMetadata(pattern.url + diff, file));
+					FileReference ref = getMetadata(pattern.url + diff, file);
+					if (ref != null)
+						refList.add(ref);
 					// TODO future: url currently would not be able to handle logo2.svg and logo2.png
 				}
 			}


### PR DESCRIPTION
Avoid adding null entries to file references list if the file metadata can't be found. Try twice before doing so. This is a bit of a hack - we know there's a file on disk, but we can't get any details about it. Trying twice will tell us if it's a temporary/timing problem or not, and better to never add null file ref (i.e. miss telling clients about one reaction vs crashing). Also two fixes to reaction video recorder:
- Fix potential problem with file extension length if we use another video container.
- Don't delete 0-byte downloads. This will be more annoying to clients, but avoids adding the file on another CDS and then deleting the underlying file.