### PR TITLE
Default contest id from yaml

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -303,8 +303,8 @@ public class ConfiguredContest {
 			}
 		}
 
-		// if no id, default to id from contest.yaml
-		// we could wait for the contest to load, but
+		// if no id, default to id from contest.yaml. We could wait for the contest to load,
+		// but by then some data could be accessible to clients
 		if (id == null && path != null) {
 			try {
 				Info info = YamlParser.importContestInfo(new File(path, "contest.yaml"), false);

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -42,6 +42,7 @@ import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.State;
+import org.icpc.tools.contest.model.internal.YamlParser;
 import org.icpc.tools.contest.model.internal.account.AccountHelper;
 import org.w3c.dom.Element;
 
@@ -301,6 +302,18 @@ public class ConfiguredContest {
 					id = url.substring(ind + 1);
 			}
 		}
+
+		// if no id, default to id from contest.yaml
+		// we could wait for the contest to load, but
+		if (id == null && path != null) {
+			try {
+				Info info = YamlParser.importContestInfo(new File(path, "contest.yaml"), false);
+				id = info.getId();
+			} catch (Exception ex) {
+				Trace.trace(Trace.ERROR, "Could not read default contest id from contest yaml", ex);
+			}
+		}
+
 		// if no id, default to last folder in location
 		if (id == null && path != null) {
 			int ind = Math.max(path.lastIndexOf("/"), path.lastIndexOf("\\"));
@@ -431,10 +444,6 @@ public class ConfiguredContest {
 
 	public String getId() {
 		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
 	}
 
 	public boolean isRecordingReactions() {


### PR DESCRIPTION
If a contest is configured in a folder where the contest id doesn't match the folder name, and there is no CCS configured, and the contest id isn't set in cdsConfig.xml, we should be picking up the default contest id from the contest.yaml, not the folder name.

Adding support for this only for contest.yaml, not contest.json for now. We could wait until the contest is loaded and let the disk contest source load the id, but this delays too much, e.g. clients might be able to see the endpoints or contest exist in the web pages first.