### PR TITLE
Increase segments in balloon map pres

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/BalloonMapPresentation.java
@@ -33,7 +33,7 @@ public class BalloonMapPresentation extends AbstractICPCPresentation {
 	private static final long TIME_TO_KEEP_FAILED = 8000;
 	private static final long TIME_TO_KEEP_RECENT = 14000;
 	private static final long TIME_TO_FADE_RECENT = 2000;
-	private static final int NUM_SEGMENTS = 15;
+	private static final int NUM_SEGMENTS = 50;
 
 	private static final Movement SUBMISSION_MOVEMENT = new Movement(0.1, 0.1);
 


### PR DESCRIPTION
When a team is far away from the contest site the arc a balloon takes to travel there is noticeably a set of line segments in an arc approximating a curve. We could get fancy and have a variable number of segments depending on the distance or switch to an actual curve... but just increasing the number of segments should be fine.