### PR TITLE
Contest access should null out file references, not create empty lists

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -158,6 +158,19 @@ public abstract class ContestObject implements IContestObject {
 		return Timestamp.parse((String) value);
 	}
 
+	protected static FileReferenceList parseFileReference(Object value) {
+		if (value == null)
+			return null;
+		return new FileReferenceList(value);
+	}
+
+	protected static Location parseLocation(Object value) {
+		Location loc = new Location(value);
+		if (loc.isValid())
+			return loc;
+		return null;
+	}
+
 	public static long getTime(IContestObject obj) {
 		if (obj instanceof TimedEvent) {
 			return ((TimedEvent) obj).getTime();

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
@@ -27,8 +27,10 @@ public class FileReferenceList implements Iterable<FileReference> {
 			return;
 		}
 		Object[] objs = JSONParser.getOrReadArray(value);
-		for (Object obj : objs) {
-			refs.add(new FileReference((JsonObject) obj));
+		if (objs != null) {
+			for (Object obj : objs) {
+				refs.add(new FileReference((JsonObject) obj));
+			}
 		}
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -105,13 +105,11 @@ public class Group extends ContestObject implements IGroup {
 				return true;
 			}
 			case LOCATION: {
-				Location loc = new Location(value);
-				if (loc.isValid())
-					location = loc;
+				location = parseLocation(value);
 				return true;
 			}
 			case LOGO: {
-				logo = new FileReferenceList(value);
+				logo = parseFileReference(value);
 				return true;
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -263,9 +263,7 @@ public class Info extends ContestObject implements IInfo {
 			timeMultiplier = parseDouble(value);
 			return true;
 		} else if (name2.equals(LOCATION)) {
-			Location loc = new Location(value);
-			if (loc.isValid())
-				location = loc;
+			location = parseLocation(value);
 			return true;
 		} else if (name2.equals(SCOREBOARD_TYPE)) {
 			if ("pass-fail".equals(value))
@@ -276,10 +274,10 @@ public class Info extends ContestObject implements IInfo {
 				return false;
 			return true;
 		} else if (name2.equals(LOGO)) {
-			logo = new FileReferenceList(value);
+			logo = parseFileReference(value);
 			return true;
 		} else if (name2.equals(BANNER)) {
-			banner = new FileReferenceList(value);
+			banner = parseFileReference(value);
 			return true;
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -167,17 +167,15 @@ public class Organization extends ContestObject implements IOrganization {
 				return true;
 			}
 			case LOCATION: {
-				Location loc = new Location(value);
-				if (loc.isValid())
-					location = loc;
+				location = parseLocation(value);
 				return true;
 			}
 			case LOGO: {
-				logo = new FileReferenceList(value);
+				logo = parseFileReference(value);
 				return true;
 			}
 			case COUNTRY_FLAG: {
-				countryFlag = new FileReferenceList(value);
+				countryFlag = parseFileReference(value);
 				return true;
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -173,35 +173,37 @@ public class Person extends ContestObject implements IPerson {
 				return true;
 			}
 			case ROLE: {
-				role = (String) value;
+				role = (String) value; // TODO - ClassCast - Object[1] {"staff"}
+				if (role != null && !role.equals("contestant") && !role.equals("coach") && !role.equals("staff"))
+					role = "other";
 				return true;
 			}
 			case PHOTO: {
-				photo = new FileReferenceList(value);
+				photo = parseFileReference(value);
 				return true;
 			}
 			case DESKTOP: {
-				desktop = new FileReferenceList(value);
+				desktop = parseFileReference(value);
 				return true;
 			}
 			case WEBCAM: {
-				webcam = new FileReferenceList(value);
+				webcam = parseFileReference(value);
 				return true;
 			}
 			case AUDIO: {
-				audio = new FileReferenceList(value);
+				audio = parseFileReference(value);
 				return true;
 			}
 			case BACKUP: {
-				backup = new FileReferenceList(value);
+				backup = parseFileReference(value);
 				return true;
 			}
 			case KEY_LOG: {
-				keylog = new FileReferenceList(value);
+				keylog = parseFileReference(value);
 				return true;
 			}
 			case TOOL_DATA: {
-				tooldata = new FileReferenceList(value);
+				tooldata = parseFileReference(value);
 				return true;
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -217,11 +217,11 @@ public class Problem extends ContestObject implements IProblem {
 				return true;
 			}
 			case PACKAGE: {
-				package_ = new FileReferenceList(value);
+				package_ = parseFileReference(value);
 				return true;
 			}
 			case STATEMENT: {
-				statement = new FileReferenceList(value);
+				statement = parseFileReference(value);
 				return true;
 			}
 			default:

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -141,10 +141,10 @@ public class Submission extends TimedEvent implements ISubmission {
 			entryPoint = (String) value;
 			return true;
 		} else if (FILES.equals(name)) {
-			files = new FileReferenceList(value);
+			files = parseFileReference(value);
 			return true;
 		} else if (REACTION.equals(name)) {
-			reaction = new FileReferenceList(value);
+			reaction = parseFileReference(value);
 			return true;
 		}
 		return super.addImpl(name, value);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -339,35 +339,35 @@ public class Team extends ContestObject implements ITeam {
 				return true;
 			}
 			case PHOTO: {
-				photo = new FileReferenceList(value);
+				photo = parseFileReference(value);
 				return true;
 			}
 			case VIDEO: {
-				video = new FileReferenceList(value);
+				video = parseFileReference(value);
 				return true;
 			}
 			case BACKUP: {
-				backup = new FileReferenceList(value);
+				backup = parseFileReference(value);
 				return true;
 			}
 			case KEY_LOG: {
-				keylog = new FileReferenceList(value);
+				keylog = parseFileReference(value);
 				return true;
 			}
 			case TOOL_DATA: {
-				tooldata = new FileReferenceList(value);
+				tooldata = parseFileReference(value);
 				return true;
 			}
 			case DESKTOP: {
-				desktop = new FileReferenceList(value);
+				desktop = parseFileReference(value);
 				return true;
 			}
 			case WEBCAM: {
-				webcam = new FileReferenceList(value);
+				webcam = parseFileReference(value);
 				return true;
 			}
 			case AUDIO: {
-				audio = new FileReferenceList(value);
+				audio = parseFileReference(value);
 				return true;
 			}
 			case HIDDEN: {


### PR DESCRIPTION
While testing the contest access policy I noticed that if you don't have access to something like a webcam then you see "webcam:[]" instead of not seeing it at all. This is because you couldn't truly null something out via set("webcam",null) since it would parse as an empty file reference. Use a common parseFileReference() method to check this in one place, and update Location to do the same thing.