### PR TITLE
Add ability to start multiple contests at the same time.

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -431,7 +431,7 @@
         setInterval(updateInfoStartStatus, 5000);
 
         $('#lock').change(function() {
-        	  if (!$(this).prop('checked')) {
+        	  if ($(this).prop('checked')) {
             	  $("#locker").removeClass('btn-secondary').addClass('btn-danger');
             	  $("#lock-group").find('*').addClass("disabled");
         	  } else {

--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -9,70 +9,11 @@
 <div class="container-fluid">
     <div class="row">
         <div class="col-8">
-        <div class="card">
-           <div class="card-header">
-             <h3 class="card-title">Countdown Control</h3>
-             <div class="card-tools">
-               <div class="btn-group-toggle" data-toggle="buttons">
-                 <label class="btn btn-secondary active fa fa-lock" id="locker">
-                 <input id="lock" type="checkbox" autocomplete="off">Lock
-                 </label>
-               </div>
-             </div>
-           </div>
-        <div class="card-body" id="lock-group">
-          <b><font size="+7"><span id="countdown">&nbsp;</span></font></b>
-        
-           <p>You cannot change time in the final 30s before a contest starts.</p>
-                <button id="pause" class="btn btn-secondary" onclick="sendCommand('pause', 'pause')">Pause</button>
-                <button id="resume" class="btn btn-secondary" onclick="sendCommand('resume', 'resume')">Resume</button>
-                <button id="clear" class="btn btn-secondary" onclick="sendCommand('clear', 'clear')">Clear</button>
-                <span id="status">&nbsp;</span>
-
-                <table class="table table-sm table-hover table-striped">
-                    <tbody>
-                    <tr>
-                        <td>
-                            <select id="timeSelect" class="custom-select">
-                                <option value="0:00:01">1 second</option>
-                                <option value="0:00:05">5 seconds</option>
-                                <option value="0:00:15">15 seconds</option>
-                                <option value="0:00:30">30 seconds</option>
-                                <option value="0:01:00" selected>1 minute</option>
-                                <option value="0:05:00">5 minutes</option>
-                                <option value="0:15:00">15 minutes</option>
-                                <option value="0:30:00">30 minutes</option>
-                                <option value="1:00:00">1 hour</option>
-                                <option value="2:00:00">2 hours</option>
-                            </select>
-                        </td>
-                        <td>
-                            <button id="set" class="btn btn-secondary" onclick="sendCommand('set', 'set: ' + $('#timeSelect').children('option:selected').val())">Set</button>
-                        </td>
-                        <td>
-                            <button id="add" class="btn btn-secondary" onclick="sendCommand('add', 'add: ' + $('#timeSelect').children('option:selected').val())">Add</button>
-                        </td>
-                        <td>
-                            <button id="remove" class="btn btn-secondary" onclick="sendCommand('remove', 'remove: ' + $('#timeSelect').children('option:selected').val())">Remove</button>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <input type="text" id="timeSelect2" value="0:01:00" class="form-control"/>
-                        </td>
-                        <td>
-                            <button id="set2" class="btn btn-secondary" onclick="sendCommand('set', 'set: ' + $('#timeSelect2').val())">Set</button>
-                        </td>
-                        <td>
-                            <button id="add2" class="btn btn-secondary" onclick="sendCommand('add', 'add: ' + $('#timeSelect2').val())">Add</button>
-                        </td>
-                        <td>
-                            <button id="remove3" class="btn btn-secondary" onclick="sendCommand('remove', 'remove: ' + $('#timeSelect2').val())">Remove</button>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
-          </div></div>
+            <%
+                IContest[] countdownContests = {contest};
+                boolean multiCountdown = false;
+            %>
+            <%@ include file="countdown-control.jsp" %>
       </div>
 
       <div class="col-4">
@@ -228,34 +169,7 @@
 </script>
 <script>
     contest = new Contest("/api", "<%= cc.getId() %>");
-	cds.setContestId("<%= cc.getId() %>");
-
-    function sendCommand(id, command) {
-    	if ($("#locker").hasClass('btn-danger'))
-    		return;
-    	
-        document.getElementById(id).disabled = true;
-
-        var xmlhttp = new XMLHttpRequest();
-        xmlhttp.onreadystatechange = function () {
-            document.getElementById("status").innerHTML = "Sending request...";
-            if (xmlhttp.readyState == 4) {
-                if (xmlhttp.status == 200)
-                    document.getElementById("status").innerHTML = "Request successful";
-                else
-                    document.getElementById("status").innerHTML = xmlhttp.responseText;
-                document.getElementById(id).disabled = false;
-                updateInfoStartStatus();
-            }
-        }
-        xmlhttp.timeout = 10000;
-        xmlhttp.ontimeout = function () {
-            document.getElementById("status").innerHTML = "Request timed out";
-            document.getElementById(id).disabled = false;
-        }
-        xmlhttp.open("PUT", "<%= webroot %>/admin/time/" + command, true);
-        xmlhttp.send();
-    }
+    cds.setContestId("<%= cc.getId() %>");
 
     function addStartStatusDefaults() {
     	addStartStatus("Security", 0);
@@ -424,21 +338,10 @@
     }
 
     function updateInBackground() {
-    	updateContestClock(contest, "countdown", true);
         updateInfoStartStatus();
         updateResolver();
 
         setInterval(updateInfoStartStatus, 5000);
-
-        $('#lock').change(function() {
-        	  if ($(this).prop('checked')) {
-            	  $("#locker").removeClass('btn-secondary').addClass('btn-danger');
-            	  $("#lock-group").find('*').addClass("disabled");
-        	  } else {
-        	      $("#locker").removeClass('btn-danger').addClass('btn-secondary');
-        	      $("#lock-group").find('*').removeClass("disabled");
-        	  }
-        	})
     }
 
     $(document).ready(updateInBackground);

--- a/CDS/WebContent/WEB-INF/jsps/countdown-control.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/countdown-control.jsp
@@ -1,0 +1,199 @@
+<div class="card">
+    <div class="card-header">
+        <h3 class="card-title">Countdown Control</h3>
+        <div class="card-tools">
+            <div class="btn-group-toggle" data-toggle="buttons">
+                <label class="btn btn-secondary active fa fa-lock" id="locker">
+                    <input id="lock" type="checkbox" autocomplete="off">Lock
+                </label>
+            </div>
+        </div>
+    </div>
+    <div class="card-body" id="lock-group">
+        <% if (multiCountdown) { %>
+        <% for (IContest countdownContest : countdownContests) { %>
+        <% boolean started = countdownContest.getState().getStarted() != null; %>
+        <b>
+            <font size="+7">
+                <span class="btn-group-toggle" data-toggle="buttons">
+                    <label class="btn <%= started ? "btn-danger" : "btn-success" %>" style="min-width: 130px;">
+                        <input type="checkbox" autocomplete="off" <% if (!started) { %>checked<% } %>
+                               data-countdown-contest="<%= countdownContest.getId() %>">
+                        <span><%= started ? "Not included" : "Included" %></span>
+                    </label>
+                </span>
+                <%= countdownContest.getName() %>:
+                <span id="countdown-<%= countdownContest.getId() %>">&nbsp;</span>
+            </font>
+        </b>
+        <span id="status-<%= countdownContest.getId() %>" class="ml-3">&nbsp;</span>
+        <br/>
+        <% } %>
+        <% } else { %>
+        <b><font size="+7"><span id="countdown-<%= countdownContests[0].getId() %>">&nbsp;</span></font></b>
+        <span id="status-<%= countdownContests[0].getId() %>" class="ml-3">&nbsp;</span>
+        <% } %>
+
+        <% if (multiCountdown) { %>
+        <p>Click the buttons above to determine which contests to include in your actions. By default all non-started
+            contests are selected.</p>
+        <% } %>
+        <p>You cannot change time in the final 30s before a contest starts.</p>
+        <button id="pause" class="btn btn-secondary" onclick="sendCommand('pause', 'pause')">Pause</button>
+        <button id="resume" class="btn btn-secondary" onclick="sendCommand('resume', 'resume')">Resume</button>
+        <button id="clear" class="btn btn-secondary" onclick="sendCommand('clear', 'clear')">Clear</button>
+
+        <table class="table table-sm table-hover table-striped">
+            <tbody>
+            <tr>
+                <td>
+                    <select id="timeSelect" class="custom-select">
+                        <option value="0:00:01">1 second</option>
+                        <option value="0:00:05">5 seconds</option>
+                        <option value="0:00:15">15 seconds</option>
+                        <option value="0:00:30">30 seconds</option>
+                        <option value="0:01:00" selected>1 minute</option>
+                        <option value="0:05:00">5 minutes</option>
+                        <option value="0:15:00">15 minutes</option>
+                        <option value="0:30:00">30 minutes</option>
+                        <option value="1:00:00">1 hour</option>
+                        <option value="2:00:00">2 hours</option>
+                    </select>
+                </td>
+                <td>
+                    <button id="set" class="btn btn-secondary"
+                            onclick="sendCommand('set', 'set: ' + $('#timeSelect').children('option:selected').val())">
+                        Set
+                    </button>
+                </td>
+                <td>
+                    <button id="add" class="btn btn-secondary"
+                            onclick="sendCommand('add', 'add: ' + $('#timeSelect').children('option:selected').val())">
+                        Add
+                    </button>
+                </td>
+                <td>
+                    <button id="remove" class="btn btn-secondary"
+                            onclick="sendCommand('remove', 'remove: ' + $('#timeSelect').children('option:selected').val())">
+                        Remove
+                    </button>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <input type="text" id="timeSelect2" value="0:01:00" class="form-control"/>
+                </td>
+                <td>
+                    <button id="set2" class="btn btn-secondary"
+                            onclick="sendCommand('set', 'set: ' + $('#timeSelect2').val())">Set
+                    </button>
+                </td>
+                <td>
+                    <button id="add2" class="btn btn-secondary"
+                            onclick="sendCommand('add', 'add: ' + $('#timeSelect2').val())">Add
+                    </button>
+                </td>
+                <td>
+                    <button id="remove3" class="btn btn-secondary"
+                            onclick="sendCommand('remove', 'remove: ' + $('#timeSelect2').val())">Remove
+                    </button>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<script>
+    var requestsDone = 0;
+
+    function sendCommandForContest(id, contestId, command) {
+        <% if (multiCountdown) { %>
+        var $included = $('[data-countdown-contest="' + contestId + '"]');
+        if (!$included.prop('checked')) {
+            requestsDone++;
+            if (requestsDone == <%= countdownContests.length %>) {
+                document.getElementById(id).disabled = false;
+            }
+            return;
+        }
+        <% } %>
+
+        var xmlhttp = new XMLHttpRequest();
+        xmlhttp.onreadystatechange = function () {
+            document.getElementById("status-" + contestId).innerHTML = "Sending request...";
+            if (xmlhttp.readyState == 4) {
+                if (xmlhttp.status == 200) {
+                    // Reload the countdown info
+                    contests[contestId].info = null;
+                    document.getElementById("status-" + contestId).innerHTML = "Request successful";
+                } else {
+                    document.getElementById("status-" + contestId).innerHTML = xmlhttp.responseText;
+                }
+                requestsDone++;
+                if (requestsDone == <%= countdownContests.length %>) {
+                    document.getElementById(id).disabled = false;
+                }
+                <% if (!multiCountdown) { %>
+                updateInfoStartStatus();
+                <% } %>
+            }
+        }
+        xmlhttp.timeout = 10000;
+        xmlhttp.ontimeout = function () {
+            document.getElementById("status-" + contestId).innerHTML = "Request timed out";
+            requestsDone++;
+            if (requestsDone == <%= countdownContests.length %>) {
+                document.getElementById(id).disabled = false;
+            }
+        }
+        xmlhttp.open("PUT", "<%= request.getContextPath() %>/contests/" + contestId + "/admin/time/" + command, true);
+        xmlhttp.send();
+    }
+
+    function sendCommand(id, command) {
+        if ($("#locker").hasClass('btn-danger'))
+            return;
+
+        requestsDone = 0;
+
+        document.getElementById(id).disabled = true;
+
+        <% for (IContest countdownContest : countdownContests) { %>
+        sendCommandForContest(id, "<%= countdownContest.getId() %>", command);
+        <% } %>
+    }
+
+    var contests = {
+        <% for (IContest countdownContest : countdownContests) { %>
+        "<%= countdownContest.getId()%>": new Contest("/api", "<%= countdownContest.getId() %>"),
+        <% } %>
+    };
+
+    $(function () {
+        $('#lock').change(function () {
+            if ($(this).prop('checked')) {
+                $("#locker").removeClass('btn-secondary').addClass('btn-danger');
+                $("#lock-group").find('*').addClass("disabled");
+            } else {
+                $("#locker").removeClass('btn-danger').addClass('btn-secondary');
+                $("#lock-group").find('*').removeClass("disabled");
+            }
+        });
+
+        $('[data-countdown-contest]').change(function () {
+            var $button = $(this).closest('label');
+            var $span = $button.find('span');
+            if ($(this).prop('checked')) {
+                $span.text('Included');
+                $button.removeClass('btn-danger').addClass('btn-success');
+            } else {
+                $span.text('Not included');
+                $button.removeClass('btn-success').addClass('btn-danger');
+            }
+        });
+
+        <% for (IContest countdownContest : countdownContests) { %>
+        updateContestClock(contests["<%= countdownContest.getId() %>"], "countdown-<%= countdownContest.getId() %>", true);
+        <% } %>
+    });
+</script>

--- a/CDS/WebContent/WEB-INF/jsps/countdown.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/countdown.jsp
@@ -1,0 +1,27 @@
+<%@ page import="java.util.Arrays" %>
+<%@ page import="java.util.List" %>
+<%@ page import="java.util.ArrayList" %>
+<% request.setAttribute("title", "Multi-contest Countdown Control"); %>
+<%@ include file="layout/head.jsp" %>
+<script src="${pageContext.request.contextPath}/js/contest.js"></script>
+<script src="${pageContext.request.contextPath}/js/cds.js"></script>
+<script src="${pageContext.request.contextPath}/js/ui.js"></script>
+<script src="${pageContext.request.contextPath}/js/model.js"></script>
+<script src="${pageContext.request.contextPath}/js/types.js"></script>
+<script src="${pageContext.request.contextPath}/js/mustache.min.js"></script>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-10">
+            <%
+                List<IContest> contests = new ArrayList<>();
+                for (ConfiguredContest c : CDSConfig.getContests()) {
+                    contests.add(c.getContest());
+                }
+                IContest[] countdownContests = contests.toArray(new IContest[0]);
+                boolean multiCountdown = true;
+            %>
+            <%@ include file="countdown-control.jsp" %>
+        </div>
+    </div>
+</div>
+<%@ include file="layout/footer.jsp" %>

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -168,6 +168,16 @@ function logout() {
               </ul>
             </li>
             <% } } %>
+
+            <% if (CDSAuth.isAdmin(request)) { %>
+            <li class="nav-item">
+              <a href="${pageContext.request.contextPath}/countdown"
+                 class="nav-link<% if (request.getAttribute("javax.servlet.forward.request_uri").toString().contains("countdown")) { %> active<% } %>">
+                <i class="nav-icon fas fa-clock"></i>
+                <p>Countdown Control</p>
+              </a>
+            </li>
+            <% } %>
             
             <% if (CDSAuth.isPresAdmin(request)) { %>
             <li class="nav-item">

--- a/CDS/src/org/icpc/tools/cds/service/CountdownServlet.java
+++ b/CDS/src/org/icpc/tools/cds/service/CountdownServlet.java
@@ -1,0 +1,27 @@
+package org.icpc.tools.cds.service;
+
+import org.icpc.tools.cds.CDSAuth;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@WebServlet(urlPatterns = "/countdown", asyncSupported = true)
+public class CountdownServlet extends HttpServlet {
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+		if (!CDSAuth.isAdmin(request)) {
+			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+		}
+
+		request.setCharacterEncoding("UTF-8");
+		response.setCharacterEncoding("UTF-8");
+		response.setHeader("Cache-Control", "no-cache");
+		response.setHeader("ICPC-Tools", "CDS");
+		response.setHeader("X-Frame-Options", "sameorigin");
+		request.getRequestDispatcher("/WEB-INF/jsps/countdown.jsp").forward(request, response);
+	}
+}


### PR DESCRIPTION
Fixes #814

This also fixes a bug with the lock button, where you needed to press it twice to do the initial lock.

Basically this extracts the countdown logic to it's own JSP and it now has two modes:
* The old behaviour where it would manage one contest. Nothing changed here except some HTML ID's and I have moved the status label to after the countdown, to be consistent with the new mode.
* The new behaviour where it can manage multiple contests. You can toggle what contests to manage and by default it manages all non-started contests, since that is probably what you want if you use this mode.

The new mode basically just loops over all contests and does the old logic for most buttons and javascript.

I also made it that if you performed an action that it will clear the info of the contest, thus refetching the state.

The change looks pretty big but it's mostly moving code to another file.

Screenshot:
<img width="1731" alt="image" src="https://github.com/icpctools/icpctools/assets/550145/e8c98301-2e3a-4f80-b7e5-bfc7130e8d62">
