### PR TITLE
Hide clarification reply to id if the account can't see it

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -16,6 +16,7 @@ import org.icpc.tools.contest.model.IState;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.internal.Account;
+import org.icpc.tools.contest.model.internal.Clarification;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.Judgement;
 import org.icpc.tools.contest.model.internal.Person;
@@ -213,8 +214,10 @@ public class PublicContest extends Contest implements IFilteredContest {
 				IClarification clar = (IClarification) obj;
 
 				// everyone sees broadcasts
-				if (clar.getFromTeamId() == null && clar.getToTeamId() == null)
+				if (clar.getFromTeamId() == null && clar.getToTeamId() == null) {
+					clar = filterClarification(clar);
 					super.add(clar);
+				}
 
 				return;
 			}
@@ -264,6 +267,21 @@ public class PublicContest extends Contest implements IFilteredContest {
 		p.add(EMAIL, null);
 		p.add(SEX, null);
 		return p;
+	}
+
+	/**
+	 * Helper method for subclasses to filter clarifications.
+	 */
+	protected IClarification filterClarification(IClarification clar) {
+		String rtId = clar.getReplyToId();
+		if (getClarificationById(rtId) == null) {
+			// strip reply_to_id if this account can't see it
+			// (e.g. in case a response to a team was broadcast to everyone)
+			Clarification c = (Clarification) ((Clarification) clar).clone();
+			c.add("reply_to_id", null);
+			return c;
+		}
+		return clar;
 	}
 
 	/**

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
@@ -88,11 +88,13 @@ public class TeamContest extends PublicContest {
 
 				// teams see messages to or from them
 				if (clar.getFromTeamId() != null && teamId.equals(clar.getFromTeamId())) {
+					clar = filterClarification(clar);
 					addIt(clar);
 					return;
 				}
 
 				if (clar.getToTeamId() != null && teamId.equals(clar.getToTeamId())) {
+					clar = filterClarification(clar);
 					addIt(clar);
 					return;
 				}


### PR DESCRIPTION
Removes the clarification reply_to_id if the receiver can't see the original clarification.

Mostly for paranoia and consistentcy it's done for teams as well.

Fixes #871.