### PR TITLE
Send back empty JSON object for singletons.

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -371,6 +371,9 @@ public class ContestRESTService extends HttpServlet {
 				writer.write(obj);
 			}
 		}
+		if (IContestObject.isSingleton(type) && objects.length == 0) {
+			writer.writeEmpty();
+		}
 		if (isArray)
 			writer.writePostlude();
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONArrayWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONArrayWriter.java
@@ -28,6 +28,11 @@ public class JSONArrayWriter {
 		je.close();
 	}
 
+	public void writeEmpty() {
+		je.open();
+		je.close();
+	}
+
 	public void writeSeparator() {
 		je.writeSeparator();
 	}


### PR DESCRIPTION
Fixes #860.

This make it that when we don't have a singleton object, we return `{}`.
Does this make sense for all singletons?