### PR TITLE
Judges & posting commentary

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
@@ -36,6 +36,33 @@
 			</div>
 		</div>
     </div>
+    <div class="row" id="submit-clar-ui" style="display: none">
+        <div class="col-12">
+			<div class="card">
+			    <div class="card-header">
+			        <h4 class="card-title">Submit Clarification</h4>
+			        <div class="card-tools">
+			        	<div id="clar-status"></div>
+			        </div>
+			    </div>
+			    <div class="card-body">
+			      <div class="form-group row">
+                       <label class="col-sm-2 col-form-label">Problem</label>
+                       <select id="problem-id" class="col-sm-3 custom-select">
+                         <option id="*No Selection*">None</option>
+                       </select>
+                     </div>
+                     <div class="form-group row">
+                       <label class="col-sm-2 col-form-label">Clarification</label>  
+			        <textarea id="text" class="col-sm-10 form-control" placeholder="Enter clarification..."></textarea>
+			      </div>
+			    </div>
+			    <div class="card-footer">
+                  <button type="submit" class="btn btn-primary" onclick="submitClarification()">Submit</button>
+                </div>
+			</div>
+        </div>
+    </div>
 </div>
 <script type="text/html" id="clarifications-template">
   <td><a href="{{api}}">{{id}}</a></td>
@@ -61,17 +88,24 @@ function clarificationsRefresh() {
 
 $(document).ready(function () {
 	clarificationsRefresh();
+	
+	$.when(contest.loadAccess()).done(function () {
+        var access = contest.getAccess();
+        if (access.capabilities.some(e => (e === 'team_clar' || e === 'admin_clar')))
+	        $("#submit-clar-ui").show();
+    })
 })
 
-function submitClarification(to_team, text) {
-	var obj = { to_team_id: to_team, text: text };
-	console.log(obj);
-	console.log(JSON.stringify(obj));
+function submitClarification() {
+	var obj = { text: $('#text').val() };
+	prob = $('#problem-id').children(":selected").attr("id");
+	if (prob != '*No Selection*')
+		obj.problem_id = $('#problem-id').children(":selected").attr("id");
 	contest.postClarification(JSON.stringify(obj), function(body) {
-		$('#object-status').text("Posted successfully: " + body);
+		$('#clar-status').text("Posted successfully");
 	}, function(result) {
-		$('#object-status').text("Post failed: " + result.responseText);
-	})
+		$('#clar-status').text("Post failed: " + result.responseText);
+	});
 }
 
 updateContestClock(contest, "contest-time");

--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -55,8 +55,8 @@
 			      </div>
 			    </div>
 			    <div class="card-footer">
-                     <button type="submit" class="btn btn-primary" onclick="submitClarification()">Submit</button>
-                   </div>
+                  <button type="submit" class="btn btn-primary" onclick="submitClarification()">Submit</button>
+                </div>
 			</div>
         </div>
     </div>
@@ -92,8 +92,8 @@ $(document).ready(function () {
 	
 	$.when(contest.loadAccess()).done(function () {
         var access = contest.getAccess();
-        if (access.capabilities.some(e => e === 'team_clar'))
-	        $("#submit-clar-ui").show();
+        if (access.capabilities.some(e => (e === 'team_clar' || e === 'admin_clar')))
+	      $("#submit-clar-ui").show();
     })
 })
 
@@ -106,7 +106,7 @@ function submitClarification() {
 		$('#clar-status').text("Submitted successfully");
 	}, function(result) {
 		$('#clar-status').html("Not accepted: " + sanitizeHTML(result));
-	})
+	});
 }
 
 updateContestClock(contest, "contest-time");

--- a/CDS/WebContent/WEB-INF/jsps/commentary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/commentary.jsp
@@ -1,11 +1,28 @@
 <% request.setAttribute("title", "Commentary"); %>
 <%@ include file="layout/head.jsp" %>
 <script src="${pageContext.request.contextPath}/js/contest.js"></script>
+<script src="${pageContext.request.contextPath}/js/cds.js"></script>
 <script src="${pageContext.request.contextPath}/js/model.js"></script>
 <script src="${pageContext.request.contextPath}/js/ui.js"></script>
 <script src="${pageContext.request.contextPath}/js/types.js"></script>
 <script src="${pageContext.request.contextPath}/js/mustache.min.js"></script>
 <div class="container-fluid">
+	<div class="row" id="submit-comment-ui" style="display: none">
+        <div class="col-12">
+			<div class="card">
+			    <div class="card-header">
+			        <h4 class="card-title">Submit Commentary</h4>
+			        <div class="card-tools">
+			        	<div id="comm-status"></div>
+			        </div>
+			    </div>
+			    <div class="card-body p-0">
+				    <textarea class="form-control" rows="2" id="commentary-message" placeholder="Commentary"></textarea>
+					<button type="button" onclick="postCommentary()">Post</button>
+			    </div>
+			</div>
+		</div>
+    </div>
     <div class="row">
         <div class="col-12">
 			<div class="card">
@@ -44,6 +61,7 @@
 </script>
 <script type="text/javascript">
 contest = new Contest("/api", "<%= cc.getId() %>");
+cds.setContestId("<%= cc.getId() %>");
 registerContestObjectTable("commentary");
 
 function commentaryRefresh() {
@@ -55,8 +73,23 @@ function commentaryRefresh() {
     })
 }
 
+function postCommentary() {
+	var obj = { message: $('#commentary-message').val() };
+	contest.postCommentary(JSON.stringify(obj), function(body) {
+		$('#comm-status').text("Submitted successfully");
+	}, function(result) {
+		$('#comm-status').html("Not accepted: " + sanitizeHTML(result));
+	})
+}
+
 $(document).ready(function () {
 	commentaryRefresh();
+	
+	$.when(contest.loadAccess()).done(function () {
+        var access = contest.getAccess();
+        if (access.capabilities.some(e => e === 'commentary_submit'))
+	        $("#submit-comment-ui").show();
+    })
 })
 
 updateContestClock(contest, "contest-time");

--- a/CDS/WebContent/js/contest.js
+++ b/CDS/WebContent/js/contest.js
@@ -273,6 +273,7 @@ class Contest {
 		this.submissions = null;
 		this.judgements = null;
 		this.clarifications = null;
+		this.commentary = null;
 	}
 
 	post(type, body, success, error) {
@@ -281,6 +282,7 @@ class Contest {
 		    url: this.getURL(type),
 		    method: 'POST',
 		    headers: { "Accept": "application/json" },
+		    contentType: "application/json; charset=utf-8",
 		    data: body,
 		    success: success,
 		    error: function(result, ajaxOptions, thrownError) {
@@ -300,6 +302,10 @@ class Contest {
 
 	postClarification(obj, success, error) {
         this.post('clarifications', obj, success, error);
+	}
+
+	postCommentary(obj, success, error) {
+        this.post('commentary', obj, success, error);
 	}
 }
 

--- a/CDS/src/org/icpc/tools/cds/AccessService.java
+++ b/CDS/src/org/icpc/tools/cds/AccessService.java
@@ -34,10 +34,15 @@ public class AccessService {
 				caps.add("team_submit");
 				caps.add("team_clar");
 			}
+			if ("judge".equals(type)) {
+				caps.add("admin_clar");
+				caps.add("commentary_submit");
+			}
 			if ("admin".equals(type)) {
 				caps.add("contest_start");
 				caps.add("admin_submit");
 				caps.add("admin_clar");
+				caps.add("commentary_submit");
 			}
 		}
 		String user = request.getRemoteUser();

--- a/CDS/src/org/icpc/tools/cds/CDSAuth.java
+++ b/CDS/src/org/icpc/tools/cds/CDSAuth.java
@@ -133,7 +133,8 @@ public class CDSAuth implements HttpAuthenticationMechanism {
 		IAccount account = getAccount(request);
 		if (account == null)
 			return false;
-		return IAccount.STAFF.equals(account.getAccountType()) || IAccount.ADMIN.equals(account.getAccountType());
+		return IAccount.STAFF.equals(account.getAccountType()) || IAccount.ADMIN.equals(account.getAccountType())
+				|| IAccount.JUDGE.equals(account.getAccountType());
 	}
 
 	public static boolean isAnalyst(HttpServletRequest request) {

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -864,7 +864,15 @@ public class ConfiguredContest {
 		if (account == null)
 			return false;
 		String type = account.getAccountType();
-		return IAccount.ADMIN.equals(type) || IAccount.STAFF.equals(type);
+		return IAccount.ADMIN.equals(type) || IAccount.STAFF.equals(type) || IAccount.JUDGE.equals(type);
+	}
+
+	public boolean isJudge(HttpServletRequest request) {
+		IAccount account = getAccount(request.getRemoteUser());
+		if (account == null)
+			return false;
+		String type = account.getAccountType();
+		return IAccount.ADMIN.equals(type) || IAccount.JUDGE.equals(type);
 	}
 
 	public boolean isAnalyst(HttpServletRequest request) {


### PR DESCRIPTION
Initial support for logging into the CDS as an judge, and having access to post clarifications and commentary. For now only simple messages work, no ability to select a team or problem.

- Added support for judge account type, treating them like staff (read-only access to everything).
- Added new commentary_submit capability, and gave judges both it and admin_clar.
- Added /access support for judge account type.
- Made the support for POSTing objects to the CDS more generic and added support for posting commentary.
- Added basic support for posting a commentary message from the CDS web and fixed a number of issues and gaps in posting clarifications.
- Added support for judges and admins to post clarifications in the web UI.
- Fixed a few bugs when posting other content types or using an invalid URL.