### PR TITLE
Improve UIDs for CDS clients

### DIFF
--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationWebSocket.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationWebSocket.java
@@ -60,7 +60,8 @@ public class PresentationWebSocket {
 
 		if (PresentationServer.getInstance().doesClientExist(uid)) {
 			try {
-				Trace.trace(Trace.INFO, "Disconnecting client with existing uid " + Integer.toHexString(uid));
+				Trace.trace(Trace.INFO,
+						"Disconnecting, client with uid " + Integer.toHexString(uid) + " already logged in.");
 				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION, "Client is already logged in"));
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error disconnecting websocket with existing uid");

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/ClientsControl.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/ClientsControl.java
@@ -245,11 +245,17 @@ public class ClientsControl extends Canvas {
 
 					if (!found) {
 						clientRects.remove(uid);
-						clientStates.remove(uid);
 
 						ClientInfo ci = clientStates.get(uid);
-						if (ci != null && ci.thumbnail != null)
-							ci.thumbnail.dispose();
+						if (ci != null) {
+							Image img = ci.thumbnail;
+							if (img != null) {
+								ci.thumbnail = null;
+								img.dispose();
+							}
+						}
+
+						clientStates.remove(uid);
 					}
 				}
 			}
@@ -312,6 +318,7 @@ public class ClientsControl extends Canvas {
 		if (ci == null)
 			ci = new ClientInfo();
 
+		System.out.println("state for: " + id);
 		try {
 			synchronized (uiLock) {
 				if (obj.containsKey(WIDTH))

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
@@ -38,7 +38,6 @@ import org.icpc.tools.client.core.BasicClient;
 import org.icpc.tools.client.core.IConnectionListener;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
-import org.icpc.tools.contest.model.internal.NetworkUtil;
 import org.icpc.tools.presentation.core.internal.PresentationInfo;
 import org.icpc.tools.presentation.core.internal.PresentationsParser;
 
@@ -90,9 +89,7 @@ public class View {
 	}
 
 	public View(String url, String user, String password) {
-		String s = user + NetworkUtil.getLocalAddress();
-
-		client = new BasicClient(url, user, password, null, user, s.hashCode(), "admin", "pres-admin") {
+		client = new BasicClient(url, user, password, null, user, "admin", "pres-admin") {
 			/**
 			 * @throws IOException
 			 */

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -105,7 +105,7 @@ public class ClientLauncher {
 			if (member != null) {
 				teamLabel += member;
 			}
-			client = new PresentationClient(cdsSource, teamLabel, teamLabel.hashCode(), "!admin");
+			client = new PresentationClient(cdsSource, teamLabel, "!admin");
 		} else
 			client = new PresentationClient(name, "!admin", cdsSource);
 		instance = client;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/PresentationClient.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/PresentationClient.java
@@ -43,12 +43,12 @@ public class PresentationClient extends BasicClient {
 	protected boolean sendingInfoUpdate;
 	protected boolean sendingInfo;
 
-	protected PresentationClient(RESTContestSource source, String clientId, int uid, String role) {
-		this(source, clientId, uid, role, "presentation");
+	protected PresentationClient(RESTContestSource source, String clientId, String role) {
+		this(source, clientId, role, "presentation");
 	}
 
-	public PresentationClient(RESTContestSource source, String clientId, int uid, String role, String type) {
-		super(source, clientId, uid, role, type);
+	public PresentationClient(RESTContestSource source, String clientId, String role, String type) {
+		super(source, clientId, role, type);
 		executor = new ThreadPoolExecutor(2, 4, 20L, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(5),
 				new ThreadFactory() {
 					@Override
@@ -74,7 +74,7 @@ public class PresentationClient extends BasicClient {
 	}
 
 	public PresentationClient(String clientId, String role, RESTContestSource source, String type) {
-		this(source, clientId, 0, role, type);
+		this(source, clientId, role, type);
 		String s = clientId + NetworkUtil.getLocalAddress();
 		setUID(s.hashCode());
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/PresentationClient.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/PresentationClient.java
@@ -20,7 +20,6 @@ import org.icpc.tools.client.core.IPropertyListener;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
-import org.icpc.tools.contest.model.internal.NetworkUtil;
 import org.icpc.tools.presentation.core.DisplayConfig;
 import org.icpc.tools.presentation.core.IPresentationHandler;
 import org.icpc.tools.presentation.core.Presentation;
@@ -75,8 +74,6 @@ public class PresentationClient extends BasicClient {
 
 	public PresentationClient(String clientId, String role, RESTContestSource source, String type) {
 		this(source, clientId, role, type);
-		String s = clientId + NetworkUtil.getLocalAddress();
-		setUID(s.hashCode());
 	}
 
 	private void init() {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ScalingTestClient.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ScalingTestClient.java
@@ -27,7 +27,8 @@ public class ScalingTestClient {
 
 		clients = new PresentationClient[NUM_CLIENTS + 1];
 		for (int teamId = 1; teamId <= NUM_CLIENTS; teamId++) {
-			PresentationClient client = new PresentationClient(source, "team" + (teamId + START), teamId + START, null);
+			PresentationClient client = new PresentationClient(source, "team" + (teamId + START), null);
+			client.setUID(teamId + START);
 
 			clients[teamId] = client;
 			createWindow(client, SEND_THUMBNAILS && teamId == 1);

--- a/PresCore/src/org/icpc/tools/client/core/BasicClient.java
+++ b/PresCore/src/org/icpc/tools/client/core/BasicClient.java
@@ -180,7 +180,7 @@ public class BasicClient {
 		this.clientType = type;
 		if (this.name == null)
 			this.name = NetworkUtil.getLocalAddress();
-		uid = (user + NetworkUtil.getLocalAddress()).hashCode();
+		uid = (user + type + NetworkUtil.getLocalAddress()).hashCode();
 	}
 
 	// helper method to create based on a REST contest source
@@ -200,7 +200,7 @@ public class BasicClient {
 		this.clientType = type;
 		if (this.name == null)
 			this.name = NetworkUtil.getLocalAddress();
-		uid = (contestSource.getUser() + NetworkUtil.getLocalAddress()).hashCode();
+		uid = (contestSource.getUser() + type + NetworkUtil.getLocalAddress()).hashCode();
 	}
 
 	/**
@@ -225,14 +225,14 @@ public class BasicClient {
 		this.clientType = clientType.toLowerCase();
 
 		name += " " + NetworkUtil.getLocalAddress();
-		uid = (contestSource.getUser() + NetworkUtil.getLocalAddress()).hashCode();
+		uid = (contestSource.getUser() + clientType + NetworkUtil.getLocalAddress()).hashCode();
 	}
 
 	private static String getAuth(String user, String password) throws UnsupportedEncodingException {
 		return Base64.getEncoder().encodeToString((user + ":" + password).getBytes("UTF-8"));
 	}
 
-	protected void setUID(int uid) {
+	public void setUID(int uid) {
 		this.uid = uid;
 	}
 

--- a/PresCore/src/org/icpc/tools/client/core/BasicClient.java
+++ b/PresCore/src/org/icpc/tools/client/core/BasicClient.java
@@ -163,7 +163,7 @@ public class BasicClient {
 
 	private WSClientEndpoint clientEndpoint;
 
-	public BasicClient(String url, String user, String password, String contestIds, String name, int uid, String role,
+	public BasicClient(String url, String user, String password, String contestIds, String name, String role,
 			String type) {
 		this.url = url.replace("https", "wss").replace("http", "wss");
 		if (this.url.endsWith("/"))
@@ -176,15 +176,15 @@ public class BasicClient {
 		if (contestIds != null)
 			this.contestIds = new String[] { contestIds };
 		this.name = name;
-		this.uid = uid;
 		this.role = role;
 		this.clientType = type;
 		if (this.name == null)
 			this.name = NetworkUtil.getLocalAddress();
+		uid = (user + NetworkUtil.getLocalAddress()).hashCode();
 	}
 
 	// helper method to create based on a REST contest source
-	public BasicClient(RESTContestSource contestSource, String name, int uid, String role, String type) {
+	public BasicClient(RESTContestSource contestSource, String name, String role, String type) {
 		try {
 			URL url2 = contestSource.getURL();
 			this.url = "wss://" + url2.getHost();
@@ -196,11 +196,11 @@ public class BasicClient {
 		}
 		this.contestIds = new String[] { contestSource.getContestId() };
 		this.name = name;
-		this.uid = uid;
 		this.role = role;
 		this.clientType = type;
 		if (this.name == null)
 			this.name = NetworkUtil.getLocalAddress();
+		uid = (contestSource.getUser() + NetworkUtil.getLocalAddress()).hashCode();
 	}
 
 	/**
@@ -224,9 +224,8 @@ public class BasicClient {
 		this.name = clientType;
 		this.clientType = clientType.toLowerCase();
 
-		String s = contestSource.getUser();
 		name += " " + NetworkUtil.getLocalAddress();
-		uid = s.hashCode();
+		uid = (contestSource.getUser() + NetworkUtil.getLocalAddress()).hashCode();
 	}
 
 	private static String getAuth(String user, String password) throws UnsupportedEncodingException {


### PR DESCRIPTION
Coach view was using the same UID (hash of user name) for all clients trying to connect to the CDS. This resulted in a lot of repeated "Disconnecting client with existing uid" messages in the CDS log, and eventually even a CPU spike due to garbage collection threads (no real clue why, but stopping coach view fixed it).

Switched to always use the hashcode of "username + network address" for all clients and improved the error message a little. While using the admin to test I noticed a case where thumbnail images aren't disposed of properly, fixed this as well.