### PR TITLE
Team photo fixes

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamListPhotoPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamListPhotoPresentation.java
@@ -172,8 +172,8 @@ public class TeamListPhotoPresentation extends AbstractICPCPresentation {
 				for (int j = 0; j < c.teamIds.size(); j++) {
 					String teamId = c.teamIds.get(j);
 					if (c.teamLogos.get(teamId) != null) {
-						c.teamPhotos.get(teamId).flush();
-						c.teamPhotos.remove(teamId);
+						c.teamLogos.get(teamId).flush();
+						c.teamLogos.remove(teamId);
 					}
 				}
 			}
@@ -309,7 +309,7 @@ public class TeamListPhotoPresentation extends AbstractICPCPresentation {
 			BufferedImage logo = c.teamLogos.get(t.getId());
 			if (logo != null)
 				text.addImage(logo);
-			text.addSpacer(8, fm.getHeight());
+			text.addSpacer(fm.getHeight() / 2, fm.getHeight());
 			text.addString(t.getActualDisplayName());
 			Dimension b = text.getBounds();
 


### PR DESCRIPTION
Fixes two minor issues I noticed:
- When cleaning up, flushes wrong images (and can cause exceptions).
- Spacer between logo and team name should be smaller, and proportional.