### PR TITLE
Make pass/fail the default scoring algorithm.

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -182,7 +182,7 @@ public class Info extends ContestObject implements IInfo {
 	}
 
 	public ScoreboardType getScoreboardType() {
-		return scoreboardType;
+		return scoreboardType == null ? ScoreboardType.PASS_FAIL : scoreboardType;
 	}
 
 	public void setLogo(FileReferenceList list) {


### PR DESCRIPTION
Without this the resolver assumed scoring as the default, meaning nothing showed up.