### PR TITLE
Groups don't need external id

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -148,9 +148,6 @@ public class Group extends ContestObject implements IGroup {
 	public List<String> validate(IContest c) {
 		List<String> errors = super.validate(c);
 
-		if (icpcId == null)
-			errors.add("Missing external id");
-
 		if (name == null || name.isEmpty())
 			errors.add("Name missing");
 


### PR DESCRIPTION
Groups don't require an external id, removing invalid validation.