### PR TITLE
Allow contest object filtering by null

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -325,6 +325,8 @@ public class ContestRESTService extends HttpServlet {
 				StringTokenizer st = new StringTokenizer(val2, ",");
 				while (st.hasMoreTokens()) {
 					String val = st.nextToken();
+					if ("<null>".equals(val))
+						val = null;
 					propFilter.addFilter(name, val);
 				}
 			}


### PR DESCRIPTION
Just allows you to filter properties by `"<null>"` to find cases where a property is unset.