### PR TITLE
Resource loading updates

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -15,6 +15,7 @@ import javax.servlet.AsyncContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.websocket.Session;
 
+import org.icpc.tools.cds.service.ExecutorListener;
 import org.icpc.tools.cds.util.PlaybackContest;
 import org.icpc.tools.cds.video.VideoAggregator;
 import org.icpc.tools.cds.video.VideoAggregator.ConnectionMode;
@@ -630,6 +631,7 @@ public class ConfiguredContest {
 
 			contestSource.setInitialContest(pc);
 			contest = contestSource.getContest();
+			contestSource.setExecutor(ExecutorListener.getExecutor());
 
 			if (isTesting())
 				contest.setHashCode(contest.hashCode() + (int) (Math.random() * 500.0));

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -49,6 +49,9 @@ public class PlaybackContest extends Contest {
 	private static final String COUNTRY_FLAG = "country_flag";
 	private static final String PACKAGE = "package";
 	private static final String STATEMENT = "statement";
+	private static final String BACKUP = "backup";
+	private static final String KEY_LOG = "key_log";
+	private static final String TOOL_DATA = "tool_data";
 
 	protected ConfiguredContest cc;
 	protected String contestId;
@@ -162,7 +165,9 @@ public class PlaybackContest extends Contest {
 			Team t = (Team) obj;
 			downloadMissingFiles(src, obj, PHOTO, t.getPhoto());
 			downloadMissingFiles(src, obj, VIDEO, t.getVideo());
-			// later: backup, key_log or tool data
+			downloadMissingFiles(src, obj, BACKUP, t.getBackup());
+			downloadMissingFiles(src, obj, KEY_LOG, t.getKeyLog());
+			downloadMissingFiles(src, obj, TOOL_DATA, t.getToolData());
 			src.attachLocalResources(t);
 		} else if (obj instanceof Person) {
 			Person tm = (Person) obj;


### PR DESCRIPTION
- Support default team and person photo. Drop a photo in 'default-id' folder for either and it'll be used whenever there is no photo (issue #534).
- Correctly support .jpeg file extension mime-type.
- Add support for downloading backup, key log, and tool data from contest source (CCS). Not there today, but keeps things consistent.