### PR TITLE
Coach view: avoid error when reactions is null

### DIFF
--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -303,13 +303,15 @@ public class CoachView extends Panel {
 			@Override
 			public void mouseClicked(MouseEvent e) {
 				String reactionURL = null;
-				for (Rectangle r : reactions.keySet()) {
-					if (r.contains(e.getX(), e.getY())) {
-						reactionURL = reactions.get(r);
+				if (reactions != null) {
+					for (Rectangle r : reactions.keySet()) {
+						if (r.contains(e.getX(), e.getY())) {
+							reactionURL = reactions.get(r);
+						}
 					}
+					if (reactionURL == null)
+						return;
 				}
-				if (reactionURL == null)
-					return;
 
 				Trace.trace(Trace.INFO, "Selected reaction: " + reactionURL);
 				displayMode = DisplayMode.REACTION;


### PR DESCRIPTION
During testing I found a case where reactions == null, just catching this case to avoid error.