### PR TITLE
Added resolution options for solution, list awards

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
@@ -204,12 +204,15 @@ public class ResolutionUtil {
 		public int topTeam;
 		public Map<String, SelectType> selections;
 		public boolean photos;
+		public boolean after;
 
-		public ListAwardStep(IAward award, ITeam[] teams, Map<String, SelectType> selections, boolean photos) {
+		public ListAwardStep(IAward award, ITeam[] teams, Map<String, SelectType> selections, boolean photos,
+				boolean after) {
 			this.award = award;
 			this.teams = teams;
 			this.selections = selections;
 			this.photos = photos;
+			this.after = after;
 		}
 
 		@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -1,6 +1,10 @@
 package org.icpc.tools.contest.model.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
@@ -229,6 +233,7 @@ public class AwardUtil {
 
 			Award solutionAward = new Award(IAward.SOLVED, "solved-" + ns, teamIds, citation.replace("{0}", ns + ""),
 					mode);
+			solutionAward.setParameter(ns.toString());
 			contest.add(solutionAward);
 		}
 	}
@@ -456,7 +461,8 @@ public class AwardUtil {
 		return firstTeamIndex + numTeams;
 	}
 
-	public static void createMedalAwards(Contest contest, List<IAward> goldList, List<IAward> silverList, List<IAward> bronzeList) {
+	public static void createMedalAwards(Contest contest, List<IAward> goldList, List<IAward> silverList,
+			List<IAward> bronzeList) {
 		ITeam[] teams = contest.getOrderedTeams();
 		if (teams.length == 0)
 			return;
@@ -695,12 +701,8 @@ public class AwardUtil {
 		silver.setParameter("4");
 		Award bronze = new Award(IAward.MEDAL, "bronze", null, (String) null);
 		bronze.setParameter("4");
-		createMedalAwards(
-				contest,
-				Collections.singletonList(gold),
-				Collections.singletonList(silver),
-				Collections.singletonList(bronze)
-		);
+		createMedalAwards(contest, Collections.singletonList(gold), Collections.singletonList(silver),
+				Collections.singletonList(bronze));
 
 		Award group = new Award(IAward.GROUP, "*", null, (String) null);
 		group.setParameter("1");


### PR DESCRIPTION
- When using a template/award util, the solution award assigns a parameter with the number of solved problems. This is used to make sure the award does not appear until that number of problems has been solved.
- Team list and photo awards can use a parameter "after" (manually assigned) to indicate that they do not want to appear until after individual awards.