### PR TITLE
Use Github Container Registry for Docker images.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: icpctools/builder
+    container: ghcr.io/icpctools/builder
     steps:
       - uses: actions/checkout@v2
         with:
@@ -22,7 +22,7 @@ jobs:
           path: dist/*
   push-release:
     runs-on: ubuntu-latest
-    container: icpctools/website
+    container: ghcr.io/icpctools/website
     needs: build
     if: github.ref == 'refs/heads/main'
     steps:
@@ -75,7 +75,7 @@ jobs:
           done
   update-website:
     runs-on: ubuntu-latest
-    container: icpctools/website
+    container: ghcr.io/icpctools/website
     needs: push-release
     if: github.ref == 'refs/heads/main'
     steps:
@@ -122,12 +122,13 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v1 
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
         run: |
           export VERSION_PREFIX=$(awk -F '=' '{ print $2 } ' version.properties)
           VERSION=${VERSION_PREFIX}.$(git rev-list $GITHUB_SHA --count)
           cd build/cds/Docker
-          docker build -t icpctools/cds:${VERSION} --build-arg CDS_VERSION=${VERSION} .
-          docker push icpctools/cds:${VERSION}
+          docker build -t ghcr.io/icpctools/cds:${VERSION} --build-arg CDS_VERSION=${VERSION} .
+          docker push ghcr.io/icpctools/cds:${VERSION}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,47 @@ We will add information on how to run and debug later.
 
 See [the IntelliJ IDEA specific documentation](doc/intellij-idea.md).
 
+### Using the CDS docker image
+
+A [Docker image](https://ghcr.io/icpctools/cds) is provided to run the CDS without having to install it yourself.
+
+#### Running it
+
+The basic way to run it, is to run
+
+```bash
+docker run --name cds --rm -it  -p 8080:8080 -p 8443:8443 -e CCS_URL=https://www.domjudge.org/demoweb/api/contests/nwerc18 -e CCS_USER=admin -e CCS_PASSWORD=admin ghcr.io/icpctools/cds:2.2.407
+```
+
+Replace `https://www.domjudge.org/demoweb/api/contests/nwerc18` with your CCS contest API URL, `CCS_USER` with a user with admin privileges to the CCS URL, `CCS_PASSWORD` with the password for the given user and `2.2.407` with the version of the CDS you want to run.
+
+Now you can access the CDS at https://localhost:8443/.
+
+*Note*: this will use default credentials for all users, so it is recommended to change them. This can be done using environment variables or overwriting the `users.xml` file.
+
+#### Environment variables
+
+* `ADMIN_PASSWORD`: the password for the user with admin privileges.
+* `PRESADMIN_PASSWORD`: the password for the user with presentation admin privileges.
+* `BLUE_PASSWORD`: the password for the user with blue privileges.
+* `BALLOON_PASSWORD`: the password for the user with balloon privileges.
+* `PUBLIC_PASSWORD`: the password for the user with public privileges.
+* `PRESENTATION_PASSWORD`: the password for the user with presentation privileges.
+* `MYICPC_PASSWORD`: the password for the user with MyICPC privileges.
+* `LIVE_PASSWORD`: the password for the user with Live privileges.
+* `CCS_URL`: the URL to a CCS contest.
+* `CCS_USER`: the user that has admin access to `CCS_URL`.
+* `CCS_PASSWORD`: the password for `CCS_USER`.
+
+#### Overwriting config files
+
+* If you want to supply your own `users.xml`, mount a file at `/opt/wlp/usr/servers/cds/users.xml`.
+* If you want to supply your own `cdsConfig.xml`, mount a file at `/opt/wlp/usr/servers/cds/config/cdsConfig.xml`.
+
+#### Contest data directory
+
+The contest data directory is located at `/contest` so you can mount that as a volume if you want to store the data or use team photos, organization logos, banners or any other files.
+
 ## License
 
 All of the tools are provided under the included license and are "Free as in Beer". We welcome you to use

--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -1,5 +1,7 @@
 FROM openjdk:17-bullseye
 LABEL maintainer="Tim deBoer"
+LABEL org.opencontainers.image.description="ICPC Tools code builder"
+LABEL org.opencontainers.image.source=https://github.com/icpctools/icpctools
 
 RUN apt-get update \
    && apt-get install -y ant pandoc texlive \

--- a/build/cds/Docker/Dockerfile
+++ b/build/cds/Docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu:focal
 
 ENV DEBIAN_FRONTEND=noninteractive
+LABEL org.opencontainers.image.description="ICPC Tools Contest Data Server"
+LABEL org.opencontainers.image.source=https://github.com/icpctools/icpctools
 
 ARG CDS_VERSION
 

--- a/build/readme.build.txt
+++ b/build/readme.build.txt
@@ -1,5 +1,5 @@
-docker build . -f builder.Dockerfile -t icpctools/builder
-docker push icpctools/builder
+docker build . -f builder.Dockerfile -t ghcr.io/icpctools/builder
+docker push ghcr.io/icpctools/builder
 
-docker build . -f website.Dockerfile -t icpctools/website
-docker push icpctools/website
+docker build . -f website.Dockerfile -t ghcr.io/icpctools/website
+docker push ghcr.io/icpctools/website

--- a/build/website.Dockerfile
+++ b/build/website.Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:22.04
 LABEL maintainer="Tim deBoer"
+LABEL org.opencontainers.image.description="ICPC Tools website builder"
+LABEL org.opencontainers.image.source=https://github.com/icpctools/icpctools
 
 RUN apt-get update \
    && apt-get install -y wget openssh-client git httpie jq curl python3 python3-requests unzip \

--- a/website/content/cds.md
+++ b/website/content/cds.md
@@ -34,6 +34,6 @@ required and that the CA configures their use into the CDS) include:
 * an RSS feed for the contest
 * the set of files which a team submitted to the judges for a specific run
 
-Note that a [Docker image](https://hub.docker.com/r/icpctools/cds) also exists for the CDS.
+Note that a [Docker image](https://ghcr.io/icpctools/cds) also exists for the CDS.
 
 {{< tooldownload name=CDS toolname=wlp.CDS doc=ContestDataServer >}}


### PR DESCRIPTION
This should be all to replace Docker Hub by GitHub Container Registry, now that Docker Hub wants money.