### PR TITLE
Use single window for multi-contest resolver

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -652,17 +652,20 @@ public class Resolver {
 						if (ui.length == 1)
 							return;
 
-						ui[activeUI].setVisible(false);
+						// show new resolver, then hide the current one
+						int newUI = activeUI + 1;
+						if (newUI >= ui.length)
+							newUI = 0;
 
-						activeUI++;
-						if (activeUI >= ui.length)
-							activeUI = 0;
-
-						Trace.trace(Trace.USER, "Switching to contest " + (activeUI + 1));
+						Trace.trace(Trace.USER, "Switching to contest " + newUI);
 
 						sendActiveUI();
 
-						ui[activeUI].setVisible(true);
+						ui[newUI].setVisible(true);
+
+						ui[activeUI].setVisible(false);
+
+						activeUI = newUI;
 					}
 				}, lightMode);
 

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -648,6 +648,7 @@ public class ResolverUI {
 				Presentation bp = (Presentation) bc.getDeclaredConstructor().newInstance();
 				if (bp != null && bp instanceof BrandingPresentation) {
 					BrandingPresentation bp2 = (BrandingPresentation) bp;
+					bp2.setContest(getFirstContest());
 					bp2.setChildPresentation(pres2);
 					pres2 = bp2;
 				}


### PR DESCRIPTION
Instead of each resolver using it's own window and trying to swap the
visibility, just open one window and swap whether the resolver UI is
active by (re)setting the current presentation and enabling/disabling
keys and mouse.

Allows a seamless and faster transition between contests without any
flashing.