### PR TITLE
Add support for showing (colored) contest title in most presentations.

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/AbstractICPCPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/AbstractICPCPresentation.java
@@ -14,8 +14,9 @@ public abstract class AbstractICPCPresentation extends Presentation {
 	private IContest contest = ContestData.getContest();
 
 	private Font contestTitleFont;
-	private final int contestTitleHeight = 20;
-	private final int contestTitleMargin = 2;
+	private int contestTitleHeight;
+	private final double contestTitleMarginPercentage = 0.1; // Percentage of contestTitleHeight
+	private int contestTitleMargin;
 	private BufferedImage contestTitleImage;
 	private static String contestTitleTemplate;
 	protected static Color contestTitleColor;
@@ -24,6 +25,10 @@ public abstract class AbstractICPCPresentation extends Presentation {
 		final float dpi = 96;
 		float size = (int) (height * 72.0 * 0.028 / dpi);
 		contestTitleFont = ICPCFont.deriveFont(Font.BOLD, size * 2.2f);
+
+		Canvas c = new Canvas();
+		contestTitleHeight = c.getFontMetrics(contestTitleFont).getHeight();
+		contestTitleMargin = (int)(contestTitleHeight * contestTitleMarginPercentage);
 
 		contestTitleImage = createContestTitleImage();
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.presentation.contest.internal;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.util.List;
 
@@ -37,6 +38,13 @@ public class ClientLauncher {
 		System.out.println("     --multi-display p@wxh");
 		System.out.println("         Stretch the presentation across multiple clients. Use \"2@3x2\"");
 		System.out.println("         to indicate this client is position 2 (top middle) in a 3x2 grid");
+		System.out.println("     --contestTitle");
+		System.out.println("         Set the contest title of the presentations to the contest name");
+		System.out.println("     --contestTitleTemplate template");
+		System.out.println("         Set the contest title of the presentations using a template. Parameters:");
+		System.out.println("         {contest.name) and {contest.formal_name)");
+		System.out.println("     --contestTitleColor");
+		System.out.println("         Set the contest title color of the presentations. Currently supports `blue` and `yellow`");
 		System.out.println("     --light");
 		System.out.println("         Use light mode");
 		System.out.println("     --help");
@@ -52,6 +60,8 @@ public class ClientLauncher {
 		String[] nameStr = new String[1];
 		String[] displayStr = new String[2];
 		String[] displayName = new String[1];
+		String[] contestTitle = new String[1];
+		Color[] contestTitleColor = new Color[1];
 		boolean[] lightMode = new boolean[1];
 		ContestSource contestSource = ArgumentParser.parse(args, new OptionParser() {
 			@Override
@@ -68,12 +78,25 @@ public class ClientLauncher {
 					ArgumentParser.expectOptions(option, options, "p@wxh:string");
 					displayStr[1] = (String) options.get(0);
 					return true;
+				} else if ("--contestTitle".equalsIgnoreCase(option)) {
+					ArgumentParser.expectNoOptions(option, options);
+					contestTitle[0] = "{contest.name}";
+					return true;
+				} else if ("--contestTitleTemplate".equalsIgnoreCase(option)) {
+					ArgumentParser.expectOptions(option, options, "contestTitleTemplate:string");
+					contestTitle[0] = (String) options.get(0);
+					return true;
+				} else if ("--contestTitleColor".equalsIgnoreCase(option)) {
+					ArgumentParser.expectOptions(option, options, "contestTitleColor:string");
+					String contestTitleColorString = (String) options.get(0);
+					try {
+						contestTitleColor[0] = Color.decode(contestTitleColorString);
+					} catch (NumberFormatException e) {
+						throw new IllegalArgumentException("Invalid contest title color " + contestTitleColorString);
+					}
+					return true;
 				} else if ("--light".equals(option)) {
 					lightMode[0] = true;
-					return true;
-				} else if ("--display_name".equals(option)) {
-					ArgumentParser.expectOptions(option, options, "display_name:string");
-					displayName[0] = (String) options.get(0);
 					return true;
 				}
 				return false;
@@ -98,6 +121,8 @@ public class ClientLauncher {
 			TeamDisplay.overrideDisplayName(cdsSource.getContest(), displayName[0]);
 
 		String name = nameStr[0];
+		AbstractICPCPresentation.setContestTitleTemplate(contestTitle[0]);
+		AbstractICPCPresentation.setContestTitleColor(contestTitleColor[0]);
 		PresentationClient client = null;
 		if ("team".equals(name)) {
 			String teamLabel = TeamUtil.getTeamId();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -44,7 +44,7 @@ public class ClientLauncher {
 		System.out.println("         Set the contest title of the presentations using a template. Parameters:");
 		System.out.println("         {contest.name) and {contest.formal_name)");
 		System.out.println("     --contestTitleColor");
-		System.out.println("         Set the contest title color of the presentations. Currently supports `blue` and `yellow`");
+		System.out.println("         Set the contest title color of the presentations. Supports hex colors starting with #");
 		System.out.println("     --light");
 		System.out.println("         Use light mode");
 		System.out.println("     --help");

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCColors.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCColors.java
@@ -88,4 +88,14 @@ public class ICPCColors {
 
 		return ICPCColors.PENDING2[k];
 	}
+
+	public static Color foregroundColor(Color background) {
+		int r = background.getRed();
+		int g = background.getGreen();
+		int b = background.getBlue();
+		// http://www.w3.org/TR/AERT#color-contrast
+		int brightness = (int)Math.round(((r * 299) + (g * 587) + (b * 114)) / 1000.0);
+
+		return brightness > 125 ? Color.black : Color.white;
+	}
 }

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/CommentaryPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/CommentaryPresentation.java
@@ -169,7 +169,7 @@ public class CommentaryPresentation extends TitledPresentation {
 	}
 
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ICPCTeamPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ICPCTeamPresentation.java
@@ -30,7 +30,7 @@ public class ICPCTeamPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		int h = 0;
 		if (image != null) {
 			int w = image.getWidth();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/MessagePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/MessagePresentation.java
@@ -35,7 +35,7 @@ public class MessagePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
 		int h = 0;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoFadePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoFadePresentation.java
@@ -52,7 +52,7 @@ public class OrgLogoFadePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoSlidePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoSlidePresentation.java
@@ -45,7 +45,7 @@ public class OrgLogoSlidePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 		g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoWallPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoWallPresentation.java
@@ -61,7 +61,7 @@ public class OrgLogoWallPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
 		IContest contest = getContest();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/PersonPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/PersonPresentation.java
@@ -40,7 +40,7 @@ public class PersonPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 
 		if (photo != null)

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemColorsPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemColorsPresentation.java
@@ -168,7 +168,7 @@ public class ProblemColorsPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		if (problemInfos == null)
 			return;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummaryPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/ProblemSummaryPresentation.java
@@ -75,7 +75,7 @@ public class ProblemSummaryPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/SnakePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/SnakePresentation.java
@@ -62,7 +62,7 @@ public class SnakePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		double time = getRepeatTimeMs();
 		Color color = ICPCColors.BLUE;
 		double start = (double) (x - min) * WAVE_TIME_MS / (max - min);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/StaticLogoPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/StaticLogoPresentation.java
@@ -25,7 +25,7 @@ public class StaticLogoPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		if (image != null)
 			g.drawImage(image, (width - image.getWidth()) / 2, (height - image.getHeight()) / 2, null);
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -241,7 +241,7 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamJudgePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamJudgePresentation.java
@@ -182,7 +182,7 @@ public class TeamJudgePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		SubmissionRecord[] submissions2 = null;
 		synchronized (submissions) {
 			submissions2 = submissions.toArray(new SubmissionRecord[0]);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TitledPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TitledPresentation.java
@@ -134,7 +134,7 @@ public abstract class TitledPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
@@ -156,11 +156,11 @@ public abstract class TitledPresentation extends AbstractICPCPresentation {
 		Graphics2D g2 = (Graphics2D) g.create();
 		g2.translate(0, headerHeight + titleHeight);
 		g2.setClip(0, 0, width, height - headerHeight - titleHeight);
-		paintImpl(g2);
+		paintImplTitled(g2);
 		g2.dispose();
 	}
 
-	protected abstract void paintImpl(Graphics2D g);
+	protected abstract void paintImplTitled(Graphics2D g);
 
 	@Override
 	public void setProperty(String value) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/WavePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/WavePresentation.java
@@ -86,7 +86,7 @@ public class WavePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		long timeMs = getRepeatTimeMs();
 		double time = timeMs * speed;
 		long waveWidth = WAVE_WIDTH_MS;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/ClockPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/ClockPresentation.java
@@ -17,6 +17,11 @@ public class ClockPresentation extends AbstractICPCPresentation {
 	private BufferedImage image;
 	protected int verticalOffset;
 
+	@Override
+	protected boolean shouldDrawContestTitle() {
+		return false;
+	}
+
 	protected Long getClock() {
 		IContest contest = getContest();
 		if (contest == null)
@@ -60,7 +65,7 @@ public class ClockPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
@@ -21,6 +21,11 @@ public class CountdownPresentation extends ClockPresentation {
 	}
 
 	@Override
+	protected boolean shouldDrawContestTitle() {
+		return false;
+	}
+
+	@Override
 	public void setProperty(String value) {
 		super.setProperty(value);
 		if (value == null || value.isEmpty())

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/floor/BalloonFloorPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/floor/BalloonFloorPresentation.java
@@ -234,7 +234,7 @@ public class BalloonFloorPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/floor/ContestFloorPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/floor/ContestFloorPresentation.java
@@ -46,7 +46,7 @@ public class ContestFloorPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
@@ -290,7 +290,7 @@ public class BalloonMapPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/GroupPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/GroupPresentation.java
@@ -118,7 +118,7 @@ public class GroupPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -284,7 +284,7 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/WorldPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/WorldPresentation.java
@@ -91,7 +91,7 @@ public class WorldPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		WorldMap.drawMap(g, width, height);
 
 		if (organizationGroups.isEmpty())

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/AbstractTickerPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/AbstractTickerPresentation.java
@@ -184,7 +184,7 @@ public class AbstractTickerPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		paintBackground(g);
 
 		if (verticalTicker)

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/BalloonPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/BalloonPresentation.java
@@ -91,7 +91,7 @@ public class BalloonPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setFont(textFont);
 		FontMetrics fm = g.getFontMetrics();
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/FloorNamePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/FloorNamePresentation.java
@@ -23,7 +23,7 @@ public class FloorNamePresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest contest = getContest();
 		if (floor == null)
 			floor = new FloorMap(contest);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/FloorPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/FloorPresentation.java
@@ -39,7 +39,7 @@ public class FloorPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/LogScreenPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/LogScreenPresentation.java
@@ -62,7 +62,7 @@ public class LogScreenPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		float index = getTimeMs() / 1000f;
 		// g.setColor(Color.blue);
 		// g.fillRect((1280-640)/2, 50, 640, 480);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/SolvedPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/SolvedPresentation.java
@@ -103,7 +103,7 @@ public class SolvedPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		if (currentRun == null) {
 			if (runs.isEmpty())
 				return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/TeamPicturesPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/TeamPicturesPresentation.java
@@ -55,7 +55,7 @@ public class TeamPicturesPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		if (current == null)
 			return;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/OrgsPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/OrgsPresentation.java
@@ -220,7 +220,7 @@ public class OrgsPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/SplashPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/SplashPresentation.java
@@ -30,6 +30,11 @@ public class SplashPresentation extends AbstractICPCPresentation {
 	private BufferedImage icpcToolsImage;
 
 	@Override
+	protected boolean shouldDrawContestTitle() {
+		return false;
+	}
+
+	@Override
 	public void init() {
 		float dpi = 96;
 		float inch = height * 72f / dpi / 10f;
@@ -91,7 +96,7 @@ public class SplashPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		g.setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
@@ -244,7 +244,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		Cache c = currentCache;
 		if (c == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamListPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamListPresentation.java
@@ -169,7 +169,7 @@ public class TeamListPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g2) {
+	public void paintImpl(Graphics2D g2) {
 		if (award == null || teams == null)
 			return;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamLogoPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamLogoPresentation.java
@@ -28,7 +28,7 @@ public class TeamLogoPresentation extends AbstractICPCPresentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		if (logo != null)
 			g.drawImage(logo, (width - logo.getWidth()) / 2, (height - logo.getHeight()) / 2, null);
 	}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -582,7 +582,7 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 	}
 
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/FirstSolutionPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/FirstSolutionPresentation.java
@@ -231,7 +231,7 @@ public class FirstSolutionPresentation extends AbstractScoreboardPresentation {
 	}
 
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		SubmissionRecord[] runs2 = null;
 		synchronized (submissions) {
 			runs2 = submissions.toArray(new SubmissionRecord[0]);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/FirstToSolvePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/FirstToSolvePresentation.java
@@ -165,7 +165,7 @@ public class FirstToSolvePresentation extends AbstractScoreboardPresentation {
 	}
 
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		SubmissionRecord[] runs2 = null;
 		synchronized (submissions) {
 			runs2 = submissions.toArray(new SubmissionRecord[0]);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
@@ -157,7 +157,7 @@ public class JudgePresentation extends AbstractScoreboardPresentation {
 	}
 
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		SubmissionRecord[] submissions2 = null;
 		synchronized (submissions) {
 			submissions2 = submissions.toArray(new SubmissionRecord[0]);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/ScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/ScoreboardPresentation.java
@@ -63,7 +63,7 @@ public class ScoreboardPresentation extends AbstractScrollingScoreboardPresentat
 	 * submissions). It also draws an "extra presenter-info" box if that option was selected.
 	 */
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/TimelinePresentation.java
@@ -102,7 +102,7 @@ public class TimelinePresentation extends AbstractScrollingScoreboardPresentatio
 	}
 
 	@Override
-	protected void paintImpl(Graphics2D g) {
+	protected void paintImplTitled(Graphics2D g) {
 		IContest contest = getContest();
 		if (contest == null)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.presentation.contest.internal.standalone;
 
+import java.awt.*;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.icpc.tools.contest.model.internal.account.AccountHelper;
 import org.icpc.tools.contest.model.util.ArgumentParser;
 import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
 import org.icpc.tools.contest.model.util.TeamDisplay;
+import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.core.DisplayConfig;
 import org.icpc.tools.presentation.core.IPresentationHandler;
 import org.icpc.tools.presentation.core.Presentation;
@@ -37,6 +39,8 @@ public class StandaloneLauncher {
 		List<String> presList = new ArrayList<String>();
 		String[] displayStr = new String[2];
 		String[] displayName = new String[1];
+		String[] contestTitle = new String[1];
+		Color[] contestTitleColor = new Color[1];
 		String[] accountType = new String[1];
 		boolean[] lightMode = new boolean[1];
 		ContestSource source = ArgumentParser.parse(args, new OptionParser() {
@@ -54,6 +58,23 @@ public class StandaloneLauncher {
 				} else if ("--multi-display".equals(option)) {
 					ArgumentParser.expectOptions(option, options, "p@wxh:string");
 					displayStr[1] = (String) options.get(0);
+					return true;
+				} else if ("--contestTitle".equalsIgnoreCase(option)) {
+					ArgumentParser.expectNoOptions(option, options);
+					contestTitle[0] = "{contest.name}";
+					return true;
+				} else if ("--contestTitleTemplate".equalsIgnoreCase(option)) {
+					ArgumentParser.expectOptions(option, options, "contestTitleTemplate:string");
+					contestTitle[0] = (String) options.get(0);
+					return true;
+				} else if ("--contestTitleColor".equalsIgnoreCase(option)) {
+					ArgumentParser.expectOptions(option, options, "contestTitleColor:string");
+					String contestTitleColorString = (String) options.get(0);
+					try {
+						contestTitleColor[0] = Color.decode(contestTitleColorString);
+					} catch (NumberFormatException e) {
+						throw new IllegalArgumentException("Invalid contest title color " + contestTitleColorString);
+					}
 					return true;
 				} else if ("--light".equals(option)) {
 					lightMode[0] = true;
@@ -95,6 +116,9 @@ public class StandaloneLauncher {
 			Trace.trace(Trace.ERROR, "Must provide one or more presentations");
 			return;
 		}
+
+		AbstractICPCPresentation.setContestTitleTemplate(contestTitle[0]);
+		AbstractICPCPresentation.setContestTitleColor(contestTitleColor[0]);
 
 		// load presentation(s)
 		Iterator<String> iter = presList.iterator();

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TilePictureScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TilePictureScoreboardPresentation.java
@@ -39,7 +39,7 @@ public class TilePictureScoreboardPresentation extends AbstractICPCPresentation 
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		IContest c = getContest();
 		if (c == null || c.getNumTeams() == 0)
 			return;

--- a/PresContest/src/org/icpc/tools/presentation/core/chart/AbstractChartPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/core/chart/AbstractChartPresentation.java
@@ -16,11 +16,12 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
 import java.awt.geom.Ellipse2D;
 
+import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.core.Presentation;
 import org.icpc.tools.presentation.core.internal.Animator;
 import org.icpc.tools.presentation.core.transition.SmoothUtil;
 
-public abstract class AbstractChartPresentation extends Presentation {
+public abstract class AbstractChartPresentation extends AbstractICPCPresentation {
 	private static final int MARGIN = 10;
 	private static final int GAP = 5;
 	private static final int DEPTH = 20;
@@ -616,7 +617,7 @@ public abstract class AbstractChartPresentation extends Presentation {
 	}
 
 	@Override
-	public void paint(Graphics2D g) {
+	public void paintImpl(Graphics2D g) {
 		if (dataSeries == null)
 			return;
 

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -121,7 +121,7 @@ public class Resolver {
 		System.out.println("         Set the contest title of the resolver presentations using a template. Parameters:");
 		System.out.println("         {contest.name) and {contest.formal_name)");
 		System.out.println("     --contestTitleColor");
-		System.out.println("         Set the contest title color of the resolver presentations. Currently supports `blue` and `yellow`");
+		System.out.println("         Set the contest title color of the resolver presentations. Supports hex colors starting with #");
 		System.out.println("     --groups");
 		System.out.println("         Resolve only the groups in the given regex pattern for ids");
 		System.out.println("         If multiple groups are given, each is resolved separately");

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.resolver;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
@@ -33,6 +34,7 @@ import org.icpc.tools.contest.model.util.ArgumentParser.OptionParser;
 import org.icpc.tools.contest.model.util.AwardUtil;
 import org.icpc.tools.contest.model.util.Taskbar;
 import org.icpc.tools.contest.model.util.TeamDisplay;
+import org.icpc.tools.presentation.contest.internal.ICPCColors;
 import org.icpc.tools.presentation.contest.internal.PresentationClient;
 import org.icpc.tools.presentation.core.DisplayConfig;
 import org.icpc.tools.resolver.ResolverUI.ClickListener;
@@ -76,6 +78,8 @@ public class Resolver {
 	private boolean test;
 	private boolean lightMode;
 	private String displayName;
+	private String contestTitle;
+	private Color contestTitleColor;
 	private String[] groupList;
 	private String[] problemList;
 	private String[] problemIdList;
@@ -111,6 +115,13 @@ public class Resolver {
 		System.out.println("     --display_name template");
 		System.out.println("         Change the way teams are displayed using a template. Parameters:");
 		System.out.println("         {team.display_name), {team.name), {org.formal_name}, and {org.name}");
+		System.out.println("     --contestTitle");
+		System.out.println("         Set the contest title of the resolver presentations to the contest name");
+		System.out.println("     --contestTitleTemplate template");
+		System.out.println("         Set the contest title of the resolver presentations using a template. Parameters:");
+		System.out.println("         {contest.name) and {contest.formal_name)");
+		System.out.println("     --contestTitleColor");
+		System.out.println("         Set the contest title color of the resolver presentations. Currently supports `blue` and `yellow`");
 		System.out.println("     --groups");
 		System.out.println("         Resolve only the groups in the given regex pattern for ids");
 		System.out.println("         If multiple groups are given, each is resolved separately");
@@ -352,6 +363,20 @@ public class Resolver {
 		} else if ("--display_name".equalsIgnoreCase(option)) {
 			ArgumentParser.expectOptions(option, options, "display_name:string");
 			displayName = (String) options.get(0);
+		} else if ("--contestTitle".equalsIgnoreCase(option)) {
+			ArgumentParser.expectNoOptions(option, options);
+			contestTitle = "{contest.name}";
+		} else if ("--contestTitleTemplate".equalsIgnoreCase(option)) {
+			ArgumentParser.expectOptions(option, options, "contestTitleTemplate:string");
+			contestTitle = (String) options.get(0);
+		} else if ("--contestTitleColor".equalsIgnoreCase(option)) {
+			ArgumentParser.expectOptions(option, options, "contestTitleColor:string");
+			String contestTitleColorString = (String) options.get(0);
+			try {
+				contestTitleColor = Color.decode(contestTitleColorString);
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException("Invalid contest title color " + contestTitleColorString);
+			}
 		} else if ("--groups".equalsIgnoreCase(option)) {
 			ArgumentParser.expectOptions(option, options, "groups:string", "*");
 			groupList = options.toArray(new String[0]);
@@ -620,7 +645,7 @@ public class Resolver {
 					public void speedFactor(double d) {
 						sendSpeedFactor(d);
 					}
-				}, lightMode);
+				}, lightMode, contestTitle, contestTitleColor);
 
 		ui.setSpeedFactor(speedFactor);
 		ui.display();

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -111,9 +111,11 @@ public class ResolverUI {
 	private Thread thread;
 	private int rowOffset;
 	private boolean light;
+	private String contestTitle;
+	private Color contestTitleColor;
 
 	public ResolverUI(List<ResolutionStep> steps, boolean showInfo, DisplayConfig displayConfig, boolean isPresenter,
-			int rowOffset, Screen screen, ClickListener listener, boolean light) {
+			int rowOffset, Screen screen, ClickListener listener, boolean light, String contestTitle, Color contestTitleColor) {
 		this.steps = steps;
 		this.showInfo = showInfo;
 		this.displayConfig = displayConfig;
@@ -147,6 +149,8 @@ public class ResolverUI {
 			}
 		});
 		this.light = light;
+		this.contestTitle = contestTitle;
+		this.contestTitleColor = contestTitleColor;
 	}
 
 	public void moveTo(int pause2) {
@@ -245,6 +249,9 @@ public class ResolverUI {
 			}
 		});
 		window.setControlable(false);
+
+		AbstractICPCPresentation.setContestTitleTemplate(contestTitle);
+		AbstractICPCPresentation.setContestTitleColor(contestTitleColor);
 
 		if (screen == Screen.TEAM || screen == Screen.SIDE || screen == Screen.ORG) {
 			logoPresentation = new StaticLogoPresentation();


### PR DESCRIPTION
Fixes #808

Some screenshots:
<img width="1006" alt="Screenshot 2023-07-28 at 11 47 17" src="https://github.com/icpctools/icpctools/assets/550145/758fa4c1-0b04-4d5e-b67f-a096149784bf">
<img width="1006" alt="Screenshot 2023-07-28 at 11 47 35" src="https://github.com/icpctools/icpctools/assets/550145/6981614f-7848-4d10-acff-0b298f117760">
<img width="1006" alt="Screenshot 2023-07-28 at 11 47 54" src="https://github.com/icpctools/icpctools/assets/550145/336dcf13-f9dd-43fa-8dd1-4fdf393bbe66">
<img width="1006" alt="Screenshot 2023-07-28 at 11 48 02" src="https://github.com/icpctools/icpctools/assets/550145/fe1698c9-50a0-4e99-b912-c0c8be734cfe">
<img width="1006" alt="Screenshot 2023-07-28 at 11 48 20" src="https://github.com/icpctools/icpctools/assets/550145/24bae572-1202-4d3a-87ec-d4362407390c">
<img width="1006" alt="Screenshot 2023-07-28 at 11 48 32" src="https://github.com/icpctools/icpctools/assets/550145/25cc383f-278e-45e8-b79c-3156df709a6f">
