### PR TITLE
Move video streams to HTTPS

### DIFF
--- a/CDS/WebContent/WEB-INF/web.xml
+++ b/CDS/WebContent/WEB-INF/web.xml
@@ -16,20 +16,8 @@
   </welcome-file-list>
   <security-constraint>
     <web-resource-collection>
-        <web-resource-name>Everything but streams</web-resource-name>
-        <url-pattern>/</url-pattern>
-        <url-pattern>/api/*</url-pattern>
-        <url-pattern>/web/*</url-pattern>
-        <url-pattern>/presentation/*</url-pattern>
-        <url-pattern>/contests/*</url-pattern>
-        <url-pattern>/about</url-pattern>
-        <url-pattern>/error</url-pattern>
-        <url-pattern>/login</url-pattern>
-        <url-pattern>/logout</url-pattern>
-        <url-pattern>/search/*</url-pattern>
-        <url-pattern>/focus/*</url-pattern>
-        <url-pattern>/video/*</url-pattern>
-        <url-pattern>/welcome</url-pattern>
+        <web-resource-name>Everything</web-resource-name>
+        <url-pattern>/*</url-pattern>
     </web-resource-collection>
     <user-data-constraint>
         <transport-guarantee>CONFIDENTIAL</transport-guarantee>

--- a/CDS/src/org/icpc/tools/cds/CDSAuth.java
+++ b/CDS/src/org/icpc/tools/cds/CDSAuth.java
@@ -140,6 +140,7 @@ public class CDSAuth implements HttpAuthenticationMechanism {
 		IAccount account = getAccount(request);
 		if (account == null)
 			return false;
-		return IAccount.ANALYST.equals(account.getAccountType());
+		return IAccount.ANALYST.equals(account.getAccountType()) || IAccount.STAFF.equals(account.getAccountType())
+				|| IAccount.ADMIN.equals(account.getAccountType());
 	}
 }

--- a/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
+++ b/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
@@ -16,16 +16,7 @@ public class HttpHelper {
 	private static final String OK_CHARS = new String("[]{},.~`?!@#$^&*()-_=+:|");
 
 	public static void setThreadHost(HttpServletRequest request) {
-		StringBuilder sb = new StringBuilder(request.getServerName());
-		if (true) {
-			int port = request.getLocalPort();
-			if (port > 1000) {
-				int th = port / 1000;
-				port = th * 1000 + 80;
-				sb.append(":" + port);
-			}
-		}
-		JSONEncoder.setThreadHost(sb.toString());
+		JSONEncoder.setThreadHost("https://" + request.getServerName());
 	}
 
 	public static void sendFile(HttpServletRequest request, HttpServletResponse response, File f) throws IOException {

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -237,7 +237,7 @@ public class PlaybackContest extends Contest {
 			if (ConnectionMode.DIRECT.equals(vs.getMode()))
 				ref.href = vs.getURL();
 			else
-				ref.href = "http://<host>/stream/" + i;
+				ref.href = "<host>/stream/" + i;
 			ref.mime = vs.getMimeType();
 			list.add(ref);
 		}

--- a/CDS/src/org/icpc/tools/cds/video/VideoStream.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStream.java
@@ -264,7 +264,7 @@ public class VideoStream implements IStore {
 		// TODO sync lock issue List<VideoStreamListener>
 		synchronized (listeners) {
 			for (VideoStreamListener vsl : listeners) {
-				if (!vsl.isTrusted()) {
+				if (!vsl.isAnalyst()) {
 					removeListener(vsl);
 				}
 			}

--- a/CDS/src/org/icpc/tools/cds/video/VideoStreamListener.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStreamListener.java
@@ -6,12 +6,12 @@ import java.io.OutputStream;
 public class VideoStreamListener {
 	private OutputStream out;
 	private long startTime;
-	private boolean trusted;
+	private boolean analyst;
 	private boolean done;
 
-	public VideoStreamListener(OutputStream out, boolean trusted) {
+	public VideoStreamListener(OutputStream out, boolean analyst) {
 		this.out = out;
-		this.trusted = trusted;
+		this.analyst = analyst;
 		startTime = System.currentTimeMillis();
 	}
 
@@ -23,8 +23,8 @@ public class VideoStreamListener {
 		return done;
 	}
 
-	public boolean isTrusted() {
-		return trusted;
+	public boolean isAnalyst() {
+		return analyst;
 	}
 
 	public void write(byte[] b) throws IOException {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
@@ -17,7 +17,7 @@ public class JSONEncoder {
 	}
 
 	private static final ThreadLocal<String> local = new ThreadLocal<>();
-	private static String DEFAULT_HOST = "cds";
+	private static String DEFAULT_HOST = "http://cds";
 	static {
 		try {
 			DEFAULT_HOST = NetworkUtil.getLocalAddress();


### PR DESCRIPTION
We initially tried HTTPS >10 years ago, and removed it for video when we hit a performance problem that was triggered when live accidentally did a DoS attack. Since then there has been a hesitation to try it again due to lack of a systems test and worry that some clients (e.g. VLC at the time) couldn't handle HTTPS well.

All clients that I've tried now support HTTPS (it's pretty much standard now) and David did some performance tests in Dhaka which confirmed that the overhead for HTTPS is negligible. This change:
- Moves all CDS content to HTTPS (was just missing video streams before).
- Removes the block on HTTPS in video servlet.
- Renames 'trusted' to 'analyst' to match the account type.
- Moved hardcoded 'http' to be part of '<host>' so that the transport, host, and port are all calculated in one place, HTTPHelper (and much simpler anyway).