### PR TITLE
Change PENDING_COLOR to (66,114,245)

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCColors.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ICPCColors.java
@@ -9,7 +9,7 @@ public class ICPCColors {
 	public static final Color YELLOW = new Color(255, 223, 54);
 	public static final Color RED = new Color(196, 58, 36);
 
-	public static final Color PENDING_COLOR = new Color(230, 230, 0);
+	public static final Color PENDING_COLOR = new Color(66, 114, 245);
 	public static final Color SOLVED_COLOR = new Color(0, 230, 0);
 	public static final Color FIRST_TO_SOLVE_COLOR = new Color(0, 100, 0);
 	public static final Color FAILED_COLOR = new Color(240, 0, 0);


### PR DESCRIPTION
Change the PENDING_COLOR to a shade of blue instead of yellow in order to improve accessibility for colorblind folks. The current shade of yellow is very hard to distinguish from the green SOLVED_COLOR.
This change is discussed in Issue #978. This color choice is Option 2 in that discussion. Screenshots can be found there. If you have further comments on the color choice, please continue the discussion in Issue #978