### PR TITLE
Empty locations

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -105,7 +105,9 @@ public class Group extends ContestObject implements IGroup {
 				return true;
 			}
 			case LOCATION: {
-				location = new Location(value);
+				Location loc = new Location(value);
+				if (loc.isValid())
+					location = loc;
 				return true;
 			}
 			case LOGO: {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -263,7 +263,9 @@ public class Info extends ContestObject implements IInfo {
 			timeMultiplier = parseDouble(value);
 			return true;
 		} else if (name2.equals(LOCATION)) {
-			location = new Location(value);
+			Location loc = new Location(value);
+			if (loc.isValid())
+				location = loc;
 			return true;
 		} else if (name2.equals(SCOREBOARD_TYPE)) {
 			if ("pass-fail".equals(value))

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Location.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Location.java
@@ -46,7 +46,15 @@ public class Location {
 	}
 
 	protected String getJSON() {
-		return "{\"" + LATITUDE + "\":" + round(latitude) + ",\"" + LONGITUDE + "\":" + round(longitude) + "}";
+		StringBuilder sb = new StringBuilder("{");
+		if (!Double.isNaN(latitude))
+			sb.append("\"" + LATITUDE + "\":" + round(latitude));
+		if (!Double.isNaN(latitude) && !Double.isNaN(longitude))
+			sb.append(",");
+		if (!Double.isNaN(longitude))
+			sb.append("\"" + LONGITUDE + "\":" + round(longitude));
+		sb.append("}");
+		return sb.toString();
 	}
 
 	private static double round(double d) {
@@ -70,6 +78,10 @@ public class Location {
 			return false;
 
 		return true;
+	}
+
+	public boolean isValid() {
+		return !Double.isNaN(latitude) && !Double.isNaN(longitude);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -167,7 +167,9 @@ public class Organization extends ContestObject implements IOrganization {
 				return true;
 			}
 			case LOCATION: {
-				location = new Location(value);
+				Location loc = new Location(value);
+				if (loc.isValid())
+					location = loc;
 				return true;
 			}
 			case LOGO: {


### PR DESCRIPTION
The CMS outputs empty locations (location:{}) for orgs that don't have one set. Although we're trying to fill these in, it's better if the CDS doesn't have a location element for these cases, or where the location wasn't readable.