### PR TITLE
Remove default contest info

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -96,7 +96,6 @@ public class Contest implements IContest {
 
 	public Contest(boolean keepHistory) {
 		data = new ContestData(keepHistory);
-		data.add(info);
 		data.add(state);
 	}
 


### PR DESCRIPTION
When we fixed an issue with default contest state I thought I'd be clever and also fix the default contest info. This was a bad idea, because a default contest info has no id or name, since we don't know that yet. And having a contest info with the wrong id, etc. in the history causes worse problem, like not merging correctly when there is new data, causing the / endpoint to return two contests, scoreboards to fail, ...

There was no need to make this part of the change, so let's remove it. :)