### PR TITLE
Fix penalty time

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IResult.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IResult.java
@@ -41,11 +41,11 @@ public interface IResult {
 	long getContestTime();
 
 	/**
-	 * Return the penalty time for this problem, in minutes.
+	 * Return the penalty time for this problem.
 	 *
-	 * @return the penalty time
+	 * @return the penalty time, in ms.
 	 */
-	int getPenaltyTime();
+	long getPenaltyTime();
 
 	/**
 	 * Return the score for this problem.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1027,14 +1027,14 @@ public class Contest implements IContest {
 
 			for (int i = 0; i < numTeams; i++) {
 				int numSolved = 0;
-				int penalty = 0;
+				long penalty = 0;
 				long lastSolution = -1;
 				double score = 0;
 				for (int j = 0; j < numProblems; j++) {
 					penalty += tempResults[i][j].getPenaltyTime();
 					if (tempResults[i][j].getStatus() == Status.SOLVED) {
 						long time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime());
-						penalty += time;
+						penalty += time * (60 * 1000L);
 						numSolved++;
 						score += tempResults[i][j].getScore();
 						if (time > lastSolution)
@@ -1042,7 +1042,7 @@ public class Contest implements IContest {
 					}
 				}
 
-				tempStandings[i].init(numSolved, penalty, score, lastSolution);
+				tempStandings[i].init(numSolved, (int) (penalty / (60 * 1000L)), score, lastSolution);
 			}
 
 			for (int i = 0; i < numTeams; i++) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -252,7 +252,7 @@ public class Info extends ContestObject implements IInfo {
 			return true;
 		} else if (name2.equals(PENALTY_TIME)) {
 			try {
-				penalty = parseLong(value);
+				penalty = parseInt(value) * (60 * 1000L);
 				// TODO future relative time
 				// penalty = parseRelativeTime(value);
 			} catch (Exception e) {
@@ -334,7 +334,7 @@ public class Info extends ContestObject implements IInfo {
 			props.addLiteralString(SCOREBOARD_THAW_TIME, Timestamp.format(thawTime.longValue()));
 
 		if (penalty != null)
-			props.addInt(PENALTY_TIME, penalty.intValue());
+			props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
 		// TODO: future - props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
 
 		if (!Double.isNaN(timeMultiplier))

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
@@ -10,8 +10,8 @@ public class Result implements IResult {
 	private int numPending;
 	private int numJudged;
 	private long time;
-	private int penalty;
-	private int pendingPenalty;
+	private long penalty;
+	private long pendingPenalty;
 	private double score;
 	private boolean isFTS;
 
@@ -35,7 +35,7 @@ public class Result implements IResult {
 	}
 
 	@Override
-	public int getPenaltyTime() {
+	public long getPenaltyTime() {
 		return penalty;
 	}
 
@@ -70,9 +70,10 @@ public class Result implements IResult {
 					score = j.getScore();
 			} else if (jt.isPenalty()) {
 				status = Status.FAILED;
-				Long penaltyTime = contest.getPenaltyTime(); // TODO relative time
-				if (penaltyTime != null)
-					pendingPenalty += penaltyTime / (60L * 1000L);
+				Long penaltyTime = contest.getPenaltyTime();
+				if (penaltyTime != null) {
+					pendingPenalty += penaltyTime;
+				}
 				numJudged++;
 			} // else compile or judgement error that doesn't count as an attempt or penalty
 		}

--- a/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
@@ -394,8 +394,8 @@ public class EventFeedUtil {
 				s += " (submissions: " + r.getNumSubmissions();
 				if (r.getStatus() == Status.SOLVED) {
 					s += ", time: " + ContestUtil.getTimeInMin(r.getContestTime());
-					if (r.getPenaltyTime() != 0)
-						s += ", penalty: " + r.getPenaltyTime() + "";
+					if (r.getPenaltyTime() > 0)
+						s += ", penalty: " + ContestUtil.getTimeInMin(r.getPenaltyTime()) + "";
 					s += ")";
 				}
 			}


### PR DESCRIPTION
The previous change for long penalty time was incomplete and causes the penalty to be 0 on the scoreboard. This fixes that problem and follows references to make sure that Result is also fully switched over to long ms time values. Standings and all other classes are left with penalty as an integer (minute) value.