### PR TITLE
Resolver multi-contest switching

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -68,6 +68,8 @@ public class ResolverUI {
 		public void scroll(boolean pause);
 
 		public void speedFactor(double d);
+
+		public void swap();
 	}
 
 	private static enum Action {
@@ -247,6 +249,9 @@ public class ResolverUI {
 					scoreboardPresentation.setShowSubmissionInfo(!scoreboardPresentation.getShowSubmissionInfo());
 				else if (' ' == e.getKeyChar() || 'f' == e.getKeyChar() || 'F' == e.getKeyChar())
 					processAction(Action.FORWARD);
+
+				else if ('s' == e.getKeyChar() && listener != null)
+					listener.swap();
 			}
 		});
 
@@ -336,6 +341,13 @@ public class ResolverUI {
 			moveTo(firstStep);
 		else
 			moveTo(0);
+	}
+
+	public void setVisible(boolean b) {
+		if (messageFont == null)
+			display();
+
+		window.setVisible(b);
 	}
 
 	private String getStatusInfo() {


### PR DESCRIPTION
We may not use this in Sharm anyway, but I had already written the code and I think it's useful in other cases. The resolver could already load multiple contests (command line argument url1&url2&url3), and this adds support for easily swapping between them at any point by pressing 's'.

For example, if you want to resolve a contest for division 1 and then a second contest for division 2, you don't need to finish one, exit, change the command-line/batch file, and launch the other - you can just resolve one and click 's' to start the next one. Or if you're in Sharm, you could swap back and forth ad nauseam.

This only works for presenters/standalone at the moment, no signal is sent to clients. It may also halve the frame rate after switching (?) because I didn't confirm it totally backgrounds the other contest's UI threads (but it was fast on my machine, so maybe I'm just paranoid). Either of those are simple fixes though.