### PR TITLE
Fix properties when using a branding presentation

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/BrandingPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/BrandingPresentation.java
@@ -51,11 +51,20 @@ public class BrandingPresentation extends AbstractICPCPresentation {
 		return childPresentation.getRepeatTimeMs();
 	}
 
+	private static String getPresentationKey(String className) {
+		int ind = className.lastIndexOf(".");
+		return "property[" + className.substring(ind + 1) + "|" + className.hashCode() + "]";
+	}
+
 	@Override
 	public void setProperty(String s) {
 		super.setProperty(s);
-		if (childPresentation != null)
-			childPresentation.setProperty(s);
+		if (childPresentation != null) {
+			String k = getPresentationKey(childPresentation.getClass().getName()) + ":";
+			if (s.startsWith(k)) {
+				childPresentation.setProperty(s.substring(k.length()));
+			}
+		}
 	}
 
 	@Override

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -120,6 +120,8 @@ public class PresentationWindowImpl extends PresentationWindow {
 			for (Presentation p : presentations) {
 				if (key.equals(getPresentationKey(p.getClass().getName())))
 					p.setProperty(value);
+				else if ("BrandingPresentation".equals(p.getClass().getSimpleName()))
+					p.setProperty(key + ":" + value);
 			}
 
 			if (isGlobalKey(key))


### PR DESCRIPTION
Presentations 'inside' a branding presentation were not receiving their property changes, e.g. you couldn't set the text on a message presentation. This is because each property is passed to a specific presentation, and since e.g. branding pres != message pres, it wouldn't be told about the property change in order to pass it on.

This makes the branding presentation special and told about all property changes, and it in turn decides if the presentation should be

Ok, I know this is getting a little ugly, but still better to do the minimal change for supporting 'branding' presentations until we know how we would want to use them long term.