### PR TITLE
Resolver branding

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -38,6 +38,7 @@ import org.icpc.tools.contest.model.resolver.ResolutionUtil.ToJudgeStep;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.TextHelper;
+import org.icpc.tools.presentation.contest.internal.presentations.BrandingPresentation;
 import org.icpc.tools.presentation.contest.internal.presentations.MessagePresentation;
 import org.icpc.tools.presentation.contest.internal.presentations.StaticLogoPresentation;
 import org.icpc.tools.presentation.contest.internal.presentations.resolver.JudgePresentation2;
@@ -619,6 +620,24 @@ public class ResolverUI {
 			return;
 
 		currentPresentation = pres2;
+
+		try {
+			String brand = System.getProperty("ICPC_BRANDING_PRES");
+			if (brand == null)
+				brand = System.getenv("ICPC_BRANDING_PRES");
+			if (brand != null) {
+				Class<?> bc = getClass().getClassLoader().loadClass(brand);
+				Presentation bp = (Presentation) bc.getDeclaredConstructor().newInstance();
+				if (bp != null && bp instanceof BrandingPresentation) {
+					BrandingPresentation bp2 = (BrandingPresentation) bp;
+					bp2.setChildPresentation(pres2);
+					pres2 = bp2;
+				}
+			}
+		} catch (Exception e) {
+			Trace.trace(Trace.ERROR, "Error loading branding", e);
+		}
+
 		window.setPresentation(pres2);
 		// Transition t = new SlidesTransition();
 		// long time = System.currentTimeMillis() + 1000;


### PR DESCRIPTION
Unfortunately the branding code needs to be added to the resolver UI in addition to the presentations. I already have better ideas of how to do this in the future, but for now this is an easy (and now tested) way to load the contest 'branding'.