### PR TITLE
Add missing jars to CDS classpath

### DIFF
--- a/CDS/.classpath
+++ b/CDS/.classpath
@@ -24,5 +24,15 @@
 			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="lib" path="cdi-api-2.0.jar">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="lib" path="javaee-web-api-8.0.jar">
+		<attributes>
+			<attribute name="org.eclipse.jst.component.nondependency" value=""/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="WebContent/WEB-INF/classes"/>
 </classpath>


### PR DESCRIPTION
The CDS includes 2 new jars but I forgot to commit the .classpath file that adds them to the build path in Eclipse