### PR TITLE
Correctly filter objects sent on thaw

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -56,8 +56,10 @@ public class AnalystContest extends SpectatorContest {
 				// hide runs for submissions after freeze
 				if (getFreezeDuration() != null) {
 					long freezeTime = getDuration() - getFreezeDuration();
-					if (s.getContestTime() >= freezeTime)
+					if (s.getContestTime() >= freezeTime && getState().getThawed() != null) {
+						freeze.add(run);
 						return;
+					}
 				}
 
 				addIt(run);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/BalloonContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/BalloonContest.java
@@ -59,6 +59,7 @@ public class BalloonContest extends PublicContest {
 				return;
 			}
 
+			// never add to freeze list b/c we don't want to print balloons on thaw
 			return;
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -54,6 +54,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 
 	protected List<IProblem> problems = new ArrayList<>();
 
+	// objects seen during the freeze that should be sent on thaw
 	protected List<IContestObject> freeze = new ArrayList<>();
 
 	public PublicContest() {
@@ -113,11 +114,8 @@ public class PublicContest extends Contest implements IFilteredContest {
 					}
 					problems.clear();
 				}
-				if (state.getThawed() != null) {
-					for (IContestObject co : freeze) {
-						super.add(co);
-					}
-					freeze.clear();
+				if (state.getThawed() != null && !freeze.isEmpty()) {
+					thaw();
 				}
 				return;
 			}
@@ -204,7 +202,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 				// or during the freeze
 				if (getFreezeDuration() != null) {
 					long freezeTime = getDuration() - getFreezeDuration();
-					if (time >= freezeTime) {
+					if (time >= freezeTime && getState().getThawed() != null) {
 						freeze.add(j);
 						return;
 					}
@@ -242,6 +240,14 @@ public class PublicContest extends Contest implements IFilteredContest {
 			default:
 				return;
 		}
+	}
+
+	protected void thaw() {
+		for (IContestObject co : freeze) {
+			// send objects back through add() to ensure filtering
+			add(co);
+		}
+		freeze.clear();
 	}
 
 	/**


### PR DESCRIPTION
Moved thawing out to its own method, and call add() to make sure objects are still filtered if necessary. Required a couple new checks to let objects through if the contest was frozen but is now thawed.

The original issue mentioned a few object filtering methods:
- Judgement - should now be sent filtered.
- Person - not filtered during the freeze, irrelevant.
- Problem - not filtered during the freeze, irrelevant.
- Submission - some properties are filtered, but I'm not going to get fancy in this PR and try to update them later. It actually should be as simple as adding them to 'freeze', but that can be done later.

Fixes #859.