### PR TITLE
Reduce fps when not visible

### DIFF
--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -364,6 +364,12 @@ public class PresentationWindowImpl extends PresentationWindow {
 					long ns = System.nanoTime();
 					long startTime = ns;
 					while (true) {
+						// check if the window is visible
+						if (!isVisible()) {
+							// we're in the background, just delay by 500ms to slow things down
+							LockSupport.parkNanos(500 * 1000000L);
+						}
+
 						long now = System.nanoTime();
 						try {
 							boolean b = false;


### PR DESCRIPTION
When the window is not visible, slow down the frame rate to avoid using CPU.