### PR TITLE
Update team machine identification heuristics

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ClientLauncher.java
@@ -100,12 +100,12 @@ public class ClientLauncher {
 		String name = nameStr[0];
 		PresentationClient client = null;
 		if ("team".equals(name)) {
-			String teamLabel = TeamUtil.getTeamId();
+			String teamId = TeamUtil.getTeamId(cdsSource.getContest());
 			String member = TeamUtil.getTeamMember();
 			if (member != null) {
-				teamLabel += member;
+				teamId += member;
 			}
-			client = new PresentationClient(cdsSource, teamLabel, "!admin");
+			client = new PresentationClient(cdsSource, teamId, "!admin");
 		} else
 			client = new PresentationClient(name, "!admin", cdsSource);
 		instance = client;

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/SnakePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/SnakePresentation.java
@@ -41,9 +41,9 @@ public class SnakePresentation extends AbstractICPCPresentation {
 			}
 		}
 
-		String teamLabel = TeamUtil.getTeamId();
+		String teamId = TeamUtil.getTeamId(contest);
 		try {
-			x = Integer.parseInt(teamLabel);
+			x = Integer.parseInt(teamId);
 		} catch (Exception e) {
 			// ignore
 		}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -73,7 +73,7 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 
 	@Override
 	public void init() {
-		setTeam(TeamUtil.getTeamId(), TeamUtil.getTeamMember());
+		setTeam(TeamUtil.getTeamId(getContest()), TeamUtil.getTeamMember());
 	}
 
 	@Override
@@ -91,7 +91,7 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 
 			IContest contest = getContest();
 			FloorMap map = new FloorMap(contest);
-			ITeam t = contest.getTeamById(teamId + "");
+			ITeam t = contest.getTeamById(teamId);
 			Trace.trace(Trace.INFO, "Floor map team: " + t);
 			if (t != null) {
 				ITeam tt = map.getTeamToLeftOf(t);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/WavePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/WavePresentation.java
@@ -37,7 +37,7 @@ public class WavePresentation extends AbstractICPCPresentation {
 	public void init() {
 		min = Double.MAX_VALUE;
 		max = Double.MIN_VALUE;
-		String teamId = TeamUtil.getTeamId();
+		String teamId = TeamUtil.getTeamId(getContest());
 		IContest contest = getContest();
 		for (ITeam t : contest.getTeams()) {
 			double vv = 0;


### PR DESCRIPTION
Update TeamUtil to support team labels in addition to ids. Uppercase the environment var and system properties we look for, and use _ instead of - to match the spec better.