### PR TITLE
Multi-client resolver swap

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -131,6 +131,7 @@ public class ResolverUI {
 	public void setup(List<ResolutionStep> steps) {
 		this.steps = steps;
 
+		control = new ResolutionControl(steps);
 		IContest contest = getFirstContest();
 		IResolveInfo resolveInfo = contest.getResolveInfo();
 		if (resolveInfo != null) {
@@ -140,7 +141,6 @@ public class ResolverUI {
 				firstStep = resolveInfo.getClicks() % 1000 + 1000;
 		}
 
-		control = new ResolutionControl(steps);
 		control.addListener(new IResolutionListener() {
 			@Override
 			public void toPause(int pause, boolean includeDelays) {


### PR DESCRIPTION
Implemented a property to let clients know when the resolver presenter switches active UIs (contests). This is really just bringing back one global property so the code is almost copy/paste of some of the previous code.

Using this I am able to bring up a resolver presenter and client both pointing to two contests, and you can resolve and swap both whenever you want. Alternately, you could still have two clients each pointing to a different contest; the single presenter can still swap between them and resolve. I used a string contest id property so technically you could have one presenter controlling multiple clients each of which is showing different contests... although that'd be confusing.

I've confirmed that swapping UIs means that the unswapped presentations are still running in the background. There's no impact on my macbook but might be a little slower on other platforms? I'll release a fix for that independently.

Includes a timing fix for creating the UI before adjusting the speed factor.