### PR TITLE
Resolver clients shouldn't have control

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -289,7 +289,7 @@ public class Resolver {
 							if (newActiveUI == -1)
 								return;
 
-							Trace.trace(Trace.ERROR, "Switching active UI to " + newActiveUI);
+							Trace.trace(Trace.INFO, "Switching active UI to " + newActiveUI);
 							ui[activeUI].setVisible(false);
 							activeUI = newActiveUI;
 							if (activeUI > ui.length)
@@ -625,8 +625,8 @@ public class Resolver {
 	}
 
 	protected ResolverUI createUI(List<ResolutionStep> steps) {
-		ResolverUI ui2 = new ResolverUI(show_info, new DisplayConfig(displayStr, multiDisplayStr),
-				isPresenter || client == null, screen, new ClickListener() {
+		ResolverUI ui2 = new ResolverUI(show_info, new DisplayConfig(displayStr, multiDisplayStr), isPresenter, screen,
+				new ClickListener() {
 					@Override
 					public void clicked(int num) {
 						sendClicks(num);


### PR DESCRIPTION
Due to the refactoring of the resolver code, client is loaded later and would sometimes be null at line 629, which meant non-presenter clients would have keyboard control. It wouldn't send events in, but it could get things out of sync until the presenter does something. This change makes it clear that isPresenter is the only indicator of control.

Fixed one ERROR to INFO.