### PR TITLE
Use different names for event feed cache

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -599,7 +599,8 @@ public class ConfiguredContest {
 			contestSource = new DiskContestSource(folder);
 		} else {
 			try {
-				contestSource = new RESTContestSource(folder, ccs.getURL(), ccs.getUser(), ccs.getPassword());
+				String name = System.getProperty("CDS-name");
+				contestSource = new RESTContestSource(folder, ccs.getURL(), ccs.getUser(), ccs.getPassword(), name);
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Could not configure contest source", e);
 				contestSource = new DiskContestSource(folder);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -82,7 +82,7 @@ public class RESTContestSource extends DiskContestSource {
 	 * @throws MalformedURLException
 	 */
 	public RESTContestSource(String url, String user, String password) throws MalformedURLException {
-		this(null, url, user, password);
+		this(null, url, user, password, null);
 	}
 
 	/**
@@ -95,7 +95,7 @@ public class RESTContestSource extends DiskContestSource {
 	 * @throws MalformedURLException
 	 */
 	public RESTContestSource(File file, String user, String password) throws MalformedURLException {
-		this(file, null, user, password);
+		this(file, null, user, password, null);
 	}
 
 	/**
@@ -106,7 +106,8 @@ public class RESTContestSource extends DiskContestSource {
 	 * already have a local contest cached and only want the ability to load absolute file
 	 * references.
 	 */
-	public RESTContestSource(File file, String url, String user, String password) throws MalformedURLException {
+	public RESTContestSource(File file, String url, String user, String password, String name)
+			throws MalformedURLException {
 		super(file, url);
 
 		if (url != null)
@@ -124,11 +125,14 @@ public class RESTContestSource extends DiskContestSource {
 			setup();
 
 		if (eventFeedFile == null) {
-			String name = System.getProperty("CDS-name");
-			if (name != null)
-				feedCacheFile = new File(cacheFolder, "events-" + name + ".log");
-			else
-				feedCacheFile = new File(cacheFolder, "events.log");
+			String name2 = name;
+			if (name == null) {
+				if (user != null)
+					name2 = user;
+				else
+					name2 = "no-auth";
+			}
+			feedCacheFile = new File(cacheFolder, "events-" + name2 + ".log");
 
 			// delete if older than 8h
 			if (feedCacheFile.exists() && feedCacheFile.lastModified() < System.currentTimeMillis() - 8 * 60 * 60 * 1000) {


### PR DESCRIPTION
Allows clients to provide a name when creating a REST connector. Having a unique name means that the cache will be created in a different file, avoiding two users loading the same cache. If no name is provided, the user name is used since most users have different access roles.

This allows allows moving the CDS's use of different caches out of the REST connector, since it shouldn't really be in there.