### PR TITLE
Read problem time limit from problem.yaml

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/YamlParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/YamlParser.java
@@ -8,8 +8,6 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -296,11 +294,15 @@ public class YamlParser {
 		Map<?, ?> map = (Map<?, ?>) obj;
 		obj = map.get("name");
 		// time_limit
-		if (obj != null) {
-			if (obj instanceof String) {
-				p.add("name", obj.toString());
-			} else if (obj instanceof Map<?, ?>) {
-				// TODO map = (Map<?, ?>) obj;
+		if (obj != null && obj instanceof String) {
+			p.add("name", obj.toString());
+		}
+		obj = map.get("limits");
+		if (obj != null && obj instanceof Map<?, ?>) {
+			Map<?, ?> limits = (Map<?, ?>) obj;
+			Object s = limits.get("timeout");
+			if (s != null) {
+				p.add("time_limit", s.toString());
 			}
 		}
 


### PR DESCRIPTION
There's a new (proposed) standard for specifying problem time limits in problem.yaml. systest0 used this instead of the historic .timelimit file, which caused some problems to have no time limit on the CDS until we connected to the CCS, which caused problems for analytics.

This just adds support for reading the time limit from the yaml.