### PR TITLE
Delete temp files if another CDS was faster

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -406,7 +406,8 @@ public class RESTContestSource extends DiskContestSource {
 			// be paranoid and set the timestamp after move as well
 			if (mod != 0)
 				localFile.setLastModified(mod);
-		}
+		} else
+			temp.delete();
 
 		String etag = conn.getHeaderField("ETag");
 		updateFileInfo(localFile, href, etag);


### PR DESCRIPTION
I plan to review how multiple CDSs on a shared filesystem works, but short term it should be deleting temp files if another CDS was faster at downloading files than the current one.