### PR TITLE
Initial HLS support

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/VideoAggregator.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoAggregator.java
@@ -9,6 +9,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.icpc.tools.cds.video.VideoStream.StreamType;
+import org.icpc.tools.cds.video.containers.FLVHandler;
+import org.icpc.tools.cds.video.containers.HLSHandler;
 import org.icpc.tools.cds.video.containers.MPEGTSHandler;
 import org.icpc.tools.cds.video.containers.OggHandler;
 import org.icpc.tools.contest.Trace;
@@ -75,13 +77,20 @@ public class VideoAggregator {
 
 	protected static Stats stats = new Stats();
 
+	protected static VideoHandler[] HANDLERS = { new HLSHandler(), new MPEGTSHandler(), new OggHandler(),
+			new FLVHandler() };
+
 	protected static VideoHandler handler;
 
 	static {
-		if ("true".equals(System.getProperty("ICPC_OGG")))
-			handler = new OggHandler();
+		if ("hls".equalsIgnoreCase(System.getProperty("ICPC_VIDEO")))
+			handler = HANDLERS[0];
+		else if ("ogg".equalsIgnoreCase(System.getProperty("ICPC_VIDEO")))
+			handler = HANDLERS[2];
+		else if ("mpeg".equalsIgnoreCase(System.getProperty("ICPC_VIDEO")))
+			handler = HANDLERS[1];
 		else
-			handler = new MPEGTSHandler();
+			handler = HANDLERS[0];
 	}
 
 	protected static VideoAggregator instance = new VideoAggregator();

--- a/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
@@ -4,16 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 
 public abstract class VideoHandler {
-	public interface IStreamListener {
-		void write(byte[] b);
-
-		void write(byte[] b, int off, int len);
-
-		void flush();
-
-		boolean isDone();
-	}
-
 	/**
 	 * Interface to set and get a stream-specific object, most commonly used to store header
 	 * information.
@@ -23,6 +13,8 @@ public abstract class VideoHandler {
 
 		Object getObject();
 	}
+
+	protected abstract String getName();
 
 	protected abstract String getFileExtension();
 
@@ -36,15 +28,4 @@ public abstract class VideoHandler {
 	 * @throws IOException
 	 */
 	protected abstract boolean validate(InputStream in) throws IOException;
-
-	/**
-	 * Write header/cached information for the given stream.
-	 *
-	 * @throws IOException
-	 */
-	protected void writeHeader(IStore store, IStreamListener listener) throws IOException {
-		// default no-op
-	}
-
-	protected abstract void createReader(InputStream in, IStore store, IStreamListener listener) throws IOException;
 }

--- a/CDS/src/org/icpc/tools/cds/video/VideoServingHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServingHandler.java
@@ -1,0 +1,21 @@
+package org.icpc.tools.cds.video;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public abstract class VideoServingHandler extends VideoHandler {
+
+	/**
+	 * Optional HTTP method for video serving handlers. Responds to "/stream/<id>*".
+	 *
+	 * @param request
+	 * @param response
+	 * @throws IOException
+	 */
+	protected void doGet(HttpServletRequest request, HttpServletResponse response, int stream, IStore store,
+			String subpath) throws IOException {
+		response.sendError(404, "unsupported");
+	}
+}

--- a/CDS/src/org/icpc/tools/cds/video/VideoStreamHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStreamHandler.java
@@ -1,0 +1,27 @@
+package org.icpc.tools.cds.video;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public abstract class VideoStreamHandler extends VideoHandler {
+	public interface IStreamListener {
+		void write(byte[] b);
+
+		void write(byte[] b, int off, int len);
+
+		void flush();
+
+		boolean isDone();
+	}
+
+	/**
+	 * Write header/cached information for the given stream.
+	 *
+	 * @throws IOException
+	 */
+	protected void writeHeader(IStore store, IStreamListener listener) throws IOException {
+		// default no-op
+	}
+
+	protected abstract void createReader(InputStream in, IStore store, IStreamListener listener) throws IOException;
+}

--- a/CDS/src/org/icpc/tools/cds/video/containers/FLVHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/FLVHandler.java
@@ -4,9 +4,14 @@ import java.io.DataInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.icpc.tools.cds.video.VideoHandler;
+import org.icpc.tools.cds.video.VideoStreamHandler;
 
-public class FLVHandler extends VideoHandler {
+public class FLVHandler extends VideoStreamHandler {
+	@Override
+	protected String getName() {
+		return "FLV";
+	}
+
 	@Override
 	protected String getFileExtension() {
 		return "flv";
@@ -38,7 +43,7 @@ public class FLVHandler extends VideoHandler {
 	protected void writeHeader(IStore store, IStreamListener listener) throws IOException {
 		// TODO
 		/*FLVWriter.writeHeader(new DataOutputStream(out));
-
+		
 		FLVReader r = readers.get(stream);
 		if (r != null)
 			r.sendCache(out);*/

--- a/CDS/src/org/icpc/tools/cds/video/containers/FLVReader.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/FLVReader.java
@@ -10,7 +10,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.icpc.tools.cds.video.VideoHandler.IStreamListener;
+import org.icpc.tools.cds.video.VideoStreamHandler.IStreamListener;
 
 public class FLVReader {
 	private byte[] metadata = null;

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
@@ -1,0 +1,161 @@
+package org.icpc.tools.cds.video.containers;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.feed.HTTPSSecurity;
+
+public class HLSFileCache {
+	static class CachedFile {
+		public String name;
+		public byte[] b;
+		public long lastAccess;
+	}
+
+	private Map<String, CachedFile> map = new HashMap<>();
+	private List<String> preload = new ArrayList<>();
+
+	public HLSFileCache() {
+		// create
+	}
+
+	public void cleanCache() {
+		List<String> remove = new ArrayList<>(100);
+
+		long now = System.currentTimeMillis();
+		synchronized (map) {
+			for (String s : map.keySet()) {
+				CachedFile cf = map.get(s);
+				// older than 20s
+				if (cf.lastAccess < now - 20 * 1000L)
+					remove.add(s);
+			}
+		}
+
+		for (String s : remove) {
+			map.remove(s);
+		}
+	}
+
+	public boolean contains(String name) {
+		return map.containsKey(name);
+	}
+
+	public void preload(String name) {
+		if (map.containsKey(name) || preload.contains(name))
+			return;
+		preload.add(name);
+	}
+
+	public boolean hasPreload(String name) {
+		return preload.contains(name);
+	}
+
+	public void cache(String name, InputStream in) throws IOException {
+		ByteArrayOutputStream bout = new ByteArrayOutputStream();
+		BufferedInputStream bin = new BufferedInputStream(in);
+		byte[] b = new byte[1024 * 8];
+		int n = bin.read(b);
+		while (n != -1) {
+			bout.write(b, 0, n);
+			n = bin.read(b);
+		}
+
+		bin.close();
+		bout.close();
+
+		CachedFile cf = new CachedFile();
+		cf.name = name;
+		cf.b = bout.toByteArray();
+		cf.lastAccess = System.currentTimeMillis();
+		map.put(name, cf);
+	}
+
+	public void stream(String name, OutputStream out) throws IOException {
+		CachedFile cf = map.get(name);
+		if (cf == null)
+			throw new IOException("File does not exist");
+
+		cf.lastAccess = System.currentTimeMillis();
+
+		BufferedOutputStream bout = new BufferedOutputStream(out);
+		bout.write(cf.b, 0, cf.b.length);
+		bout.close();
+	}
+
+	protected void cacheIt(String url, String name) {
+		// TODO: what are these gap files and do they matter?
+		if ("gap.mp4".equals(name))
+			return;
+
+		// already cached, don't grab them again
+		if (contains(name))
+			return;
+
+		try {
+			URLConnection conn = HTTPSSecurity.createURLConnection(new URL(url + "/" + name), null, null);
+			conn.setConnectTimeout(15000);
+			conn.setReadTimeout(10000);
+			conn.setRequestProperty("Content-Type", "video/mp4");
+
+			if (conn instanceof HttpURLConnection) {
+				HttpURLConnection httpConn = (HttpURLConnection) conn;
+				int httpStatus = httpConn.getResponseCode();
+				if (httpStatus == HttpURLConnection.HTTP_NOT_FOUND)
+					throw new IOException("404 Not found (" + url + ")");
+				else if (httpStatus == HttpURLConnection.HTTP_UNAUTHORIZED)
+					throw new IOException("Not authorized (HTTP response code 401)");
+			}
+
+			cache(name, conn.getInputStream());
+			System.out.println("  Cache success: " + name);
+		} catch (Exception e) {
+			System.err.println("  Cache fail: " + name);
+			Trace.trace(Trace.ERROR, "Could not cache HLS " + url + "/" + name, e);
+		}
+	}
+
+	protected void preloadIt(String url, String name) {
+		// TODO: what are these gap files and do they matter?
+		if ("gap.mp4".equals(name))
+			return;
+
+		// already cached, don't grab them again
+		if (contains(name))
+			return;
+
+		try {
+			URLConnection conn = HTTPSSecurity.createURLConnection(new URL(url + "/" + name), null, null);
+			conn.setConnectTimeout(15000);
+			conn.setReadTimeout(10000);
+			conn.setRequestProperty("Content-Type", "video/mp4");
+
+			if (conn instanceof HttpURLConnection) {
+				HttpURLConnection httpConn = (HttpURLConnection) conn;
+				int httpStatus = httpConn.getResponseCode();
+				if (httpStatus == HttpURLConnection.HTTP_NOT_FOUND)
+					throw new IOException("404 Not found (" + url + ")");
+				else if (httpStatus == HttpURLConnection.HTTP_UNAUTHORIZED)
+					throw new IOException("Not authorized (HTTP response code 401)");
+			}
+
+			cache(name, conn.getInputStream());
+			System.out.println("  Cache success: " + name);
+		} catch (Exception e) {
+			System.err.println("  Cache fail: " + name);
+			Trace.trace(Trace.ERROR, "Could not cache HLS " + url + "/" + name, e);
+		}
+	}
+}

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSHandler.java
@@ -1,0 +1,270 @@
+package org.icpc.tools.cds.video.containers;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.icpc.tools.cds.video.VideoServingHandler;
+import org.icpc.tools.cds.video.VideoStream;
+import org.icpc.tools.cds.video.VideoStreamHandler.IStreamListener;
+import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.feed.HTTPSSecurity;
+
+/**
+ * HLS handler. https://localhost:8443/stream/11?_HLS_msn=10&_HLS_part=3&_HLS_skip=YES
+ * https://localhost:8443/stream/11?_HLS_msn=10&_HLS_part=4&_HLS_skip=YES
+ */
+// TODO - cache HLS m3u8
+// TODO - handle HLS query params
+// TODO - no hardcoded stream
+// TODO - multiplexing
+// TODO - cache cleanup
+public class HLSHandler extends VideoServingHandler {
+	private static final String HEADER = "#EXTM3U";
+	/*private static final String PARAM_MEDIA = "_HLS_msn";
+	private static final String PARAM_PART = "_HLS_part";
+	private static final String PARAM_SKIP = "_HLS_skip";
+	*/
+	// protected static final HLSFileCache fileCache = new HLSFileCache();
+
+	protected List<String> deleteMe = new ArrayList<>();
+
+	class Store {
+		HLSParser parser;
+	}
+
+	@Override
+	protected String getName() {
+		return "HLS";
+	}
+
+	@Override
+	protected String getFileExtension() {
+		return "m3u8";
+	}
+
+	@Override
+	protected String getMimeType() {
+		return "application/vnd.apple.mpegurl";
+	}
+
+	@Override
+	protected boolean validate(InputStream in) throws IOException {
+		BufferedReader br = null;
+		try {
+			br = new BufferedReader(new InputStreamReader(in));
+
+			String head = br.readLine();
+			return (head != null && head.equals(HEADER));
+		} catch (Exception e) {
+			return false;
+		} finally {
+			if (br != null) {
+				try {
+					br.close();
+				} catch (Exception e) {
+					// ignore
+				}
+			}
+		}
+	}
+
+	// @Override
+	protected void handleIndex(HttpServletRequest request, HttpServletResponse response, int stream, IStore store) {
+		System.out.println("hls index: " + request.getRequestURL());
+		String query = request.getQueryString();
+		if (query != null)
+			System.out.println("  query: " + query);
+
+		/*String media = request.getParameter(PARAM_MEDIA);
+		String part = request.getParameter(PARAM_PART);
+		String skip = request.getParameter(PARAM_SKIP);
+		boolean doSkip = "YES".equals(skip);*/
+
+		VideoStream vs = (VideoStream) store;
+		String url = vs.getURL();
+
+		InputStream in = null;
+		try {
+			URLConnection conn = null;
+			if (query != null)
+				conn = HTTPSSecurity.createURLConnection(new URL(url + "/stream.m3u8?" + query), null, null);
+			else
+				conn = HTTPSSecurity.createURLConnection(new URL(url + "/stream.m3u8"), null, null);
+
+			conn.setConnectTimeout(15000);
+			conn.setReadTimeout(10000);
+			conn.setRequestProperty("Content-Type", "application/vnd.apple.mpegurl");
+			// index.m3u8
+			if (conn instanceof HttpURLConnection) {
+				HttpURLConnection httpConn = (HttpURLConnection) conn;
+				int httpStatus = httpConn.getResponseCode();
+				if (httpStatus == HttpURLConnection.HTTP_NOT_FOUND)
+					throw new IOException("404 Not found (" + url + ")");
+				else if (httpStatus == HttpURLConnection.HTTP_UNAUTHORIZED)
+					throw new IOException("Not authorized (HTTP response code 401)");
+			}
+
+			HLSParser parser = new HLSParser();
+			parser.setURLPrefix(stream + "/");
+
+			in = conn.getInputStream();
+			parser.read(in);
+			response.setContentType(getMimeType());
+			parser.write(response.getOutputStream());
+
+			HLSFileCache fileCache = (HLSFileCache) store.getObject();
+			if (fileCache == null) {
+				fileCache = new HLSFileCache();
+				store.setObject(fileCache);
+			}
+
+			// cache files - segments + parts
+			for (String s : parser.files()) {
+				fileCache.cacheIt(url, s);
+			}
+
+			for (String s : parser.getPreload()) {
+				System.out.println("  preload: " + s);
+				fileCache.preload(s);
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	protected void start(ScheduledExecutorService executor) {
+		// TODO cache cleanup
+		// executor.scheduleAtFixedRate(() -> output(), 5000, 250, TimeUnit.MILLISECONDS);
+	}
+
+	@Override
+	protected void doGet(HttpServletRequest request, HttpServletResponse response, int stream, IStore store, String path)
+			throws IOException {
+		if (path == null) {
+			handleIndex(request, response, stream, store);
+			return;
+		}
+		String name = path;
+		System.out.println("hls: " + name);
+		HLSFileCache fileCache = (HLSFileCache) store.getObject();
+		if (fileCache == null) {
+			response.sendError(HttpServletResponse.SC_NOT_FOUND, "Attempt to load from unindexed stream");
+			return;
+		}
+
+		if (!fileCache.contains(name)) {
+			if (fileCache.hasPreload(name)) {
+				System.err.println("Preload unsupported: " + name);
+				response.sendError(HttpServletResponse.SC_NOT_FOUND);
+				return;
+			}
+			System.err.println("Request to stream an invalid file: " + name);
+			response.sendError(HttpServletResponse.SC_NOT_FOUND);
+			return;
+		}
+
+		try {
+			fileCache.stream(name, response.getOutputStream());
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+	/*@Override
+	protected void createReader(InputStream in, IStore stream, IStreamListener listener) throws IOException {
+		// TODO
+
+		HLSParser hls = (HLSParser) stream.getObject();
+		if (hls == null)
+			hls = new HLSParser();
+
+		HLSParser parser = new HLSParser();
+		parser.read(in);
+
+		// make sure we have all the new files locally, and stream new ones to listener
+		for (Segment seg : parser.playlist) {
+			URL url = new URL(in, seg.file);
+			pullFile(url, listener);
+		}
+
+		// update playlist for all clients
+		stream.setObject(parser);
+
+		// file old files for deletion
+		for (Segment seg : hls.playlist) {
+			boolean found = false;
+			for (Segment seg2 : parser.playlist) {
+				if (seg.file.equals(seg2.file)) {
+					found = true;
+					break;
+				}
+			}
+			if (!found && !deleteMe.contains(seg.file))
+				deleteMe.add(seg.file);
+		}
+
+		//
+	}*/
+
+	protected static String pullFile(URL url, IStreamListener listener) {
+		InputStream in = null;
+		try {
+			URLConnection conn = HTTPSSecurity.createURLConnection(url, null, null);
+			conn.setConnectTimeout(15000);
+			conn.setReadTimeout(10000);
+			conn.setRequestProperty("Content-Type", "video/m2t");
+			if (conn instanceof HttpURLConnection) {
+				HttpURLConnection httpConn = (HttpURLConnection) conn;
+				int httpStatus = httpConn.getResponseCode();
+				if (httpStatus == HttpURLConnection.HTTP_NOT_FOUND)
+					throw new IOException("404 Not found");
+				else if (httpStatus == HttpURLConnection.HTTP_UNAUTHORIZED)
+					throw new IOException("Not authorized (HTTP response code 401)");
+			}
+
+			in = conn.getInputStream();
+
+			String f = "filename";
+			BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(f));
+
+			BufferedInputStream bin = new BufferedInputStream(in);
+			byte[] b = new byte[1024 * 8];
+			int n = bin.read(b);
+			while (n != -1) {
+				out.write(b, 0, n);
+				listener.write(b, 0, n);
+				n = bin.read(b);
+			}
+
+			bin.close();
+			out.close();
+
+			return f;
+		} catch (Exception e) {
+			Trace.trace(Trace.ERROR, "Could not pull video");
+			return null;
+		} finally {
+			if (in != null)
+				try {
+					in.close();
+				} catch (Exception e) {
+					// ignore
+				}
+		}
+	}
+
+}

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
@@ -1,0 +1,201 @@
+package org.icpc.tools.cds.video.containers;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An HLS parser that is able to separate individual segments (files), provide a full list of
+ * references files, output the identical file again, and do URL rewriting by adding prefixes to
+ * relative URLs.
+ */
+public class HLSParser {
+	// #EXT-X-MAP:URI="60aab25693f9_init.mp4"
+	// 60aab25693f9_seg7.mp4
+	// #EXT-X-PART:DURATION=0.20000,URI="60aab25693f9_part23.mp4"
+	// #EXT-X-PRELOAD-HINT:TYPE=PART,URI="b6d064eaa487_part10.mp4"
+
+	private static final String[] EMPTY = new String[0];
+
+	protected String[] header;
+	protected String[] footer;
+	protected String[] footerParts;
+	protected String init;
+	protected List<String> preload = new ArrayList<>();
+
+	protected String urlPrefix;
+
+	class Segment {
+		String[] comments;
+		String[] parts;
+		String file;
+	}
+
+	protected Segment[] playlist;
+
+	public HLSParser() {
+		// todo
+	}
+
+	public void setURLPrefix(String s) {
+		urlPrefix = s;
+	}
+
+	private String[] getURI(String s) {
+		int i = s.indexOf("URI=");
+		if (i < 0)
+			return null;
+		int j = s.indexOf("\"", i + 5);
+		if (j < 0)
+			return null;
+
+		String uri = s.substring(i + 5, j);
+		String edit = s.substring(0, i + 5) + urlPrefix + s.substring(i + 5);
+		return new String[] { uri, edit };
+	}
+
+	public void read(InputStream in) {
+		BufferedReader br = null;
+
+		try {
+			br = new BufferedReader(new InputStreamReader(in));
+
+			String s = br.readLine();
+			List<String> buf = new ArrayList<String>();
+			List<String> filebuf = new ArrayList<String>();
+			List<Segment> segments = new ArrayList<Segment>();
+			while (s != null) {
+				if (s.startsWith("#EXT-X-STREAM-INF:") || s.startsWith("#EXTINF:")) {
+					if (header == null) {
+						header = buf.toArray(EMPTY);
+						buf.clear();
+					}
+
+					buf.add(s);
+				} else if (s.startsWith("#EXT")) {
+					if (s.startsWith("#EXT-X-MAP:")) {
+						String[] ss = getURI(s);
+						init = ss[0];
+						buf.add(ss[1]);
+					} else if (s.startsWith("#EXT-X-PART:")) {
+						String[] ss = getURI(s);
+						filebuf.add(ss[0]);
+						buf.add(ss[1]);
+					} else if (s.startsWith("#EXT-X-PRELOAD-HINT:")) {
+						String[] ss = getURI(s);
+						preload.add(ss[0]);
+						buf.add(ss[1]);
+					} else
+						buf.add(s);
+				} else { // file
+					Segment seg = new Segment();
+					seg.comments = buf.toArray(EMPTY);
+					seg.parts = filebuf.toArray(EMPTY);
+					seg.file = s;
+					segments.add(seg);
+					buf.clear();
+					filebuf.clear();
+				}
+				s = br.readLine();
+			}
+
+			br.close();
+			footer = buf.toArray(EMPTY);
+			footerParts = filebuf.toArray(EMPTY);
+			playlist = segments.toArray(new Segment[0]);
+		} catch (Exception e) {
+			// todo
+			e.printStackTrace();
+		}
+	}
+
+	public List<String> files() {
+		List<String> list = new ArrayList<String>();
+
+		if (init != null)
+			list.add(init);
+
+		for (Segment s : playlist) {
+			list.add(s.file);
+			for (String ss : s.parts) {
+				list.add(ss);
+			}
+			list.add(s.file);
+		}
+
+		if (footerParts != null && footerParts.length > 0) {
+			for (String ss : footerParts) {
+				list.add(ss);
+			}
+		}
+
+		return list;
+	}
+
+	public List<String> getPreload() {
+		return preload;
+	}
+
+	public void write(OutputStream out) {
+		BufferedWriter bw = null;
+		try {
+			bw = new BufferedWriter(new OutputStreamWriter(out));
+
+			if (header != null) {
+				for (String s : header) {
+					bw.write(s);
+					bw.newLine();
+				}
+			}
+
+			if (playlist != null) {
+				for (Segment seg : playlist) {
+					for (String s : seg.comments) {
+						bw.write(s);
+						bw.newLine();
+					}
+
+					if (urlPrefix != null)
+						bw.write(urlPrefix + seg.file);
+					else
+						bw.write(seg.file);
+					bw.newLine();
+				}
+			}
+
+			if (footer != null) {
+				for (String s : footer) {
+					bw.write(s);
+					bw.newLine();
+				}
+			}
+
+			bw.close();
+		} catch (Exception e) {
+			// todo
+			e.printStackTrace();
+		}
+	}
+
+	@Override
+	public String toString() {
+		ByteArrayOutputStream bout = new ByteArrayOutputStream();
+		write(bout);
+		return bout.toString();
+	}
+
+	public static void main(String[] args) {
+		HLSParser parser = new HLSParser();
+		InputStream in = parser.getClass().getResourceAsStream("HLSexample2.m3u8");
+		System.out.println("Reading");
+		parser.read(in);
+		System.out.println("Writing");
+		parser.write(System.out);
+	}
+}

--- a/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
@@ -3,15 +3,20 @@ package org.icpc.tools.cds.video.containers;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.icpc.tools.cds.video.VideoHandler;
+import org.icpc.tools.cds.video.VideoStreamHandler;
 
 /**
  * MPEG-TS handler.
  *
  * For HD webcam, stream is averaging over 1850 packets/s.
  */
-public class MPEGTSHandler extends VideoHandler {
+public class MPEGTSHandler extends VideoStreamHandler {
 	private static final int PACKET_LEN = 188;
+
+	@Override
+	protected String getName() {
+		return "MPEG";
+	}
 
 	@Override
 	protected String getFileExtension() {

--- a/CDS/src/org/icpc/tools/cds/video/containers/OggHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/OggHandler.java
@@ -5,12 +5,17 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.icpc.tools.cds.video.VideoHandler;
+import org.icpc.tools.cds.video.VideoStreamHandler;
 
 /**
  * Ogg container handler.
  */
-public class OggHandler extends VideoHandler {
+public class OggHandler extends VideoStreamHandler {
+	@Override
+	protected String getName() {
+		return "OGG";
+	}
+
 	@Override
 	protected String getFileExtension() {
 		return "ogg";


### PR DESCRIPTION
This is the initial batch of changes to support HLS. It makes the structural/URL-facing changes required to support file-serving video formats (vs streaming), and sets the default video format to HLS (even though it's not really working yet!).

There is a *lot* of change in order to support HLS so I need to start pushing a branch, but there are numerous limitations (and likely some I still don't know about) listed in issue #812 and at the top of the HLSHandler. The current code works for one stream at a time, and hasn't been tested except through Safari.