### PR TITLE
Color value for contests

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContest.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.contest.model;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
@@ -53,6 +54,20 @@ public interface IContest {
 	 * @return the formal name
 	 */
 	String getActualFormalName();
+
+	/**
+	 * A 3 or 6 character hex string representing the rgb color of the contest, e.g. FF0000 or 0F0.
+	 *
+	 * @return the rgb value
+	 */
+	String getRGB();
+
+	/**
+	 * A Java Color object representation of the RGB value, e.g. Color.RED or Color(0,0,255).
+	 *
+	 * @return the color
+	 */
+	Color getColorVal();
 
 	/**
 	 * The contest start time in ms from the Unix epoch (Jan 1, 1970). Null indicates that the start

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.contest.model.internal;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.text.Collator;
@@ -521,6 +522,16 @@ public class Contest implements IContest {
 	@Override
 	public String getActualFormalName() {
 		return info.getActualFormalName();
+	}
+
+	@Override
+	public String getRGB() {
+		return info.getRGB();
+	}
+
+	@Override
+	public Color getColorVal() {
+		return info.getColorVal();
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -5,6 +5,7 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
 
+import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContest.ScoreboardType;
 import org.icpc.tools.contest.model.IContestObject;
@@ -42,6 +43,8 @@ public class Info extends ContestObject implements IInfo {
 	private Location location;
 	private FileReferenceList banner;
 	private FileReferenceList logo;
+	private String rgb;
+	private Color colorVal;
 
 	@Override
 	public ContestType getType() {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.contest.model.internal;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.List;
@@ -25,6 +26,7 @@ public class Info extends ContestObject implements IInfo {
 	private static final String COUNTDOWN_PAUSE_TIME = "countdown_pause_time";
 	private static final String LOCATION = "location";
 	private static final String SCOREBOARD_TYPE = "scoreboard_type";
+	private static final String RGB = "rgb";
 
 	private String name;
 	private String formalName;
@@ -63,6 +65,44 @@ public class Info extends ContestObject implements IInfo {
 		if (formalName == null)
 			return name;
 		return formalName;
+	}
+
+	public String getRGB() {
+		return rgb;
+	}
+
+	public Color getColorVal() {
+		if (colorVal != null)
+			return colorVal;
+
+		if (rgb == null || !(rgb.length() == 3 || rgb.length() == 4 || rgb.length() == 6 || rgb.length() == 7)) {
+			colorVal = Color.BLACK;
+			return colorVal;
+		}
+
+		try {
+			String rgbv = rgb;
+			if (rgbv.length() == 3 || rgbv.length() == 4) {
+				if (rgbv.length() == 4)
+					rgbv = rgbv.substring(1);
+				int r = Integer.parseInt(rgbv.substring(0, 1) + rgbv.substring(0, 1), 16);
+				int g = Integer.parseInt(rgbv.substring(1, 2) + rgbv.substring(1, 2), 16);
+				int b = Integer.parseInt(rgbv.substring(2, 3) + rgbv.substring(2, 3), 16);
+				colorVal = new Color(r, g, b);
+				return colorVal;
+			}
+			if (rgbv.length() == 7)
+				rgbv = rgbv.substring(1);
+			int r = Integer.parseInt(rgbv.substring(0, 2), 16);
+			int g = Integer.parseInt(rgbv.substring(2, 4), 16);
+			int b = Integer.parseInt(rgbv.substring(4, 6), 16);
+			colorVal = new Color(r, g, b);
+			return colorVal;
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Invalid color value for problem " + id + " (" + rgb + ")");
+			colorVal = Color.BLACK;
+			return colorVal;
+		}
 	}
 
 	public Long getStartTime() {
@@ -187,6 +227,10 @@ public class Info extends ContestObject implements IInfo {
 		} else if (name2.equals(FORMAL_NAME)) {
 			formalName = (String) value;
 			return true;
+		} else if (name2.equals(RGB)) {
+			rgb = (String) value;
+			colorVal = null;
+			return true;
 		} else if (name2.equals(START_TIME)) {
 			startTime = parseTimestamp(value);
 			return true;
@@ -239,6 +283,7 @@ public class Info extends ContestObject implements IInfo {
 		i.banner = banner;
 		i.name = name;
 		i.formalName = formalName;
+		i.rgb = rgb;
 		i.startTime = startTime;
 		i.duration = duration;
 		i.freezeDuration = freezeDuration;
@@ -287,6 +332,8 @@ public class Info extends ContestObject implements IInfo {
 
 		if (location != null)
 			props.add(LOCATION, location.getJSON());
+
+		props.addLiteralString(RGB, rgb);
 
 		props.addFileRef(LOGO, logo);
 		props.addFileRef(BANNER, banner);


### PR DESCRIPTION
Although it's ugly, IMHO the only way to implement #808 (contest banner in resolver and presentations) 'properly' is to set a color on the contest object, the same way that problems have colors (in fact, this implementation is copied from there).

In the contest configuration we add a file like `extend-color/contests.json` with contents like:
  `{"id":"sharm","rgb":"FF0000"}`
Now all clients see the correct color to use in the contest endpoint or feed. Presentations and resolver can use it for the contest-specific banner. No command line args required for color; clients that load two contests can see a value per-contest. Live can pick up the correct color too; or if they choose to set it differently, at least it is clear what we are using and when it doesn't match.