### PR TITLE
Make uid for multi resolver unique.

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -253,7 +253,7 @@ public class Resolver {
 			if (isPresenter)
 				role = "presAdmin";
 
-			client[con] = new PresentationClient(cdsSource.getUser(), role, cdsSource, "resolver") {
+			client[con] = new PresentationClient(cdsSource.getUser(), role, cdsSource, "resolver" + con) {
 				@Override
 				protected void clientsChanged(Client[] cl) {
 					Trace.trace(Trace.INFO, "Client list changed: " + cl.length);


### PR DESCRIPTION
We used to use the same type (`resolver`) for all connections, which means the CDS keeps kicking us out, since there can be only one client per uid. Adding the connection index seems to fix this.