### PR TITLE
Contest access control policy

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -4,20 +4,24 @@ import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IJudgement;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
+import org.icpc.tools.contest.model.internal.Person;
 
 /**
- * Filter that adds things analysts can see compared to public:
+ * Filter that adds things analysts can see compared to spectators:
  * <ul>
- * <li>Runs before the freeze</li>
- * <li>Clarifications</li>
+ * <li>Runs (until the freeze)</li>
+ * <li>Person emails</li>
+ * <li>Submission files (for submissions before the freeze)</li>
+ * <li>Judgement max runtime</li>
+ * <li>Team backups, tool data, and key logs (until the freeze)</li>
  * </ul>
  */
-public class AnalystContest extends PublicContest {
+public class AnalystContest extends SpectatorContest {
 	public AnalystContest(IAccount account) {
-		super();
-		username = account.getUsername();
+		super(account);
 	}
 
 	@Override
@@ -29,7 +33,7 @@ public class AnalystContest extends PublicContest {
 
 		IContestObject.ContestType cType = obj.getType();
 		switch (cType) {
-			case RUN: {
+			case RUN: { // TODO - access block for live
 				IRun run = (IRun) obj;
 
 				IJudgement j = getJudgementById(run.getJudgementId());
@@ -58,13 +62,41 @@ public class AnalystContest extends PublicContest {
 				addIt(run);
 				return;
 			}
-			case CLARIFICATION: {
-				addIt(obj);
-				return;
+			default:
+				super.add(obj);
+		}
+	}
+
+	@Override
+	protected IPerson filterPerson(IPerson person) {
+		Person p = (Person) ((Person) person).clone();
+		p.add("email", null);
+		return p;
+	}
+
+	@Override
+	protected IJudgement filterJudgement(IJudgement jud) {
+		return jud;
+	}
+
+	@Override
+	public boolean allowFileReference(IContestObject obj, String property) {
+		switch (obj.getType()) {
+			case TEAM: {
+				if ("backup".equals(property) || "tool_data".equals(property) || "key_log".equals(property))
+					return !this.getState().isFrozen();
+
+				return super.allowFileReference(obj, property);
+			}
+			case SUBMISSION: {
+				ISubmission s = (ISubmission) obj;
+				if ("files".equals(property)) {
+					return this.isBeforeFreeze(s);
+				}
+				return super.allowFileReference(obj, property);
 			}
 			default:
-				break;
+				return true;
 		}
-		super.add(obj);
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/IFilteredContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/IFilteredContest.java
@@ -1,0 +1,13 @@
+package org.icpc.tools.contest.model.internal.account;
+
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IContestObject;
+
+/**
+ * Helper interface that marks filtered contests and provides an extra method to limit file
+ * attachments (streams and downloads).
+ */
+public interface IFilteredContest extends IContest {
+
+	public boolean allowFileReference(IContestObject obj, String attribute);
+}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
@@ -2,11 +2,21 @@ package org.icpc.tools.contest.model.internal.account;
 
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
-import org.icpc.tools.contest.model.IContestObject.ContestType;
+import org.icpc.tools.contest.model.IDelete;
+import org.icpc.tools.contest.model.IProblem;
+import org.icpc.tools.contest.model.ISubmission;
+import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.internal.Problem;
+import org.icpc.tools.contest.model.internal.Submission;
 
 /**
- * Filter that adds things spectators can see compared to public:
+ * Filter that adds things spectators can see compared to public/team area:
  * <ul>
+ * <li>Problem test data count</li>
+ * <li>Team desktop, webcams (until the freeze)</li>
+ * <li>Team tool data, key log</li>
+ * <li>Submission language</li>
+ * <li>Submission reaction videos (until the freeze)</li>
  * <li>Commentary</li>
  * </ul>
  */
@@ -18,11 +28,79 @@ public class SpectatorContest extends PublicContest {
 
 	@Override
 	public void add(IContestObject obj) {
-		if (obj.getType() == ContestType.COMMENTARY) {
+		IContestObject.ContestType cType = obj.getType();
+		if (obj instanceof IDelete) {
 			addIt(obj);
 			return;
 		}
 
-		super.add(obj);
+		switch (cType) {
+			case SUBMISSION: {
+				ISubmission sub = (ISubmission) obj;
+
+				// hide submissions from outside the contest time
+				long time = sub.getContestTime();
+				if (time < 0 || time >= getDuration())
+					return;
+
+				// hide submissions from hidden teams
+				ITeam team = getTeamById(sub.getTeamId());
+				if (isTeamHidden(team))
+					return;
+
+				// TODO - language
+				super.add(sub);
+				return;
+			}
+			case COMMENTARY: {
+				addIt(obj);
+				return;
+			}
+			default: {
+				super.add(obj);
+			}
+		}
+	}
+
+	@Override
+	protected IProblem filterProblem(IProblem problem) {
+		Problem p = (Problem) ((Problem) problem).clone();
+		p.setPackage(null);
+		return p;
+	}
+
+	@Override
+	protected ISubmission filterSubmission(ISubmission sub) {
+		Submission s = (Submission) ((Submission) sub).clone();
+		s.setFiles(null);
+		s.add("entry_point", null);
+
+		if (!isBeforeFreeze(s))
+			s.setReaction(null);
+		return s;
+	}
+
+	@Override
+	public boolean allowFileReference(IContestObject obj, String property) {
+		switch (obj.getType()) {
+			case TEAM: {
+				if ("desktop".equals(property) || "webcam".equals(property) || "audio".equals(property))
+					return !this.getState().isFrozen();
+
+				if ("tool_data".equals(property) || "key_log".equals(property))
+					return true;
+				return super.allowFileReference(obj, property);
+			}
+			case SUBMISSION: {
+				ISubmission s = (ISubmission) obj;
+				if ("reaction".equals(property)) {
+					return this.isBeforeFreeze(s);
+				}
+				return super.allowFileReference(obj, property);
+			}
+
+			default:
+				return super.allowFileReference(obj, property);
+		}
 	}
 }


### PR DESCRIPTION
Make a few minor improvements to simplify/centralize access control (e.g. file references also use filtered contests now; analysts extend spectators since they're closer to that now), and implement changes for the approved contest information access policy: https://docs.google.com/document/d/1Jgqaxsu_nFb94MkIcBsSXFIKCasdkuxQsxGoKksRQEI