### PR TITLE
Support contests longer than a month

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonContest.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonContest.java
@@ -274,8 +274,8 @@ public class BalloonContest {
 					if (s1 == null || s2 == null)
 						return 0;
 
-					int t1 = s1.getContestTime();
-					int t2 = s2.getContestTime();
+					long t1 = s1.getContestTime();
+					long t2 = s2.getContestTime();
 					if (t1 > t2)
 						return inc;
 					if (t1 < t2)

--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationServer.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationServer.java
@@ -608,7 +608,7 @@ public class PresentationServer {
 
 						// parse time
 						int index = key.indexOf(":");
-						int time = 0;
+						long time = 0;
 						if (index > 0) {
 							String timeStr = key.substring(0, index);
 							if (timeStr.startsWith("+")) {
@@ -727,13 +727,13 @@ public class PresentationServer {
 		executor.scheduleWithFixedDelay(() -> forEachClient(clients, cl -> cl.writePing()), 30L, 45L, TimeUnit.SECONDS);
 	}
 
-	public void scheduleCallback(IContest c, int contestTimeMs) {
+	public void scheduleCallback(IContest c, long contestTimeMs) {
 		// Future: schedule based on next callback
 		/*// find next event
 		int nextEventTime = Integer.MAX_VALUE;
 		for (TimedEvent event : events)
 			nextEventTime = (int) Math.min(event.contestTimeMs, nextEventTime);
-
+		
 		// leave if there are no scheduled events
 		if (nextEventTime == Integer.MAX_VALUE)
 			return;*/
@@ -746,12 +746,12 @@ public class PresentationServer {
 		double contestTime = System.currentTimeMillis() - startTime;
 		long dt = (long) (contestTimeMs / c.getTimeMultiplier() - contestTime);
 
-		final int nextEventTimeMs = contestTimeMs;
+		final long nextEventTimeMs = contestTimeMs;
 		Trace.trace(Trace.INFO, "Callback scheduled in " + (dt / 1000) + " seconds");
 		executor.schedule(() -> onTime(nextEventTimeMs), dt / 1000, TimeUnit.SECONDS);
 	}
 
-	protected void onTime(int contestTimeMs) {
+	protected void onTime(long contestTimeMs) {
 		List<TimedEvent> remove = new ArrayList<>();
 		for (TimedEvent event : events) {
 			if (event.contestTimeMs <= contestTimeMs) {

--- a/CDS/src/org/icpc/tools/cds/service/ProjectionScoreboardService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ProjectionScoreboardService.java
@@ -31,7 +31,7 @@ public class ProjectionScoreboardService {
 
 		ITeam[] teams = contest.getOrderedTeams();
 		int numProblems = contest.getNumProblems();
-		int contestTimeMs = contest.getContestTimeOfLastEvent();
+		long contestTimeMs = contest.getContestTimeOfLastEvent();
 		// contestTimeMs -= 12000000;
 
 		pw.write("{");
@@ -111,8 +111,8 @@ public class ProjectionScoreboardService {
 	}
 
 	private static void projection(PrintWriter pw, Contest contest, ITeam team, IProblem p, IJudgementType solvedJT,
-			int contestTimeMs2) {
-		int contestTimeMs = contestTimeMs2;
+			long contestTimeMs2) {
+		long contestTimeMs = contestTimeMs2;
 		if (contestTimeMs >= contest.getDuration())
 			return;
 
@@ -131,7 +131,7 @@ public class ProjectionScoreboardService {
 			IStanding ns = clone.getStanding(team);
 			pw.write("\"rank\":" + ns.getRank());
 			pw.write(",\"total_time\":" + ns.getTime());
-			int sf = getSafetyFactor(clone, team, ns, contestTimeMs, contestTimeMs2);
+			long sf = getSafetyFactor(clone, team, ns, contestTimeMs, contestTimeMs2);
 			if (sf >= 0)
 				pw.write(",\"within_time\":" + sf);
 
@@ -172,7 +172,8 @@ public class ProjectionScoreboardService {
 		return out.toString();
 	}
 
-	private static int getSafetyFactor(Contest contest, ITeam team, IStanding s, int contestTimeMs, int contestTimeMs2) {
+	private static long getSafetyFactor(Contest contest, ITeam team, IStanding s, long contestTimeMs,
+			long contestTimeMs2) {
 		int i = contest.getOrderOf(team);
 		int[] order = contest.getOrder();
 		if (i == order.length - 1)
@@ -186,7 +187,7 @@ public class ProjectionScoreboardService {
 		return (contest.getDuration() - contestTimeMs2) / 60000;
 	}
 
-	private static Submission solveAProblem(Contest contest, ITeam team, IProblem problem, int contestTimeMs,
+	private static Submission solveAProblem(Contest contest, ITeam team, IProblem problem, long contestTimeMs,
 			IJudgementType solvedJT) {
 		String id = "projection";
 		Submission submission = new Submission();

--- a/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
+++ b/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
@@ -55,7 +55,7 @@ public class StartTimeService {
 		Trace.trace(Trace.USER, "Start time command: " + command);
 		try {
 			if (command.startsWith("set:")) {
-				setStartTime(cc, (long) -RelativeTime.parse(command.substring(4).trim()));
+				setStartTime(cc, -RelativeTime.parse(command.substring(4).trim()));
 			} else if (command.startsWith("add:")) {
 				if (errorIfContestNotPaused(currentStart, response))
 					return;
@@ -139,7 +139,7 @@ public class StartTimeService {
 		if (time == null)
 			Trace.trace(Trace.INFO, "Setting start time to: null");
 		else if (time < 0)
-			Trace.trace(Trace.INFO, "Setting start time to paused at: " + RelativeTime.format(-time.intValue()));
+			Trace.trace(Trace.INFO, "Setting start time to paused at: " + RelativeTime.format(-time.longValue()));
 		else
 			Trace.trace(Trace.INFO,
 					"Setting start time to: " + Timestamp.format(time) + " (" + ContestUtil.formatStartTime(time) + ")");

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -93,7 +93,7 @@ public class PlaybackContest extends Contest {
 	 * @param info
 	 * @param time
 	 */
-	protected void waitForContestTime(int time) {
+	protected void waitForContestTime(long time) {
 		if (startTime == null || startTime < 0)
 			return;
 

--- a/ContestModel/src/org/icpc/tools/contest/model/ContestUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ContestUtil.java
@@ -15,7 +15,7 @@ public class ContestUtil {
 
 	public static boolean flashPending = true;
 
-	public static boolean isRecent(IContest c, int contestTime) {
+	public static boolean isRecent(IContest c, long contestTime) {
 		Long l = c.getStartTime();
 		if (l == null)
 			return false;
@@ -72,8 +72,8 @@ public class ContestUtil {
 		return r2n < r1n;
 	}
 
-	public static int getTimeInMin(int timeMs) {
-		return timeMs / 60000;
+	public static long getTimeInMin(long timeMs) {
+		return timeMs / 60000L;
 	}
 
 	/**
@@ -82,7 +82,7 @@ public class ContestUtil {
 	 * @param time contest time, in ms
 	 * @return
 	 */
-	public static String getTime(int timeMs) {
+	public static String getTime(long timeMs) {
 		return getTimeInMin(timeMs) + "";
 	}
 
@@ -123,10 +123,10 @@ public class ContestUtil {
 	 * @param duration a duration, in ms
 	 * @return
 	 */
-	public static String formatDuration(Integer duration) {
+	public static String formatDuration(Long duration) {
 		if (duration == null)
 			return "None";
-		return formatDuration((int) duration);
+		return formatDuration((long) duration);
 	}
 
 	/**
@@ -135,8 +135,8 @@ public class ContestUtil {
 	 * @param duration a duration, in ms
 	 * @return
 	 */
-	public static String formatDuration(int duration2) {
-		int duration = duration2 / 1000;
+	public static String formatDuration(long duration2) {
+		long duration = duration2 / 1000;
 		if (duration < 0)
 			return "unknown";
 
@@ -144,15 +144,15 @@ public class ContestUtil {
 			return "0s";
 
 		StringBuilder sb = new StringBuilder();
-		int hours = (int) Math.floor(duration / 3600);
+		long hours = (long) Math.floor(duration / 3600);
 		if (hours > 0)
 			sb.append(hours + "h");
 
-		int mins = (int) Math.floor(duration / 60) % 60;
+		long mins = (long) Math.floor(duration / 60) % 60;
 		if (mins > 0)
 			sb.append(mins + "m");
 
-		int secs = duration % 60;
+		long secs = duration % 60;
 		if (secs > 0)
 			sb.append(secs + "s");
 		return sb.toString();

--- a/ContestModel/src/org/icpc/tools/contest/model/FreezeFilter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FreezeFilter.java
@@ -6,7 +6,7 @@ package org.icpc.tools.contest.model;
  */
 public class FreezeFilter implements IContestObjectFilter {
 	protected IContest contest;
-	protected int freezeTime;
+	protected long freezeTime;
 
 	public FreezeFilter(IContest contest) {
 		this.contest = contest;

--- a/ContestModel/src/org/icpc/tools/contest/model/IClarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IClarification.java
@@ -45,7 +45,7 @@ public interface IClarification extends IContestObject {
 	 *
 	 * @return the contest time
 	 */
-	int getContestTime();
+	long getContestTime();
 
 	/**
 	 * Returns the wall clock time, in ms since the epoch.

--- a/ContestModel/src/org/icpc/tools/contest/model/ICommentary.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ICommentary.java
@@ -9,7 +9,7 @@ public interface ICommentary extends IContestObject {
 	 *
 	 * @return the contest time
 	 */
-	int getContestTime();
+	long getContestTime();
 
 	/**
 	 * Returns the wall clock time, in ms since the epoch.

--- a/ContestModel/src/org/icpc/tools/contest/model/IContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContest.java
@@ -68,14 +68,14 @@ public interface IContest {
 	 *
 	 * @return the time remaining before the contest, in ms
 	 */
-	Integer getCountdownPauseTime();
+	Long getCountdownPauseTime();
 
 	/**
 	 * Returns the duration of the contest, in ms.
 	 *
 	 * @return the duration
 	 */
-	int getDuration();
+	long getDuration();
 
 	/**
 	 * Returns the duration of the end of contest freeze in ms, or null if there is no freeze in
@@ -83,7 +83,7 @@ public interface IContest {
 	 *
 	 * @return the freeze duration
 	 */
-	Integer getFreezeDuration();
+	Long getFreezeDuration();
 
 	/**
 	 * Returns the penalty time. null means there is no concept of penalty time; 0 indicates there
@@ -169,7 +169,7 @@ public interface IContest {
 	 *
 	 * @return
 	 */
-	int getContestTimeOfLastEvent();
+	long getContestTimeOfLastEvent();
 
 	/**
 	 * Return the most recent timed contest object.

--- a/ContestModel/src/org/icpc/tools/contest/model/IJudgement.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IJudgement.java
@@ -9,14 +9,14 @@ public interface IJudgement extends IContestObject {
 	 *
 	 * @return the contest time
 	 */
-	int getStartContestTime();
+	Long getStartContestTime();
 
 	/**
 	 * Returns the wall clock time, in ms since the epoch.
 	 *
 	 * @return the time
 	 */
-	long getStartTime();
+	Long getStartTime();
 
 	/**
 	 * Returns the submission that this judgement is for.
@@ -44,7 +44,7 @@ public interface IJudgement extends IContestObject {
 	 *
 	 * @return the contest time
 	 */
-	Integer getEndContestTime();
+	Long getEndContestTime();
 
 	/**
 	 * Returns the wall clock time, in ms since the epoch.

--- a/ContestModel/src/org/icpc/tools/contest/model/IProblemSummary.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IProblemSummary.java
@@ -16,7 +16,7 @@ public interface IProblemSummary {
 	 *
 	 * @return the submission time, in ms
 	 */
-	int getPendingContestTime();
+	long getPendingContestTime();
 
 	/**
 	 * Return the number of failed submissions.
@@ -30,7 +30,7 @@ public interface IProblemSummary {
 	 *
 	 * @return the submission time, in ms
 	 */
-	int getFailedContestTime();
+	long getFailedContestTime();
 
 	/**
 	 * Return the number of solved submissions.
@@ -44,7 +44,7 @@ public interface IProblemSummary {
 	 *
 	 * @return the submission time, in ms
 	 */
-	int getSolvedContestTime();
+	long getSolvedContestTime();
 
 	/**
 	 * Return the total number of submissions.

--- a/ContestModel/src/org/icpc/tools/contest/model/IResult.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IResult.java
@@ -38,7 +38,7 @@ public interface IResult {
 	 *
 	 * @return the submission time, in ms
 	 */
-	int getContestTime();
+	long getContestTime();
 
 	/**
 	 * Return the penalty time for this problem, in minutes.

--- a/ContestModel/src/org/icpc/tools/contest/model/IRun.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IRun.java
@@ -37,7 +37,7 @@ public interface IRun extends IContestObject {
 	 *
 	 * @return the contest time
 	 */
-	int getContestTime();
+	long getContestTime();
 
 	/**
 	 * Returns the wall clock time, in ms since the epoch.

--- a/ContestModel/src/org/icpc/tools/contest/model/IStanding.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IStanding.java
@@ -23,14 +23,14 @@ public interface IStanding {
 	 *
 	 * @return the total time of this team
 	 */
-	int getTime();
+	long getTime();
 
 	/**
 	 * Returns the time of the last (most recent) solution, in minutes.
 	 *
 	 * @return the time of last solution
 	 */
-	int getLastSolutionTime();
+	long getLastSolutionTime();
 
 	/**
 	 * Return the current rank of this team.

--- a/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
@@ -81,7 +81,7 @@ public interface ISubmission extends IContestObject {
 	 *
 	 * @return the contest time
 	 */
-	int getContestTime();
+	long getContestTime();
 
 	/**
 	 * Returns the wall clock time, in ms since the epoch.

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -27,7 +27,7 @@ public class Scoreboard {
 		pw.write(" \"event_id\":\"cds" + index + "\",\n");
 		if (obj == null) {
 			pw.write("  \"time\":\"" + Timestamp.format(System.currentTimeMillis()) + "\",\n");
-			pw.write("  \"contest_time\":\"" + RelativeTime.format(0) + "\",\n");
+			pw.write("  \"contest_time\":\"" + RelativeTime.format(0L) + "\",\n");
 		} else {
 			pw.write("  \"time\":\"" + Timestamp.format(ContestObject.getTime(obj)) + "\",\n");
 			pw.write("  \"contest_time\":\"" + RelativeTime.format(ContestObject.getContestTime(obj)) + "\",\n");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -735,7 +735,7 @@ public class RESTContestSource extends DiskContestSource {
 
 			if (time != null && time < 0) {
 				bw.write(", \"countdown_pause_time\":");
-				bw.write("\"" + RelativeTime.format(-time.intValue()) + "\"");
+				bw.write("\"" + RelativeTime.format(-time.longValue()) + "\"");
 			}
 
 			bw.write(" }");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RelativeTime.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RelativeTime.java
@@ -30,49 +30,49 @@ public class RelativeTime {
 		return contestTime;
 	}
 
-	public static int parse(String contestTime) throws ParseException {
+	public static long parse(String contestTime) throws ParseException {
 		Matcher match = TIME_PATTERN.matcher(contestTime);
 		if (!match.matches())
 			throw new ParseException("Invalid contest time string: " + contestTime, 0);
 
-		int h = Integer.parseInt(match.group(1));
-		int m = Integer.parseInt(match.group(2));
-		int s = Integer.parseInt(match.group(3));
+		long h = Integer.parseInt(match.group(1));
+		long m = Integer.parseInt(match.group(2));
+		long s = Integer.parseInt(match.group(3));
 		if (m > 59 || s > 59)
 			throw new ParseException("Invalid contest time string: " + contestTime, 0);
-		int ms = 0;
+		long ms = 0;
 		if (match.group(4) != null) {
 			ms = Integer.parseInt(match.group(4).substring(1));
 		}
 
-		int val = h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
+		long val = h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
 		if (contestTime.startsWith("-"))
 			return -val;
 
 		return val;
 	}
 
-	public static String format(Integer contestTimeMs) {
+	public static String format(Long contestTimeMs) {
 		if (contestTimeMs == null)
 			return "null";
-		return format(contestTimeMs.intValue());
+		return format(contestTimeMs.longValue());
 	}
 
-	public static String format(int contestTimeMs) {
-		int ms = contestTimeMs;
+	public static String format(long contestTimeMs) {
+		long ms = contestTimeMs;
 		StringBuilder sb = new StringBuilder();
 		if (contestTimeMs < 0) {
 			ms = -contestTimeMs;
 			sb.append("-");
 		}
 
-		int s = ms / 1000;
+		long s = ms / 1000;
 		if (s > 0)
 			ms -= s * 1000;
-		int m = s / 60;
+		long m = s / 60;
 		if (m > 0)
 			s -= m * 60;
-		int h = m / 60;
+		long h = m / 60;
 		if (h > 0)
 			m -= h * 60;
 
@@ -96,7 +96,7 @@ public class RelativeTime {
 		String o = "1:22:05.034";
 		// String o = "2:09:05.134";
 		// String o = "2:09:05";
-		int num = parse(o);
+		long num = parse(o);
 		System.out.println(o + " -> " + num + " -> " + format(num));
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -79,7 +79,7 @@ public class Contest implements IContest {
 	private Recent[] recentActivity;
 	private IJudgement[] submissionJudgements;
 	private IJudgementType[] submissionJudgementTypes;
-	private int lastEventTime;
+	private long lastEventTime;
 	private IContestObject lastTimedEvent;
 	private int lastTimedEventIndex;
 
@@ -173,7 +173,7 @@ public class Contest implements IContest {
 				knownProps.add(name);
 	}
 
-	private void updateTime(int time) {
+	private void updateTime(long time) {
 		lastEventTime = Math.max(lastEventTime, time);
 	}
 
@@ -549,7 +549,7 @@ public class Contest implements IContest {
 	}
 
 	@Override
-	public Integer getCountdownPauseTime() {
+	public Long getCountdownPauseTime() {
 		return info.getCountdownPauseTime();
 	}
 
@@ -559,7 +559,7 @@ public class Contest implements IContest {
 	 * @return the duration
 	 */
 	@Override
-	public int getDuration() {
+	public long getDuration() {
 		return info.getDuration();
 	}
 
@@ -569,7 +569,7 @@ public class Contest implements IContest {
 	 * @return the freeze duration
 	 */
 	@Override
-	public Integer getFreezeDuration() {
+	public Long getFreezeDuration() {
 		return info.getFreezeDuration();
 	}
 
@@ -740,7 +740,7 @@ public class Contest implements IContest {
 		if (startTime != null)
 			return startTime;
 
-		Integer pause = info.getCountdownPauseTime();
+		Long pause = info.getCountdownPauseTime();
 		if (pause == null)
 			return null;
 
@@ -1020,14 +1020,14 @@ public class Contest implements IContest {
 			// sort submissions by time (just in case they aren't)
 			ISubmission[] sortedSubs = new ISubmission[submissions.length];
 			System.arraycopy(submissions, 0, sortedSubs, 0, submissions.length);
-			Arrays.sort(sortedSubs, Comparator.comparingInt(ISubmission::getContestTime));
+			Arrays.sort(sortedSubs, Comparator.comparingLong(ISubmission::getContestTime));
 
 			// sb.append((System.currentTimeMillis() - scoreTime) + "ms ");
 
 			String[] tempFTS = new String[numProblems];
-			int duration = getDuration();
+			long duration = getDuration();
 			for (ISubmission s : sortedSubs) {
-				int time = s.getContestTime();
+				long time = s.getContestTime();
 				if (time >= 0 && time < duration) {
 					int teamIndex = getTeamIndex(s.getTeamId());
 					int problemIndex = getProblemIndex(s.getProblemId());
@@ -1054,12 +1054,12 @@ public class Contest implements IContest {
 			for (int i = 0; i < numTeams; i++) {
 				int numSolved = 0;
 				int penalty = 0;
-				int lastSolution = -1;
+				long lastSolution = -1;
 				double score = 0;
 				for (int j = 0; j < numProblems; j++) {
 					penalty += tempResults[i][j].getPenaltyTime();
 					if (tempResults[i][j].getStatus() == Status.SOLVED) {
-						int time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime());
+						long time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime());
 						penalty += time;
 						numSolved++;
 						score += tempResults[i][j].getScore();
@@ -1331,7 +1331,7 @@ public class Contest implements IContest {
 	}
 
 	@Override
-	public int getContestTimeOfLastEvent() {
+	public long getContestTimeOfLastEvent() {
 		return lastEventTime;
 	}
 
@@ -1839,7 +1839,7 @@ public class Contest implements IContest {
 		List<IContestObject> remove = new ArrayList<>();
 
 		for (ISubmission s : getSubmissions()) {
-			int time = s.getContestTime();
+			long time = s.getContestTime();
 			if (time < 0 || time >= getDuration())
 				removeSubmission(remove, s);
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -170,7 +170,7 @@ public abstract class ContestObject implements IContestObject {
 		return 0;
 	}
 
-	public static int getContestTime(IContestObject obj) {
+	public static long getContestTime(IContestObject obj) {
 		if (obj instanceof TimedEvent) {
 			return ((TimedEvent) obj).getContestTime();
 		} else if (obj instanceof IJudgement) {
@@ -182,7 +182,7 @@ public abstract class ContestObject implements IContestObject {
 		return 0;
 	}
 
-	protected static Integer parseRelativeTime(Object value) throws ParseException {
+	protected static Long parseRelativeTime(Object value) throws ParseException {
 		if (value == null || "null".equals(value))
 			return null;
 		return RelativeTime.parse((String) value);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -28,10 +28,10 @@ public class Info extends ContestObject implements IInfo {
 	private String name;
 	private String formalName;
 	private Long startTime;
-	private Integer pauseTime;
+	private Long pauseTime;
 	private boolean supportsPauseTime;
-	private int duration;
-	private Integer freezeDuration;
+	private long duration;
+	private Long freezeDuration;
 	private Integer penalty;
 	private ScoreboardType scoreboardType;
 	private double timeMultiplier = Double.NaN;
@@ -72,7 +72,7 @@ public class Info extends ContestObject implements IInfo {
 			pauseTime = null;
 			startTime = null;
 		} else if (start.longValue() < 0) {
-			pauseTime = -start.intValue();
+			pauseTime = -start.longValue();
 			supportsPauseTime = true;
 			startTime = null;
 		} else {
@@ -85,15 +85,15 @@ public class Info extends ContestObject implements IInfo {
 		return supportsPauseTime;
 	}
 
-	public Integer getCountdownPauseTime() {
+	public Long getCountdownPauseTime() {
 		return pauseTime;
 	}
 
-	public int getDuration() {
+	public long getDuration() {
 		return duration;
 	}
 
-	public Integer getFreezeDuration() {
+	public Long getFreezeDuration() {
 		return freezeDuration;
 	}
 
@@ -111,7 +111,7 @@ public class Info extends ContestObject implements IInfo {
 		timeMultiplier = multiplier;
 	}
 
-	public void setCountdownPauseTime(Integer time) {
+	public void setCountdownPauseTime(Long time) {
 		supportsPauseTime = true;
 		pauseTime = time;
 	}
@@ -291,7 +291,7 @@ public class Info extends ContestObject implements IInfo {
 	}
 
 	public int deepHash() {
-		int hash = duration + (int) timeMultiplier;
+		int hash = (int) duration + (int) timeMultiplier;
 		if (freezeDuration != null)
 			hash += freezeDuration;
 		if (penalty != null)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Judgement.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Judgement.java
@@ -23,9 +23,9 @@ public class Judgement extends ContestObject implements IJudgement {
 
 	private String submissionId;
 	private String judgementTypeId;
-	protected int startContestTime = Integer.MIN_VALUE;
-	protected long startTime = Long.MIN_VALUE;
-	protected Integer endContestTime;
+	protected Long startContestTime = Long.MIN_VALUE;
+	protected Long startTime = Long.MIN_VALUE;
+	protected Long endContestTime;
 	protected Long endTime;
 	protected int maxRunTime;
 	protected Double score;
@@ -64,17 +64,17 @@ public class Judgement extends ContestObject implements IJudgement {
 	}
 
 	@Override
-	public int getStartContestTime() {
+	public Long getStartContestTime() {
 		return startContestTime;
 	}
 
 	@Override
-	public long getStartTime() {
+	public Long getStartTime() {
 		return startTime;
 	}
 
 	@Override
-	public Integer getEndContestTime() {
+	public Long getEndContestTime() {
 		return endContestTime;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Judgement.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Judgement.java
@@ -23,8 +23,8 @@ public class Judgement extends ContestObject implements IJudgement {
 
 	private String submissionId;
 	private String judgementTypeId;
-	protected Long startContestTime = Long.MIN_VALUE;
-	protected Long startTime = Long.MIN_VALUE;
+	protected Long startContestTime;
+	protected Long startTime;
 	protected Long endContestTime;
 	protected Long endTime;
 	protected int maxRunTime;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ProblemSummary.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ProblemSummary.java
@@ -6,11 +6,11 @@ import org.icpc.tools.contest.model.Status;
 
 public class ProblemSummary implements IProblemSummary {
 	private int numPending;
-	private int pendingTime;
+	private long pendingTime;
 	private int numSolved;
-	private int solvedTime;
+	private long solvedTime;
 	private int numFailed;
-	private int failedTime;
+	private long failedTime;
 
 	public ProblemSummary() {
 		super();
@@ -22,7 +22,7 @@ public class ProblemSummary implements IProblemSummary {
 	}
 
 	@Override
-	public int getPendingContestTime() {
+	public long getPendingContestTime() {
 		return failedTime;
 	}
 
@@ -32,7 +32,7 @@ public class ProblemSummary implements IProblemSummary {
 	}
 
 	@Override
-	public int getSolvedContestTime() {
+	public long getSolvedContestTime() {
 		return failedTime;
 	}
 
@@ -42,7 +42,7 @@ public class ProblemSummary implements IProblemSummary {
 	}
 
 	@Override
-	public int getFailedContestTime() {
+	public long getFailedContestTime() {
 		return failedTime;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
@@ -9,7 +9,7 @@ public class Result implements IResult {
 	private Status status = Status.UNATTEMPTED;
 	private int numPending;
 	private int numJudged;
-	private int time;
+	private long time;
 	private int penalty;
 	private int pendingPenalty;
 	private double score;
@@ -40,7 +40,7 @@ public class Result implements IResult {
 	}
 
 	@Override
-	public int getContestTime() {
+	public long getContestTime() {
 		return time;
 	}
 
@@ -54,7 +54,7 @@ public class Result implements IResult {
 		return score;
 	}
 
-	protected void addSubmission(Contest contest, int submissionTime, IJudgement j, IJudgementType jt) {
+	protected void addSubmission(Contest contest, long submissionTime, IJudgement j, IJudgementType jt) {
 		if (status == Status.SOLVED)
 			return;
 
@@ -106,7 +106,7 @@ public class Result implements IResult {
 
 	@Override
 	public int hashCode() {
-		return getNumSubmissions() * 80000 + getContestTime();
+		return getNumSubmissions() * 80000 + (int) getContestTime();
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Standing.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Standing.java
@@ -5,7 +5,7 @@ import org.icpc.tools.contest.model.IStanding;
 public class Standing implements IStanding {
 	private int penalty;
 	private int numSolved;
-	private int lastSolution;
+	private long lastSolution;
 	private String rank;
 	private double score;
 
@@ -13,7 +13,7 @@ public class Standing implements IStanding {
 		// do nothing
 	}
 
-	public void init(int numSolved2, int penalty2, double score2, int lastSolution2) {
+	public void init(int numSolved2, int penalty2, double score2, long lastSolution2) {
 		this.numSolved = numSolved2;
 		this.penalty = penalty2;
 		this.score = score2;
@@ -25,7 +25,7 @@ public class Standing implements IStanding {
 	}
 
 	@Override
-	public int getTime() {
+	public long getTime() {
 		return penalty;
 	}
 
@@ -39,7 +39,7 @@ public class Standing implements IStanding {
 	}
 
 	@Override
-	public int getLastSolutionTime() {
+	public long getLastSolutionTime() {
 		return lastSolution;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/TimedEvent.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/TimedEvent.java
@@ -10,7 +10,7 @@ public abstract class TimedEvent extends ContestObject {
 	private static final String CONTEST_TIME = "contest_time";
 	private static final String TIME = "time";
 
-	protected int contestTime = Integer.MIN_VALUE;
+	protected long contestTime = Long.MIN_VALUE;
 	protected long time = Long.MIN_VALUE;
 
 	public TimedEvent() {
@@ -21,7 +21,7 @@ public abstract class TimedEvent extends ContestObject {
 		super(id);
 	}
 
-	public int getContestTime() {
+	public long getContestTime() {
 		return contestTime;
 	}
 
@@ -43,7 +43,7 @@ public abstract class TimedEvent extends ContestObject {
 
 	@Override
 	protected void getProperties(Properties props) {
-		if (contestTime != Integer.MIN_VALUE)
+		if (contestTime != Long.MIN_VALUE)
 			props.addLiteralString(CONTEST_TIME, RelativeTime.format(contestTime));
 		if (time != Long.MIN_VALUE)
 			props.addLiteralString(TIME, Timestamp.format(time));
@@ -53,7 +53,7 @@ public abstract class TimedEvent extends ContestObject {
 	public List<String> validate(IContest c) {
 		List<String> errors = super.validate(c);
 
-		if (contestTime == Integer.MIN_VALUE)
+		if (contestTime == Long.MIN_VALUE)
 			errors.add("Invalid contest time " + contestTime);
 
 		if (time == Long.MIN_VALUE)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/YamlParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/YamlParser.java
@@ -62,16 +62,16 @@ public class YamlParser {
 					else if ("short-name".equals(key))
 						info.add("name", value);
 					else if ("length".equals(key) || "duration".equals(key)) {
-						int length = RelativeTime.parse(value);
+						long length = RelativeTime.parse(value);
 						if (length >= 0)
 							info.add("duration", RelativeTime.format(length));
 					} else if ("scoreboard-freeze".equals(key)) {
-						int length = RelativeTime.parse(value);
-						int d = info.getDuration();
+						long length = RelativeTime.parse(value);
+						long d = info.getDuration();
 						if (length >= 0 && d > 0)
 							info.add("scoreboard_freeze_duration", RelativeTime.format(d / 1000 - length));
 					} else if ("scoreboard-freeze-length".equals(key)) {
-						int length = RelativeTime.parse(value);
+						long length = RelativeTime.parse(value);
 						if (length >= 0)
 							info.add("scoreboard_freeze_duration", RelativeTime.format(length));
 					} else if ("penalty-time".equals(key)) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -44,13 +44,13 @@ public class AnalystContest extends PublicContest {
 					return;
 
 				// hide runs for submissions outside the contest time
-				int time = s.getContestTime();
+				long time = s.getContestTime();
 				if (time < 0 || time >= getDuration())
 					return;
 
 				// hide runs for submissions after freeze
 				if (getFreezeDuration() != null) {
-					int freezeTime = getDuration() - getFreezeDuration();
+					long freezeTime = getDuration() - getFreezeDuration();
 					if (s.getContestTime() >= freezeTime)
 						return;
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/BalloonContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/BalloonContest.java
@@ -36,7 +36,7 @@ public class BalloonContest extends PublicContest {
 				return;
 
 			// hide judgements for submissions outside the contest time
-			int time = s.getContestTime();
+			long time = s.getContestTime();
 			if (time < 0 || time >= getDuration())
 				return;
 
@@ -46,7 +46,7 @@ public class BalloonContest extends PublicContest {
 
 			// do show before the freeze
 			if (getFreezeDuration() != null) {
-				int freezeTime = getDuration() - getFreezeDuration();
+				long freezeTime = getDuration() - getFreezeDuration();
 				if (time < freezeTime) {
 					addIt(j);
 					return;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -127,7 +127,7 @@ public class PublicContest extends Contest {
 				ISubmission sub = (ISubmission) obj;
 
 				// hide submissions from outside the contest time
-				int time = sub.getContestTime();
+				long time = sub.getContestTime();
 				if (time < 0 || time >= getDuration())
 					return;
 
@@ -147,13 +147,13 @@ public class PublicContest extends Contest {
 					return;
 
 				// hide judgements for submissions outside the contest time
-				int time = s.getContestTime();
+				long time = s.getContestTime();
 				if (time < 0 || time >= getDuration())
 					return;
 
 				// or during the freeze
 				if (getFreezeDuration() != null) {
-					int freezeTime = getDuration() - getFreezeDuration();
+					long freezeTime = getDuration() - getFreezeDuration();
 					if (time >= freezeTime)
 						return;
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -50,7 +50,7 @@ public class AwardUtil {
 				boolean afterFreeze = false;
 
 				if (contest.getFreezeDuration() != null) {
-					int freezeMin = (contest.getDuration() - contest.getFreezeDuration()) / 60000;
+					long freezeMin = (contest.getDuration() - contest.getFreezeDuration()) / 60000;
 					if (ContestUtil.getTimeInMin(s.getContestTime()) < freezeMin)
 						beforeFreeze = true;
 					else
@@ -162,7 +162,7 @@ public class AwardUtil {
 				boolean afterFreeze = false;
 
 				if (contest.getFreezeDuration() != null) {
-					int freezeMin = (contest.getDuration() - contest.getFreezeDuration()) / 60000;
+					long freezeMin = (contest.getDuration() - contest.getFreezeDuration()) / 60000;
 					if (ContestUtil.getTimeInMin(s.getContestTime()) < freezeMin)
 						beforeFreeze = true;
 					else

--- a/ContestModel/src/org/icpc/tools/contest/model/util/ScoreboardData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/ScoreboardData.java
@@ -11,7 +11,7 @@ public class ScoreboardData {
 		public String rank;
 		public String teamId;
 		public int numSolved;
-		public int totalTime;
+		public long totalTime;
 		public SProblem[] problems;
 
 		@Override
@@ -115,7 +115,7 @@ public class ScoreboardData {
 
 	public String eventId;
 	public Long time;
-	public Integer contestTime;
+	public Long contestTime;
 	public IState state;
 
 	public STeam[] teams;

--- a/ContestModel/src/org/icpc/tools/contest/model/util/ScoreboardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/ScoreboardUtil.java
@@ -149,11 +149,11 @@ public class ScoreboardUtil {
 		cc.add(row, "Different " + field + " (" + a + " vs " + b + ")");
 	}
 
-	private static void match(CompareCount cc, String row, String field, int a, int b) {
+	private static void match(CompareCount cc, String row, String field, long a, long b) {
 		cc.add(row, "Different " + field + " (" + a + " vs " + b + ")");
 	}
 
-	private static void match(CompareCount cc, String row, String problem, String field, int a, int b) {
+	private static void match(CompareCount cc, String row, String problem, String field, long a, long b) {
 		cc.add(row, problem, "Different " + field + " (" + a + " vs " + b + ")");
 	}
 

--- a/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
@@ -263,7 +263,7 @@ public class EventFeedUtil {
 			}
 		}
 
-		int freeze = 0;
+		long freeze = 0;
 		if (contest.getFreezeDuration() != null)
 			freeze = contest.getDuration() - contest.getFreezeDuration();
 		int unjudgedSubmissions = 0;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/AbstractICPCPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/AbstractICPCPresentation.java
@@ -39,7 +39,7 @@ public abstract class AbstractICPCPresentation extends Presentation {
 		if (state.getStarted() != null)
 			return getTime((getTimeMs() - state.getStarted()) * timeMultiplier, true);
 
-		Integer pauseTime = contest.getCountdownPauseTime();
+		Long pauseTime = contest.getCountdownPauseTime();
 		if (pauseTime != null)
 			return NLS.bind(Messages.pausedAt, getTime(-pauseTime * timeMultiplier, false));
 
@@ -67,7 +67,7 @@ public abstract class AbstractICPCPresentation extends Presentation {
 		if (state.getStarted() != null)
 			return getTime((state.getStarted() - getTimeMs()) * timeMultiplier + contest.getDuration(), false);
 
-		Integer pauseTime = contest.getCountdownPauseTime();
+		Long pauseTime = contest.getCountdownPauseTime();
 		if (pauseTime != null)
 			return NLS.bind(Messages.pausedAt, getTime(-pauseTime * timeMultiplier, false));
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ShadedRectangle.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ShadedRectangle.java
@@ -92,7 +92,7 @@ public class ShadedRectangle {
 	}
 
 	public static void drawRoundRect(Graphics2D g, int x, int y, int w, int h, IContest contest, Status status,
-			int contestTime, long time, String s) {
+			long contestTime, long time, String s) {
 		Paint paint = getPaint(h, status, ContestUtil.isRecent(contest, contestTime), false, time);
 		drawRoundRect(g, x, y, w, h, paint, null, s);
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/StatisticsGenerator.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/StatisticsGenerator.java
@@ -57,7 +57,7 @@ public class StatisticsGenerator {
 		int numProblems = problems.length;
 
 		int[] totalProblemSolved = new int[numProblems];
-		int[] fastestProblemSolved = new int[numProblems];
+		long[] fastestProblemSolved = new long[numProblems];
 		ITeam[] fastestProblemSolvedTeam = new ITeam[numProblems];
 
 		for (int j = 0; j < numProblems; j++)
@@ -65,7 +65,7 @@ public class StatisticsGenerator {
 
 		int mostAttempts = -1;
 		int mostAttemptsProblem = -1;
-		int lastSolvedTime = -1;
+		long lastSolvedTime = -1;
 		int lastSolvedProblem = -1;
 		int totalPending = 0;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/HistoricalComparisonChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/HistoricalComparisonChart.java
@@ -24,7 +24,7 @@ public class HistoricalComparisonChart extends AbstractChartPresentation {
 	private static final int MIN = 5;
 
 	protected IContest contest = ContestData.getContest();
-	protected int maxTime;
+	protected long maxTime;
 	protected int numValues;
 	protected List<IContest> pastContests;
 	protected List<Series> pastData = new ArrayList<>();
@@ -75,7 +75,7 @@ public class HistoricalComparisonChart extends AbstractChartPresentation {
 			}
 		}
 
-		numValues = maxTime / 60000 / MIN;
+		numValues = (int) (maxTime / 60000 / MIN);
 		if (numValues < 1)
 			numValues = 1;
 	}
@@ -97,7 +97,7 @@ public class HistoricalComparisonChart extends AbstractChartPresentation {
 			int[] total = new int[numValues];
 			ISubmission[] submissions = contest2.getSubmissions();
 			for (ISubmission s : submissions) {
-				int time = s.getContestTime();
+				long time = s.getContestTime();
 				if (time <= maxTime) {
 					int rt = (int) Math.max(0, time / 1000L / 60 / MIN);
 					rt = Math.min(rt, numValues - 1);
@@ -134,7 +134,7 @@ public class HistoricalComparisonChart extends AbstractChartPresentation {
 		int[] total = new int[numValues];
 		ISubmission[] submissions = contest.getSubmissions();
 		for (ISubmission s : submissions) {
-			int time = s.getContestTime();
+			long time = s.getContestTime();
 			if (time < maxTime) {
 				int rt = (int) Math.max(0, time / 1000L / 60 / MIN);
 				rt = Math.min(rt, numValues - 1);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/JudgeQueueDepthChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/JudgeQueueDepthChart.java
@@ -41,8 +41,8 @@ public class JudgeQueueDepthChart extends AbstractChartPresentation {
 		if (contest == null)
 			return;
 
-		int dur = contest.getDuration();
-		numPoints = dur / INTERVAL;
+		long dur = contest.getDuration();
+		numPoints = (int) (dur / INTERVAL);
 		if (numPoints < 1)
 			numPoints = 1;
 
@@ -67,7 +67,7 @@ public class JudgeQueueDepthChart extends AbstractChartPresentation {
 		if (contest == null || getSeries() == null)
 			return;
 
-		int now = contest.getContestTimeOfLastEvent();
+		long now = contest.getContestTimeOfLastEvent();
 		int ms2 = (int) (Math.floor(now / (double) INTERVAL));
 
 		int[] arr = new int[numPoints];

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemComparisonChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemComparisonChart.java
@@ -29,7 +29,7 @@ public class ProblemComparisonChart extends AbstractChartPresentation {
 
 		setTitle("Submissions by Problem");
 
-		numMin = contest.getContestTimeOfLastEvent() / 60000 / MIN;
+		numMin = (int) (contest.getContestTimeOfLastEvent() / 60000 / MIN);
 		if (numMin < 1)
 			numMin = 1;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemDetailChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ProblemDetailChart.java
@@ -45,7 +45,7 @@ public class ProblemDetailChart extends AbstractChartPresentation {
 		IProblem problem = contest.getProblems()[problemNum];
 		setTitle("Problem " + problem.getLabel() + " Submissions");
 
-		numMin = contest.getContestTimeOfLastEvent() / 60000 / MIN;
+		numMin = (int) (contest.getContestTimeOfLastEvent() / 60000 / MIN);
 		if (numMin < 1)
 			numMin = 1;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ScoreboardChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/ScoreboardChart.java
@@ -33,7 +33,7 @@ public class ScoreboardChart extends AbstractChartPresentation {
 		if (contest == null || contest.getNumTeams() < NUM_TEAMS)
 			return;
 
-		numValues = contest.getContestTimeOfLastEvent() / MS_PER_MIN / MIN_PER_STEP;
+		numValues = (int) (contest.getContestTimeOfLastEvent() / MS_PER_MIN / MIN_PER_STEP);
 		if (numValues < 1)
 			numValues = 1;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/TotalProblemsChart.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/chart/TotalProblemsChart.java
@@ -38,7 +38,7 @@ public class TotalProblemsChart extends AbstractChartPresentation {
 		if (contest == null)
 			return;
 
-		numValues = contest.getContestTimeOfLastEvent() / 60000 / MIN;
+		numValues = (int) (contest.getContestTimeOfLastEvent() / 60000 / MIN);
 		if (numValues < 1)
 			numValues = 1;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummary.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummary.java
@@ -25,7 +25,7 @@ public class ProblemSummary {
 	private Color darkBgColor;
 
 	// private boolean recent;
-	private int[] stats;
+	private long[] stats;
 
 	public ProblemSummary(Rectangle r, IProblem p) {
 		this.r = r;
@@ -59,7 +59,7 @@ public class ProblemSummary {
 		g.drawString(s, x + (w - fm.stringWidth(s)) / 2, y + (h + fm.getAscent()) / 2 - 1);
 	}
 
-	public void setStats(int[] s) {
+	public void setStats(long[] s) {
 		stats = s;
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummaryPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummaryPresentation.java
@@ -90,7 +90,7 @@ public class ProblemSummaryPresentation extends AbstractICPCPresentation {
 				if (timeMs <= i * FLY_IN)
 					break;
 
-				int[] stats = new int[4]; // attempted, solved, failed, fts
+				long[] stats = new long[4]; // attempted, solved, failed, fts
 				stats[3] = -1;
 
 				if (probs[i].getProblem() != null) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
@@ -92,10 +92,10 @@ public class CountdownPresentation extends ClockPresentation {
 
 		// where should we switch countdown between the start and end of a contest?
 		// switch at the contest freeze, or (if there is no freeze) 2/3 of the contest
-		int duration = contest.getDuration();
+		long duration = contest.getDuration();
 		long switchPoint = duration * 2 / 3;
 
-		Integer freezeDuration = contest.getFreezeDuration();
+		Long freezeDuration = contest.getFreezeDuration();
 		if (freezeDuration != null)
 			switchPoint = duration - freezeDuration;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/PolarCountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/PolarCountdownPresentation.java
@@ -49,16 +49,16 @@ public class PolarCountdownPresentation extends CountdownPresentation {
 			int[] angle = new int[NUM_ARCS];
 
 			int s = (int) Math.floor(l.longValue() / 1000.0);
-			int maxHours = contest.getDuration() / 3600000;
+			long maxHours = contest.getDuration() / 3600000;
 			if (maxHours != 0) {
 				if (s < 0) {
 					angle[0] = -(59 + (s % 120)) * 6;
 					angle[1] = -(60 + ((s / 60) % 120)) * 6;
-					angle[2] = -(maxHours + ((s / 3600) % maxHours)) * (360 / maxHours);
+					angle[2] = (int) -((maxHours + ((s / 3600) % maxHours)) * (360 / maxHours));
 				} else {
 					angle[0] = -(s % 120) * 6;
 					angle[1] = -((s / 60) % 120) * 6;
-					angle[2] = -((s / 3600) % maxHours) * (360 / maxHours);
+					angle[2] = (int) -(((s / 3600) % maxHours) * (360 / maxHours));
 				}
 			}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/LeaderTickerPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/LeaderTickerPresentation.java
@@ -23,9 +23,9 @@ public class LeaderTickerPresentation extends AbstractTickerPresentation {
 		protected int rank;
 		protected String name;
 		protected int solved;
-		protected int penalty;
+		protected long penalty;
 
-		public LeaderTicker(int rank, String name, int solved, int penalty) {
+		public LeaderTicker(int rank, String name, int solved, long penalty) {
 			this.rank = rank;
 			this.name = name;
 			this.solved = solved;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -450,12 +450,12 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 					width - BORDER - fm.stringWidth(" 9999") - (fm.stringWidth("99") + fm.stringWidth(s)) / 2, 5);
 		}
 
-		n = standing.getTime();
+		long t = standing.getTime();
 
 		g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 		g.setFont(rowFont);
-		if (n > 0) {
-			s = n + "";
+		if (t > 0) {
+			s = t + "";
 			TextImage.drawString(g, s, width - BORDER - (fm.stringWidth("9999") + fm.stringWidth(s)) / 2, 5);
 		}
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
@@ -342,10 +342,10 @@ public class JudgePresentation extends AbstractScoreboardPresentation {
 					width - BORDER - fm.stringWidth(" 9999") - (fm.stringWidth("99") + fm.stringWidth(s)) / 2, 5);
 		}
 
-		n = standing.getTime();
+		long t = standing.getTime();
 		g.setFont(rowFont);
-		if (n > 0) {
-			String s = n + "";
+		if (t > 0) {
+			String s = t + "";
 			TextImage.drawString(g, s, width - BORDER - (fm.stringWidth("9999") + fm.stringWidth(s)) / 2, 5);
 		}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
@@ -62,7 +62,7 @@ public class TimelinePresentation extends AbstractScrollingScoreboardPresentatio
 			g.drawLine(width - 27, -7, width - 20, 0);
 			g.drawLine(width - 27, +7, width - 20, 0);
 
-			int numHours = contest.getDuration() / MS_PER_HOUR;
+			long numHours = contest.getDuration() / MS_PER_HOUR;
 
 			int hour = 0;
 			while (hour < numHours) {
@@ -129,7 +129,7 @@ public class TimelinePresentation extends AbstractScrollingScoreboardPresentatio
 
 		// draw vertical line for current time
 		g.setColor(ICPCColors.BLUE);
-		int currentTime = 0;
+		long currentTime = 0;
 		IState state = contest.getState();
 		if (state.getEnded() != null)
 			currentTime = contest.getDuration();
@@ -193,7 +193,7 @@ public class TimelinePresentation extends AbstractScrollingScoreboardPresentatio
 		}
 	}
 
-	private int getX(int contestTimeMs) {
+	private int getX(long contestTimeMs) {
 		return start + (int) (contestTimeMs * scale);
 	}
 

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -735,7 +735,7 @@ public class Resolver {
 		}
 
 		// check freeze time
-		Integer freeze = contest.getFreezeDuration();
+		Long freeze = contest.getFreezeDuration();
 		if (freeze == null || freeze < 0 || freeze > contest.getDuration())
 			Trace.trace(Trace.WARNING, "Warning: Contest has no freeze time, will assume default");
 	}


### PR DESCRIPTION
Who would do that, right? At least that's what I thought 15 years ago when I picked the Java int type. The max ms in int is about 29 days. (In my defence, it might have even been int minutes that long ago, i.e. 60 months) But GNY decided to leave a test contest running for over a month this year to give teams plenty of time to submit. This makes the contest go into negative time and none of the tools work.

The change is really simple... but completely pervasive. If contests can be longs, then so can freeze times, standings, last submission times, etc. May as well be able to pause a contest a month in advance too. Expect a lot of change, and odds are high I'll miss something in the first commit. :)