### PR TITLE
Contest write force / singletons

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
@@ -164,7 +164,7 @@ public class FloorMap {
 	public void write(File folder) {
 		resetOrigin();
 
-		ContestWriter.write(contest, new File(folder, "extend-floor"));
+		ContestWriter.write(contest, new File(folder, "extend-floor"), false);
 	}
 
 	public Rectangle2D.Double getBounds() {

--- a/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
@@ -164,7 +164,7 @@ public class FloorMap {
 	public void write(File folder) {
 		resetOrigin();
 
-		ContestWriter.write(contest, new File(folder, "extend-floor"), false);
+		ContestWriter.write(contest, new File(folder, "extend-floor"));
 	}
 
 	public Rectangle2D.Double getBounds() {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestWriter.java
@@ -11,7 +11,7 @@ import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.internal.Contest;
 
 public class ContestWriter {
-	public static void write(IContest contest, File folder, boolean force) {
+	public static void write(IContest contest, File folder) {
 		if (!folder.exists())
 			folder.mkdirs();
 
@@ -22,9 +22,9 @@ public class ContestWriter {
 
 			String name = IContestObject.getTypeName(type);
 			IContestObject[] objs = ((Contest) contest).getObjects(type);
-			if (objs != null && (force || objs.length > 0)) {
+			if (objs != null && objs.length > 0) {
 				// do not write empty singletons
-				if (!force && IContestObject.isSingleton(type) && objs[0].getProperties().isEmpty())
+				if (IContestObject.isSingleton(type) && objs[0].getProperties().isEmpty())
 					continue;
 				try {
 					File f = new File(folder, name + ".json");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestWriter.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestWriter.java
@@ -11,7 +11,7 @@ import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.internal.Contest;
 
 public class ContestWriter {
-	public static void write(IContest contest, File folder) {
+	public static void write(IContest contest, File folder, boolean force) {
 		if (!folder.exists())
 			folder.mkdirs();
 
@@ -22,7 +22,10 @@ public class ContestWriter {
 
 			String name = IContestObject.getTypeName(type);
 			IContestObject[] objs = ((Contest) contest).getObjects(type);
-			if (objs != null && objs.length > 0) {
+			if (objs != null && (force || objs.length > 0)) {
+				// do not write empty singletons
+				if (!force && IContestObject.isSingleton(type) && objs[0].getProperties().isEmpty())
+					continue;
 				try {
 					File f = new File(folder, name + ".json");
 					BufferedWriter bw = new BufferedWriter(new FileWriter(f));


### PR DESCRIPTION
Adds a new 'force' option to the contest writer. If force is not true then empty lists or singletons will not be written as new files.