### PR TITLE
Simplify access filtering

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -393,7 +393,7 @@ public class ContestRESTService extends HttpServlet {
 
 		if (contest instanceof IFilteredContest) {
 			IFilteredContest fc = (IFilteredContest) contest;
-			if (!fc.allowFileReference(obj, url)) {
+			if (!fc.allowProperty(obj, url)) {
 				response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 				return true;
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/IFilteredContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/IFilteredContest.java
@@ -9,5 +9,21 @@ import org.icpc.tools.contest.model.IContestObject;
  */
 public interface IFilteredContest extends IContest {
 
-	public boolean allowFileReference(IContestObject obj, String attribute);
+	/**
+	 * Return true if a property is allowed/accessible on this specific object.
+	 *
+	 * @param obj
+	 * @param property
+	 * @return
+	 */
+	public boolean allowProperty(IContestObject obj, String property);
+
+	/**
+	 * Return true if a property is allowed/accessible on the type at some point in time.
+	 *
+	 * @param type
+	 * @param property
+	 * @return
+	 */
+	public boolean canAccessProperty(IContestObject.ContestType type, String property);
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
@@ -108,28 +108,41 @@ public class TeamContest extends PublicContest {
 	}
 
 	@Override
-	public boolean allowFileReference(IContestObject obj, String property) {
+	public boolean allowProperty(IContestObject obj, String property) {
 		switch (obj.getType()) {
 			case TEAM: {
 				ITeam team = (ITeam) obj;
-				if ("desktop".equals(property) || "webcam".equals(property) || "audio".equals(property))
+				if (property.startsWith("desktop") || property.startsWith("webcam") || property.startsWith("audio"))
 					return teamId.equals(team.getId());
 
-				return super.allowFileReference(obj, property);
+				return super.allowProperty(obj, property);
 			}
 			case SUBMISSION: {
 				ISubmission s = (ISubmission) obj;
-				if (!teamId.equals(s.getTeamId()))
-					super.allowFileReference(obj, property);
-
-				if ("reaction".equals(property) || "files".equals(property))
+				if (teamId.equals(s.getTeamId()))
 					return true;
 
-				return super.allowFileReference(obj, property);
+				return super.allowProperty(obj, property);
 			}
-
 			default:
-				return super.allowFileReference(obj, property);
+				return super.allowProperty(obj, property);
+		}
+	}
+
+	@Override
+	public boolean canAccessProperty(IContestObject.ContestType type, String property) {
+		switch (type) {
+			case TEAM: {
+				if (property.startsWith("desktop") || property.startsWith("webcam") || property.startsWith("audio"))
+					return true;
+
+				return super.canAccessProperty(type, property);
+			}
+			case SUBMISSION: {
+				return true;
+			}
+			default:
+				return super.canAccessProperty(type, property);
 		}
 	}
 }


### PR DESCRIPTION
Change allowFileReference() to more generic canAccessProperty() and allowProperty() functions. canAccessProperty() returns true if a type property is supported for some object & time (i.e. could be basis for access endpoint in future), while the second asks 'can I access this property on this specific object now?'.

Filtering for team and submissions use these methods, building from 'public' role to spectators and analysts.