### PR TITLE
Return valid (empty) contest state if it has never been set

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -96,6 +96,8 @@ public class Contest implements IContest {
 
 	public Contest(boolean keepHistory) {
 		data = new ContestData(keepHistory);
+		data.add(info);
+		data.add(state);
 	}
 
 	@Override
@@ -742,9 +744,8 @@ public class Contest implements IContest {
 	}
 
 	public boolean isDoneUpdating() {
-		IState state2 = getState();
-		if (state2 != null)
-			return state2.isDoneUpdating();
+		if (state != null)
+			return state.isDoneUpdating();
 
 		return false;
 	}


### PR DESCRIPTION
The contest's initial info and state were being set in the initializer, but not written into the contest data in the constructor. With a default/empty state the endpoint correctly returns "{}".

Fixes #860.