### PR TITLE
Explicitly aet contest on team award presentation so we cache for the…

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -313,6 +313,7 @@ public class ResolverUI {
 			}
 		};
 		awardPresentation.setSize(window.getSize());
+		awardPresentation.setContest(contest);
 		awardPresentation.cacheAwards(steps);
 		awardPresentation.setShowInfo(showInfo);
 


### PR DESCRIPTION
… correct contest.