### PR TITLE
Avoid printing twice

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
@@ -483,18 +483,14 @@ public class BalloonUtility {
 
 			// print & update flags
 			if (autoPrint && b.getFlags() >= 0)
-				javax.swing.SwingUtilities.invokeLater(() -> {
-					print(b);
-				});
+				print(b);
 
 			bc.updateFlags(new BalloonContest.FlagListener() {
 				@Override
 				public void updatedFlags(Balloon bb) {
 					updateBalloon(bb);
-					if (autoPrint && isRunFromGroup(bb)) {
-						javax.swing.SwingUtilities.invokeLater(() -> {
-							print(bb);
-						});
+					if (autoPrint && !b.isPrinted() && isRunFromGroup(bb)) {
+						print(bb);
 					}
 				}
 			});


### PR DESCRIPTION
Skip using swing thread when calling print, since print() method does it internally. Second auto-print should check if the balloon is already printed