### PR TITLE
HLS improvements

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -166,9 +166,6 @@ public class VideoServlet extends HttpServlet {
 			}
 		}
 
-		Trace.trace(Trace.INFO, "Video request: " + request.getRemoteUser() + " requesting video " + stream + " -> "
-				+ vs.getName() + " (channel: " + channel + ")");
-
 		if (VideoAggregator.handler instanceof VideoServingHandler) {
 			((VideoServingHandler) VideoAggregator.handler).doGet(request, response, stream, vs, subpath);
 		} else {
@@ -178,6 +175,10 @@ public class VideoServlet extends HttpServlet {
 
 	public static void streamVideo(HttpServletRequest request, HttpServletResponse response, final int stream,
 			VideoStream vs, boolean channel, boolean isStaff) throws IOException {
+
+		Trace.trace(Trace.INFO, "Video request: " + request.getRemoteUser() + " requesting video " + stream + " -> "
+				+ vs.getName() + " (channel: " + channel + ")");
+
 		response.setHeader("Cache-Control", "no-cache");
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		response.setHeader("X-Accel-Buffering", "no");

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
@@ -20,12 +20,13 @@ import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.feed.HTTPSSecurity;
 
 public class HLSFileCache {
-	private static final long CACHE_TIME = 20 * 1000L; // 20s
+	private static final long CACHE_TIME = 10 * 1000L; // 10s
 
 	static class CachedFile {
 		public String name;
 		public byte[] b;
-		public long lastAccess;
+		public long storeTime;
+		public long lastAccessTime;
 	}
 
 	private HLSParser parser;
@@ -46,8 +47,8 @@ public class HLSFileCache {
 		synchronized (map) {
 			for (String s : map.keySet()) {
 				CachedFile cf = map.get(s);
-				// older than 20s
-				if (cf.lastAccess < now - CACHE_TIME)
+				// remove anything older than the cache time
+				if (cf.storeTime < now - CACHE_TIME)
 					remove.add(s);
 				else
 					size += cf.b.length;
@@ -90,7 +91,7 @@ public class HLSFileCache {
 		CachedFile cf = new CachedFile();
 		cf.name = name;
 		cf.b = bout.toByteArray();
-		cf.lastAccess = System.currentTimeMillis();
+		cf.storeTime = System.currentTimeMillis();
 		map.put(name, cf);
 	}
 
@@ -99,7 +100,7 @@ public class HLSFileCache {
 		if (cf == null)
 			throw new IOException("File does not exist");
 
-		cf.lastAccess = System.currentTimeMillis();
+		cf.lastAccessTime = System.currentTimeMillis();
 
 		BufferedOutputStream bout = new BufferedOutputStream(out);
 		bout.write(cf.b, 0, cf.b.length);

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
@@ -10,6 +10,8 @@ import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.icpc.tools.contest.Trace;
+
 /**
  * An HLS parser that is able to separate individual segments (files), provide a full list of
  * references files, output the identical file again, and do URL rewriting by adding prefixes to
@@ -38,6 +40,7 @@ public class HLSParser {
 	protected String[] footerParts;
 	protected String init;
 	protected List<String> preload = new ArrayList<>();
+	protected long readTime;
 
 	protected String urlPrefix;
 
@@ -127,9 +130,10 @@ public class HLSParser {
 			footerParts = filebuf.toArray(EMPTY);
 			playlist = segments.toArray(new Segment[0]);
 		} catch (Exception e) {
-			// todo
-			e.printStackTrace();
+			Trace.trace(Trace.ERROR, "Error parsing HLS index", e);
 		}
+
+		readTime = System.currentTimeMillis();
 	}
 
 	public List<String> filesToDownload() {
@@ -197,8 +201,7 @@ public class HLSParser {
 
 			bw.close();
 		} catch (Exception e) {
-			// todo
-			e.printStackTrace();
+			Trace.trace(Trace.ERROR, "Error writing HLS index", e);
 		}
 	}
 


### PR DESCRIPTION
Made a few changes after testing against Patrick's cameras:
- Indefinite HLS index caching was breaking the video - only cache for 500ms (unfortunately this means the index cache rarely gets hit).
- The cache size for very low bandwidth feed for 20s was 2.9Mb. Drop the cache to 10s, and from the time of storing instead of last access. This drops it to ~1.4Mb/stream (still low bandwidth).
- Redid some of the logging and replaced e.printStackTrace()s. We still need to reduce console output per stream - but after caching is fixed.