### PR TITLE
Fix issue resetting contest start

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -526,9 +526,6 @@ public class PlaybackContest extends Contest {
 
 		if (def != null) {
 			Map<String, Object> props = def.getProperties();
-			if (type == IContestObject.ContestType.CONTEST) {
-				props.remove("start_time");
-			}
 			Map<String, Object> existingProps = obj.getProperties();
 			for (String key : props.keySet()) {
 				boolean found = false;
@@ -536,7 +533,8 @@ public class PlaybackContest extends Contest {
 					if (key2.equals(key))
 						found = true;
 				}
-				if (!found) {
+
+				if (!found && (type != IContestObject.ContestType.CONTEST || !key.equals("start_time"))) {
 					((ContestObject) obj).add(key, props.get(key));
 				}
 			}

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -526,6 +526,9 @@ public class PlaybackContest extends Contest {
 
 		if (def != null) {
 			Map<String, Object> props = def.getProperties();
+			if (type == IContestObject.ContestType.CONTEST) {
+				props.remove("start_time");
+			}
 			Map<String, Object> existingProps = obj.getProperties();
 			for (String key : props.keySet()) {
 				boolean found = false;


### PR DESCRIPTION
The contest info object is now in the default configuration so that we can support extended properties like the rgb value. However, that means when a CCS doesn't send a contest time (e.g. during a pause), the CDS will set the default (original) value back. This puts in a temporary fix to never set the default value for contest start time. Later we should revisit; using the contest /access endpoint might be a better solution.