### PR TITLE
Do a different fix for sending properties for file references, so it …

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -1,14 +1,9 @@
 package org.icpc.tools.contest.model.internal.account;
 
-import org.icpc.tools.contest.model.IAccount;
-import org.icpc.tools.contest.model.IContestObject;
-import org.icpc.tools.contest.model.IDelete;
-import org.icpc.tools.contest.model.IJudgement;
-import org.icpc.tools.contest.model.IPerson;
-import org.icpc.tools.contest.model.IRun;
-import org.icpc.tools.contest.model.ISubmission;
+import org.icpc.tools.contest.model.*;
 import org.icpc.tools.contest.model.internal.Person;
 import org.icpc.tools.contest.model.internal.Submission;
+import org.icpc.tools.contest.model.internal.Team;
 
 /**
  * Filter that adds things analysts can see compared to spectators:
@@ -63,6 +58,15 @@ public class AnalystContest extends SpectatorContest {
 				}
 
 				addIt(run);
+				return;
+			}
+
+			case TEAM: {
+				ITeam team = (ITeam) obj;
+				if (!isTeamHidden(team)) {
+					team = (ITeam) ((Team) team).clone();
+					super.addIt(team);
+				}
 				return;
 			}
 			default:

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -129,19 +129,12 @@ public class PublicContest extends Contest implements IFilteredContest {
 				ITeam team = (ITeam) obj;
 				if (!isTeamHidden(team)) {
 					team = (ITeam) ((Team) team).clone();
-					String[] fileReferences = new String[] {
-							"desktop",
-							"webcam",
-							"audio",
-							"backup",
-							"key_log",
-							"tool_data",
-					};
-					for (String fileReference: fileReferences) {
-						if (!allowFileReference(obj, fileReference)) {
-							((Team) team).add(fileReference, null);
-						}
-					}
+					((Team) team).add("desktop", null);
+					((Team) team).add("webcam", null);
+					((Team) team).add("audio", null);
+					((Team) team).add("backup", null);
+					((Team) team).add("key_log", null);
+					((Team) team).add("tool_data", null);
 					super.add(team);
 				}
 				return;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
@@ -1,12 +1,9 @@
 package org.icpc.tools.contest.model.internal.account;
 
-import org.icpc.tools.contest.model.IAccount;
-import org.icpc.tools.contest.model.IContestObject;
-import org.icpc.tools.contest.model.IDelete;
-import org.icpc.tools.contest.model.IProblem;
-import org.icpc.tools.contest.model.ISubmission;
+import org.icpc.tools.contest.model.*;
 import org.icpc.tools.contest.model.internal.Problem;
 import org.icpc.tools.contest.model.internal.Submission;
+import org.icpc.tools.contest.model.internal.Team;
 
 /**
  * Filter that adds things spectators can see compared to public/team area:
@@ -36,6 +33,17 @@ public class SpectatorContest extends PublicContest {
 		switch (cType) {
 			case COMMENTARY: {
 				addIt(obj);
+				return;
+			}
+			case TEAM: {
+				ITeam team = (ITeam) obj;
+				if (!isTeamHidden(team)) {
+					team = (ITeam) ((Team) team).clone();
+					((Team) team).add("backup", null);
+					((Team) team).add("key_log", null);
+					((Team) team).add("tool_data", null);
+					super.addIt(team);
+				}
 				return;
 			}
 			default: {


### PR DESCRIPTION
…works when adding objects before contest start.

A nicer approach would be to resend the objects after state changes, so hopefully Tim can implement that.