### PR TITLE
Team label support

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
@@ -262,7 +262,7 @@ public class BalloonPrinter {
 		g.drawString(s, (px - fm.stringWidth(s)) / 2, y + fm.getAscent());
 		y += fm.getHeight();
 
-		s = team.getId() + "";
+		s = team.getLabel() + "";
 		g.setFont(hugeFont);
 		fm = g.getFontMetrics();
 		if (fm.stringWidth(s) > px - 10) {

--- a/BalloonUtility/src/org/icpc/tools/balloon/SummaryPrint.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/SummaryPrint.java
@@ -127,7 +127,7 @@ public class SummaryPrint {
 
 				gc.drawString(submission.getId() + "", r.x + col[1], yy, true);
 
-				String s = team.getId() + ":";
+				String s = team.getLabel() + ":";
 				gc.drawString(s, r.x + col[2] + (int) (aw * 4.0) - gc.stringExtent(s).x, yy, true);
 
 				s = team.getActualDisplayName();

--- a/BalloonUtility/src/org/icpc/tools/balloon/TeamSummaryPrint.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/TeamSummaryPrint.java
@@ -154,7 +154,7 @@ public class TeamSummaryPrint {
 			gc.setForeground(gc.getDevice().getSystemColor(SWT.COLOR_BLACK));
 			gc.setFont(regularFont);
 
-			String s = team.getId() + ":";
+			String s = team.getLabel() + ":";
 			gc.drawString(s, r.x + col[0] + (int) (aw * 4.0) - gc.stringExtent(s).x, yy, true);
 
 			s = team.getActualDisplayName();

--- a/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
@@ -41,8 +41,8 @@
   <td><a href="{{api}}">{{id}}</a></td>
   <td class="text-center">{{{time}}}</td>
   <td class="text-center">{{#label}}<span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span>{{/label}}</td>
-  <td>{{#fromTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/fromTeam}}</td>
-  <td>{{#toTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/toTeam}}</td>
+  <td>{{#fromTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/fromTeam}}</td>
+  <td>{{#toTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/toTeam}}</td>
   <td>{{replyTo}}</td>
   <td class="pre-line">{{{text}}}</td>
 </script>

--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -65,8 +65,8 @@
 <script type="text/html" id="clarifications-template">
   <td class="text-center">{{{time}}}</td>
   <td class="text-center">{{#label}}<span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span>{{/label}}</td>
-  <td>{{#fromTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/fromTeam}}</td>
-  <td>{{#toTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/toTeam}}</td>
+  <td>{{#fromTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/fromTeam}}</td>
+  <td>{{#toTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/toTeam}}</td>
   <td class="pre-line">{{{text}}}</td>
 </script>
 <script type="text/javascript">
@@ -82,12 +82,6 @@ function clarificationsRefresh() {
         for (var i = 0; i < problems.length; i++) {
         	$('#problem-id').append('<option id="' + problems[i].id + '">' + problems[i].label + ': ' + problems[i].name + '</option>');
 		}
-
-        $.when(contest.loadAccess()).done(function () {
-            var access = contest.getAccess();
-            if (access.capabilities.some(e => e === 'team_clar'))
-    	        $("#submit-clar-ui").show();
-        })
     }).fail(function (result) {
     	console.log("Error loading clarifications: " + result);
     })
@@ -95,6 +89,12 @@ function clarificationsRefresh() {
 
 $(document).ready(function () {
 	clarificationsRefresh();
+	
+	$.when(contest.loadAccess()).done(function () {
+        var access = contest.getAccess();
+        if (access.capabilities.some(e => e === 'team_clar'))
+	        $("#submit-clar-ui").show();
+    })
 })
 
 function submitClarification() {

--- a/CDS/WebContent/WEB-INF/jsps/commentary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/commentary.jsp
@@ -39,7 +39,7 @@
   <td><a href="{{api}}">{{id}}</a></td>
   <td class="text-center">{{{time}}}</td>
   <td class="text-center">{{#problems}}<span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span>{{/problems}}</td>
-  <td>{{#teams}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/teams}}</td>
+  <td>{{#teams}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/teams}}</td>
   <td class="pre-line">{{{message}}}</td>
 </script>
 <script type="text/javascript">

--- a/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration-admin.jsp
@@ -148,6 +148,7 @@
 			                <tr>
 			                    <th class="text-center">Id</th>
 			                    <th></th>
+			                    <th class="text-center">Label</th>
 			                    <th>Name</th>
 			                    <th>Organization</th>
 			                    <th>Group</th>
@@ -180,6 +181,7 @@
 <script type="text/html" id="teams-template">
   <td class="text-right"><a href="{{api}}">{{id}}</a></td>
   <td style="width: 20px;" class="text-center">{{#logo}}<img src="{{{logo}}}" width="20" height="20"/>{{/logo}}</td>
+  <td>{{label}}</td>
   <td>{{name}}</td>
   <td>{{orgName}}</td>
   <td>{{groupNames}}</td>

--- a/CDS/WebContent/WEB-INF/jsps/registration.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/registration.jsp
@@ -19,7 +19,7 @@
 			        <table id="teams-table" class="table table-sm table-hover table-striped table-head-fixed">
 			            <thead>
 			                <tr>
-			                    <th class="text-center">#</th>
+			                    <th class="text-center">Label</th>
 			                    <th></th>
 			                    <th>Name</th>
 			                    <th>Organization</th>
@@ -75,7 +75,7 @@
     </div>
 </div>
 <script type="text/html" id="teams-template">
-  <td class="text-right">{{id}}</td>
+  <td class="text-right">{{label}}</td>
   <td style="width: 20px;" class="text-center">{{#logo}}<img src="{{{logo}}}" width="20" height="20"/>{{/logo}}</td>
   <td>{{name}}</td>
   <td>{{orgName}}</td>

--- a/CDS/WebContent/WEB-INF/jsps/submissions-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions-admin.jsp
@@ -38,7 +38,7 @@
   <td class="text-center">{{time}}</td>
   <td class="text-center"><span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span></td>
   <td class="text-center">{{lang}}</td>
-  <td>{{#team}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/team}}</td>
+  <td>{{#team}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/team}}</td>
   <td>{{#team}}{{orgName}}{{/team}}</td>
   <td class="text-center">{{{judge}}}</td>
 </script>

--- a/CDS/WebContent/WEB-INF/jsps/submissions.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/submissions.jsp
@@ -35,7 +35,7 @@
   <td class="text-center">{{{time}}}</td>
   <td class="text-center"><span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span></td>
   <td class="text-center">{{lang}}</td>
-  <td>{{#team}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{id}}: {{name}}{{/team}}</td>
+  <td>{{#team}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/team}}</td>
   <td>{{#team}}{{orgName}}{{/team}}</td>
   <td class="text-center">{{{result}}}</td>
 </script>

--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -33,6 +33,11 @@
                             </td>
                         </tr>
                         <tr>
+                            <td><b>Label:</b></td>
+                            <td><%= team.getLabel() %>
+                            </td>
+                        </tr>
+                        <tr>
                             <td><b>Display Name:</b></td>
                             <td><%= team.getDisplayName() == null ? "" : HttpHelper.sanitizeHTML(team.getDisplayName()) %>
                             </td>

--- a/CDS/WebContent/WEB-INF/jsps/video.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/video.jsp
@@ -44,7 +44,7 @@
                             if (org != null)
                                 orgName = org.getName(); %>
                             <tr>
-                                <td><%= tId %>
+                                <td><%= t.getLabel() %>
                                 </td>
                                 <td><%= HttpHelper.sanitizeHTML(t.getActualDisplayName()) %>
                                 </td>

--- a/CDS/WebContent/focusScoreboard.jsp
+++ b/CDS/WebContent/focusScoreboard.jsp
@@ -56,7 +56,7 @@ Status: <span id="status">ready</span>
 %>
 
 <tr>
-<td><button id="team<%= t.getId() %>" onclick="sendCommand('<%= t.getId() %>')"><%= t.getId() %></button></td>
+<td><button id="team<%= t.getId() %>" onclick="sendCommand('<%= t.getId() %>')"><%= t.getLabel() %></button></td>
 <td><%= t.getActualDisplayName() %></td>
 <td id="current<%= t.getId() %>">-</td>
 </tr>

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -123,7 +123,7 @@ function teamsTd(team) {
     if (team.hidden != null)
         hidden = "true";
 
-    return { id: team.id, name: name, logo: logoSrc, orgName: orgName, groupNames: groupNames, hidden: hidden };
+    return { id: team.id, label: team.label, name: name, logo: logoSrc, orgName: orgName, groupNames: groupNames, hidden: hidden };
 }
 
 function personsTd(person) {

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -301,7 +301,7 @@ function getDisplayStr(teamId) {
 
 	team = findById(contest.getTeams(), teamId);
     if (team != null)
-		return teamId + ': ' + getDisplayName(team);
+		return team.label + ': ' + getDisplayName(team);
 	
 	return teamId + ': (not found)';
 }

--- a/CDS/WebContent/solvedSubmissionList.jsp
+++ b/CDS/WebContent/solvedSubmissionList.jsp
@@ -31,7 +31,7 @@
 
 <tr>
 <td><%= r.getId() %></td>
-<td><%= team.getId() %> - <%= team.getActualDisplayName() %></td>
+<td><%= team.getLabel() %> - <%= team.getActualDisplayName() %></td>
 <td><a href="/video/reaction/<%= r.getId() %>">Reaction</a></td>
 </tr>
 <% } %>

--- a/CDS/WebContent/submissionList.jsp
+++ b/CDS/WebContent/submissionList.jsp
@@ -29,7 +29,7 @@
 
 <tr>
 <td><%= r.getId() %></td>
-<td><%= team.getId() %> - <%= team.getActualDisplayName() %></td>
+<td><%= team.getLabel() %> - <%= team.getActualDisplayName() %></td>
 <td>
 <% if (r.isSolved()) {%>
 Solved

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -629,11 +629,11 @@ public class CoachView extends Panel {
 					max = s.length;
 
 				if (max == 1) {
-					teamList.add(team.getId() + ": " + team.getActualDisplayName());
+					teamList.add(team.getLabel() + ": " + team.getActualDisplayName());
 					selections.add(new TeamSelect(i, 0));
 				} else {
 					for (int j = 0; j < max; j++) {
-						teamList.add(team.getId() + ": " + team.getActualDisplayName() + " (" + (j + 1) + ")");
+						teamList.add(team.getLabel() + ": " + team.getActualDisplayName() + " (" + (j + 1) + ")");
 						selections.add(new TeamSelect(i, j));
 					}
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
@@ -585,12 +585,13 @@ public class FloorMap {
 				gg.draw(tr);
 
 			FontMetrics fm = gg.getFontMetrics();
-			if (id != null) {
+			String label = t.getLabel();
+			if (label != null) {
 				AffineTransform transform2 = AffineTransform.getRotateInstance(Math.toRadians(90));
 				AffineTransform at = gg.getTransform();
 				at.concatenate(transform2);
 				gg.setTransform(at);
-				gg.drawString(id, -fm.stringWidth(id) / 2f, (fm.getAscent() - 3.5f) / 2f);
+				gg.drawString(label, -fm.stringWidth(label) / 2f, (fm.getAscent() - 3.5f) / 2f);
 			}
 			gg.dispose();
 		}
@@ -757,14 +758,15 @@ public class FloorMap {
 
 			gg.setColor(colors.getTextColor());
 
-			if (id != null && img == null) {
+			String label = t.getLabel();
+			if (label != null && img == null) {
 				AffineTransform transform2 = AffineTransform.getRotateInstance(Math.toRadians(90));
 				if (t.getRotation() == 270)
 					transform2 = AffineTransform.getRotateInstance(Math.toRadians(t.getRotation()));
 				AffineTransform at = gg.getTransform();
 				at.concatenate(transform2);
 				gg.setTransform(at);
-				gg.drawString(id, -fm.stringWidth(id) / 2f, (fm.getAscent() - 3.5f) / 2f);
+				gg.drawString(label, -fm.stringWidth(label) / 2f, (fm.getAscent() - 3.5f) / 2f);
 			}
 			gg.dispose();
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/IProblem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IProblem.java
@@ -17,7 +17,7 @@ public interface IProblem extends IContestObject, IPosition {
 	/**
 	 * The problem label, typically a simple letter or number like "A".
 	 *
-	 * @return the name
+	 * @return the label
 	 */
 	String getLabel();
 

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
@@ -8,6 +8,13 @@ import java.io.File;
  */
 public interface ITeam extends IContestObject, IPosition {
 	/**
+	 * The team label, typically the team number or short identifier. e.g. "15".
+	 *
+	 * @return the label
+	 */
+	String getLabel();
+
+	/**
 	 * The name of the team.
 	 *
 	 * @return the name

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -14,6 +14,7 @@ import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 public class Team extends ContestObject implements ITeam {
 	private static final String NAME = "name";
 	private static final String DISPLAY_NAME = "display_name";
+	private static final String LABEL = "label";
 	private static final String GROUP_IDS = "group_ids";
 	private static final String ORGANIZATION_ID = "organization_id";
 	private static final String ICPC_ID = "icpc_id";
@@ -33,6 +34,7 @@ public class Team extends ContestObject implements ITeam {
 
 	private String name;
 	private String displayName;
+	private String label;
 	private String[] groupIds;
 	private String organizationId;
 	private String icpcId;
@@ -67,6 +69,11 @@ public class Team extends ContestObject implements ITeam {
 	@Override
 	public String getICPCId() {
 		return icpcId;
+	}
+
+	@Override
+	public String getLabel() {
+		return label;
 	}
 
 	@Override
@@ -312,10 +319,16 @@ public class Team extends ContestObject implements ITeam {
 			}
 			case NAME: {
 				name = (String) value;
+				if (label == null)
+					label = id;
 				return true;
 			}
 			case DISPLAY_NAME: {
 				displayName = (String) value;
+				return true;
+			}
+			case LABEL: {
+				label = (String) value;
 				return true;
 			}
 			case LOCATION: {
@@ -380,6 +393,7 @@ public class Team extends ContestObject implements ITeam {
 		t.audio = audio;
 		t.name = name;
 		t.displayName = displayName;
+		t.label = label;
 		t.groupIds = groupIds;
 		t.organizationId = organizationId;
 		t.icpcId = icpcId;
@@ -393,6 +407,7 @@ public class Team extends ContestObject implements ITeam {
 	@Override
 	protected void getProperties(Properties props) {
 		props.addLiteralString(ID, id);
+		props.addString(LABEL, label);
 		props.addString(NAME, name);
 		props.addString(DISPLAY_NAME, displayName);
 		props.addLiteralString(ICPC_ID, icpcId);

--- a/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
@@ -258,7 +258,7 @@ public class EventFeedUtil {
 				IStanding standing = contest.getStanding(team);
 				Trace.trace(Trace.USER,
 						"  " + standing.getRank() + " " + standing.getNumSolved() + " " + standing.getTime());
-				Trace.trace(Trace.USER, "    " + team.getId() + ": " + team.getActualDisplayName() + " ("
+				Trace.trace(Trace.USER, "    " + team.getLabel() + ": " + team.getActualDisplayName() + " ("
 						+ getGroupLabel(contest, team) + ")");
 			}
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -120,14 +120,14 @@ public class ImagesGenerator {
 				File from = new File(args[0], "images" + File.separator + "logo" + File.separator + t.getId() + ".png");
 				File to = new File(args[0],
 						"images" + File.separator + "logo" + File.separator + t.getOrganizationId() + ".png");
-
+		
 				if (from.exists())
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
-
+		
 				from = new File(args[0], "images" + File.separator + "tile" + File.separator + t.getId() + ".png");
 				to = new File(args[0],
 						"images" + File.separator + "tile" + File.separator + t.getOrganizationId() + ".png");
-
+		
 				if (from.exists())
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
 			}
@@ -333,7 +333,7 @@ public class ImagesGenerator {
 		ITeam[] teams = contest.getTeams();
 		for (ITeam team : teams) {
 			Trace.trace(Trace.USER,
-					"Generating desktop background for: " + team.getId() + " - " + team.getActualDisplayName());
+					"Generating desktop background for: " + team.getLabel() + " - " + team.getActualDisplayName());
 
 			String teamId = team.getId();
 			String name = team.getActualDisplayName();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -190,7 +190,7 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 				}
 				String label = t.getLabel() + " - " + t.getActualDisplayName();
 				if (showOrganizations) {
-					label = t.getLabel() + " - " + org.getFormalName();
+					label = org.getFormalName();
 				}
 				Position p = new Position(lon, lat, 1, label);
 				createOrgLogo(p, org, height);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -139,6 +139,7 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 		if (contest == null)
 			return;
 
+		// TODO don't include empty groups
 		IGroup[] groups = contest.getGroups();
 		int numGroups = groups.length;
 		zooms = new GroupZoom[numGroups];
@@ -187,9 +188,9 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 					minLon = Math.min(minLon, lon);
 					maxLon = Math.max(maxLon, lon);
 				}
-				String label = t.getId() + " - " + t.getActualDisplayName();
+				String label = t.getLabel() + " - " + t.getActualDisplayName();
 				if (showOrganizations) {
-					label = org.getFormalName();
+					label = t.getLabel() + " - " + org.getFormalName();
 				}
 				Position p = new Position(lon, lat, 1, label);
 				createOrgLogo(p, org, height);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/SingleTeamPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/SingleTeamPresentation.java
@@ -21,7 +21,7 @@ public class SingleTeamPresentation extends AbstractScoreboardPresentation {
 		try {
 			ITeam[] teams = getContest().getTeams();
 			for (ITeam t : teams) {
-				if (value.equals(t.getId()))
+				if (value.equals(t.getId()) || value.equals(t.getLabel()))
 					teamId = t.getId();
 			}
 		} catch (Exception e) {

--- a/Resolver/src/org/icpc/tools/resolver/awards/AbstractAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AbstractAwardDialog.java
@@ -95,7 +95,7 @@ public abstract class AbstractAwardDialog extends Dialog {
 							IStanding standing = previewContest.getStanding(team);
 
 							TableItem ti = new TableItem(previewTable, SWT.NONE);
-							ti.setText(new String[] { standing.getRank(), team.getId(), team.getActualDisplayName(),
+							ti.setText(new String[] { standing.getRank(), team.getLabel(), team.getActualDisplayName(),
 									award.getCitation() });
 						}
 					}

--- a/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
@@ -563,7 +563,7 @@ public class AwardUI {
 			IStanding standing = contest.getStanding(team);
 			String awardStr = getAwardString(team);
 			String groupName = getGroupLabel(team);
-			ti.setText(new String[] { standing.getRank(), team.getId(), team.getActualDisplayName(), groupName,
+			ti.setText(new String[] { standing.getRank(), team.getLabel(), team.getActualDisplayName(), groupName,
 					standing.getNumSolved() + "", standing.getTime() + "", awardStr });
 		}
 	}


### PR DESCRIPTION
We're adding team labels to the Contest API, so we need to match this throughout the tools.

This PR covers:
- The actual API change.
- Default label to the id if it isn't present (this is a bit of a hack done when the name is set - couldn't think of a cleaner way). This ensures that clients can always rely on the label and it is there even if the CCS/contest package doesn't have one.
- Impact to all downstream clients: balloon printer, coach view, presentations, award util, and CDS web views.

Could I have missed something? Sure. I did a pretty thorough search which turned up all the impacts that I could think of, but until we test at NAC we won't know for sure. For now I switched all 'user output/messages' to labels, but left the few internal log messages as id because that's what you'll need for things like API lookup.