### PR TITLE
Resolver scrolling speed control

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ResolverService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ResolverService.java
@@ -164,6 +164,9 @@ public class ResolverService {
 							if (resolveInfo.getSpeedFactor() != Double.NaN) {
 								control.setSpeedFactor(resolveInfo.getSpeedFactor());
 							}
+							if (resolveInfo.getScrollSpeedFactor() != Double.NaN) {
+								control.setScrollSpeedFactor(resolveInfo.getScrollSpeedFactor());
+							}
 							int pause = resolveInfo.getClicks();
 							if (pause >= 0 && resolveInfo.getClicks() != control.getCurrentPause()) {
 								boolean includeDelays = true;

--- a/ContestModel/src/org/icpc/tools/contest/model/IResolveInfo.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IResolveInfo.java
@@ -33,7 +33,7 @@ public interface IResolveInfo extends IContestObject {
 	double getSpeedFactor();
 
 	/**
-	 * Returns the scroll speed factor. Normal speed is 1, <1 is faster and >1 is slower.
+	 * Returns the scroll speed factor. Normal speed is 1, >1 is faster and <1 is slower.
 	 *
 	 * @return the relative scrolling speed
 	 */

--- a/ContestModel/src/org/icpc/tools/contest/model/IResolveInfo.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IResolveInfo.java
@@ -33,6 +33,13 @@ public interface IResolveInfo extends IContestObject {
 	double getSpeedFactor();
 
 	/**
+	 * Returns the scroll speed factor. Normal speed is 1, <1 is faster and >1 is slower.
+	 *
+	 * @return the relative scrolling speed
+	 */
+	double getScrollSpeedFactor();
+
+	/**
 	 * Returns true if animation is currently paused.
 	 *
 	 * @return true if animation is paused

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ResolveInfo.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ResolveInfo.java
@@ -11,6 +11,7 @@ import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 public class ResolveInfo extends ContestObject implements IResolveInfo {
 	private static final String CLICKS = "clicks";
 	private static final String SPEED_FACTOR = "speed_factor";
+	private static final String SCROLL_SPEED_FACTOR = "scroll_speed_factor";
 	private static final String ANIMATION_PAUSE = "animation_pause";
 	private static final String SINGLE_STEP_ROW = "single_step_row";
 	private static final String ROW_OFFSET = "row_offset";
@@ -20,6 +21,7 @@ public class ResolveInfo extends ContestObject implements IResolveInfo {
 
 	private int clicks = Integer.MIN_VALUE;
 	private double speedFactor = Double.NaN;
+	private double scrollSpeedFactor = Double.NaN;
 	private boolean animationPause = false;
 	private int singleStepRow = Integer.MIN_VALUE;
 	private int rowOffset = Integer.MIN_VALUE;
@@ -47,6 +49,11 @@ public class ResolveInfo extends ContestObject implements IResolveInfo {
 	@Override
 	public double getSpeedFactor() {
 		return speedFactor;
+	}
+
+	@Override
+	public double getScrollSpeedFactor() {
+		return scrollSpeedFactor;
 	}
 
 	@Override
@@ -83,6 +90,14 @@ public class ResolveInfo extends ContestObject implements IResolveInfo {
 			case SPEED_FACTOR: {
 				try {
 					speedFactor = Double.parseDouble((String) value);
+				} catch (Exception e) {
+					// ignore
+				}
+				return true;
+			}
+			case SCROLL_SPEED_FACTOR: {
+				try {
+					scrollSpeedFactor = Double.parseDouble((String) value);
 				} catch (Exception e) {
 					// ignore
 				}
@@ -137,6 +152,8 @@ public class ResolveInfo extends ContestObject implements IResolveInfo {
 			props.addInt(CLICKS, clicks);
 		if (!Double.isNaN(speedFactor))
 			props.addDouble(SPEED_FACTOR, speedFactor);
+		if (!Double.isNaN(scrollSpeedFactor))
+			props.addDouble(SCROLL_SPEED_FACTOR, scrollSpeedFactor);
 		if (animationPause)
 			props.add(ANIMATION_PAUSE, "true");
 		if (singleStepRow >= 0)
@@ -168,6 +185,7 @@ public class ResolveInfo extends ContestObject implements IResolveInfo {
 		r.id = id;
 		r.clicks = clicks;
 		r.speedFactor = speedFactor;
+		r.scrollSpeedFactor = scrollSpeedFactor;
 		r.animationPause = animationPause;
 		r.singleStepRow = singleStepRow;
 		r.rowOffset = rowOffset;
@@ -181,6 +199,10 @@ public class ResolveInfo extends ContestObject implements IResolveInfo {
 
 	public void setSpeedFactor(double speedFactor) {
 		this.speedFactor = speedFactor;
+	}
+
+	public void setScrollSpeedFactor(double scrollSpeedFactor) {
+		this.scrollSpeedFactor = scrollSpeedFactor;
 	}
 
 	public void setAnimationPause(boolean animPause) {

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionControl.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionControl.java
@@ -14,6 +14,7 @@ public class ResolutionControl {
 	private int currentPause = -1;
 	private int currentStep = -1;
 	private double speedFactor = 1;
+	private double scrollSpeedFactor = 1;
 	private boolean stepping;
 
 	private final List<IResolutionListener> listeners = new ArrayList<>();
@@ -56,6 +57,14 @@ public class ResolutionControl {
 
 	public void setSpeedFactor(double d) {
 		speedFactor = d;
+	}
+
+	public double getScrollSpeedFactor() {
+		return scrollSpeedFactor;
+	}
+
+	public void setScrollSpeedFactor(double d) {
+		scrollSpeedFactor = d;
 	}
 
 	private void notifyListenersAtStep(ResolutionStep step) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamListPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamListPresentation.java
@@ -38,6 +38,7 @@ public class TeamListPresentation extends AbstractICPCPresentation {
 
 	private Animator scroll = new Animator(0, new Movement(0.5, 0.75));
 	private boolean scrollPause = false;
+	private double scrollSpeed = 1.0;
 	private IAward award;
 
 	private ITeam[] teams;
@@ -164,7 +165,7 @@ public class TeamListPresentation extends AbstractICPCPresentation {
 	@Override
 	public void incrementTimeMs(long dt) {
 		if (!scrollPause)
-			scroll.incrementTimeMs(dt);
+			scroll.incrementTimeMs((long) (dt * scrollSpeed));
 		super.incrementTimeMs(dt);
 	}
 
@@ -250,6 +251,10 @@ public class TeamListPresentation extends AbstractICPCPresentation {
 
 	public void setScrollPause(boolean pause) {
 		scrollPause = pause;
+	}
+
+	public void setScrollSpeed(double d) {
+		scrollSpeed = d;
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScrollingScoreboardPresentation.java
@@ -20,6 +20,7 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 
 	private Integer scrollToRow = null;
 	private boolean scrollPause = false;
+	private double scrollSpeed = 1.0;
 
 	private int getNumPages() {
 		IContest contest = getContest();
@@ -54,6 +55,10 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 			setScrollToRow(null);
 	}
 
+	public void setScrollSpeed(double d) {
+		scrollSpeed = d;
+	}
+
 	@Override
 	public void aboutToShow() {
 		super.aboutToShow();
@@ -64,7 +69,7 @@ public class AbstractScrollingScoreboardPresentation extends AbstractScoreboardP
 	@Override
 	public void incrementTimeMs(long dt) {
 		if (!scrollPause)
-			rowScroll.incrementTimeMs(dt);
+			rowScroll.incrementTimeMs((long) (dt * scrollSpeed));
 
 		super.incrementTimeMs(dt);
 	}

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -643,6 +643,11 @@ public class Resolver {
 					}
 
 					@Override
+					public void scrollSpeedFactor(double d) {
+						sendScrollSpeedFactor(d);
+					}
+
+					@Override
 					public void swap() {
 						if (ui.length == 1)
 							return;
@@ -720,6 +725,15 @@ public class Resolver {
 
 		ResolveInfo resolveInfo = new ResolveInfo();
 		resolveInfo.setSpeedFactor(factor);
+		putResolve(resolveInfo);
+	}
+
+	private void sendScrollSpeedFactor(double factor) {
+		if (!isPresenter || client == null)
+			return;
+
+		ResolveInfo resolveInfo = new ResolveInfo();
+		resolveInfo.setScrollSpeedFactor(factor);
 		putResolve(resolveInfo);
 	}
 

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -69,6 +69,8 @@ public class ResolverUI {
 
 		public void speedFactor(double d);
 
+		public void scrollSpeedFactor(double d);
+
 		public void swap();
 	}
 
@@ -137,6 +139,10 @@ public class ResolverUI {
 		if (resolveInfo != null) {
 			if (!Double.isNaN(resolveInfo.getSpeedFactor()))
 				setSpeedFactor(resolveInfo.getSpeedFactor());
+
+			if (!Double.isNaN(resolveInfo.getScrollSpeedFactor()))
+				setScrollSpeedFactor(resolveInfo.getScrollSpeedFactor());
+
 			if (resolveInfo.getClicks() >= 0)
 				firstStep = resolveInfo.getClicks() % 1000 + 1000;
 		}
@@ -239,11 +245,17 @@ public class ResolverUI {
 				else if ('+' == e.getKeyChar() || '=' == e.getKeyChar() || KeyEvent.VK_UP == e.getKeyCode())
 					setSpeedFactorImpl(control.getSpeedFactor() * 0.8);
 				else if ('-' == e.getKeyChar() || '_' == e.getKeyChar() || KeyEvent.VK_DOWN == e.getKeyCode())
-					setSpeedFactorImpl(control.getSpeedFactor() * 1.2); // should only affect the
+					setSpeedFactorImpl(control.getSpeedFactor() * 1.2); // TODO should only affect the
 																							// 'current' animation??
-				else if ('j' == e.getKeyChar() || 'J' == e.getKeyChar())
-					setSpeedFactorImpl(1.0); // TODO should reset to what the command line is??
-				else if ('p' == e.getKeyChar()) {
+				else if ('[' == e.getKeyChar() || '{' == e.getKeyChar())
+					setScrollSpeedFactorImpl(control.getScrollSpeedFactor() * 0.8);
+				else if (']' == e.getKeyChar() || '}' == e.getKeyChar())
+					setScrollSpeedFactorImpl(control.getScrollSpeedFactor() * 1.2);
+				else if ('j' == e.getKeyChar() || 'J' == e.getKeyChar()) {
+					// TODO should reset to what the command line is??
+					setSpeedFactorImpl(1.0);
+					setScrollSpeedFactor(1.0);
+				} else if ('p' == e.getKeyChar()) {
 					setScrollPauseImpl(!pauseScroll);
 				} else if ('i' == e.getKeyChar())
 					scoreboardPresentation.setShowSubmissionInfo(!scoreboardPresentation.getShowSubmissionInfo());
@@ -421,6 +433,25 @@ public class ResolverUI {
 		control.setSpeedFactor(d);
 	}
 
+	private void setScrollSpeedFactorImpl(double d) {
+		if (listener != null)
+			listener.scrollSpeedFactor(d);
+
+		control.setScrollSpeedFactor(d);
+
+		setScrollSpeedFactor(d);
+	}
+
+	public void setScrollSpeedFactor(double d) {
+		control.setScrollSpeedFactor(d);
+
+		if (teamListPresentation != null)
+			teamListPresentation.setScrollSpeed(d);
+
+		if (scoreboardPresentation != null)
+			scoreboardPresentation.setScrollSpeed(d);
+	}
+
 	private void setScrollPauseImpl(boolean pause) {
 		if (pause == pauseScroll)
 			return;
@@ -435,6 +466,7 @@ public class ResolverUI {
 		pauseScroll = pause;
 		if (teamListPresentation != null)
 			teamListPresentation.setScrollPause(pause);
+
 		if (scoreboardPresentation != null)
 			scoreboardPresentation.setScrollPause(pause);
 	}


### PR DESCRIPTION
Adds [ { and } ] keys to control the speed of scrolling in the resolver, for both the main scoreboard and team award list.

In the future we may want to:
 - combine this with +/-, i.e. you use the same keys but it only affects the screen you're on.
 - separate the main scoreboard scrolling from team list award scrolling.

but this adds the basic support that allows it to work, which we can expand on later.

Fixes #108.