### PR TITLE
2.5 release updates

### DIFF
--- a/doc/ChangeLog.md
+++ b/doc/ChangeLog.md
@@ -1,6 +1,9 @@
 # ICPC Tools Changelog
 
-## V2.5 - TBD
+## V2.6 - TBD
+-----------------
+
+## V2.5 - June 2024
 -----------------
 * First release supporting the 2022-07 release of the Contest API spec.
 * Dropped Java 8 support (now Java 11 minimum, and Java 17 recommended).

--- a/version.properties
+++ b/version.properties
@@ -1,1 +1,1 @@
-version=2.5
+version=2.6

--- a/website/content/_index.md
+++ b/website/content/_index.md
@@ -12,8 +12,6 @@ icon: fas fa-home
 {{< button name="Github" icon="fab fa-github" link="https://github.com/icpctools/icpctools" >}}
 {{< button name="Slack" icon="fab fa-slack" link="https://join.slack.com/t/icpctools/shared_invite/zt-wti6k1r6-t25~VYEcyKbVn4Vj_ecBLA" >}}
 
-WARNING: We are in the middle of making massive code changes for the ICPC 46th and 47th World Finals. We would love feedback on whether the latest changes cause any regressions, but if you are running a live contest we strongly suggest you use v2.5.940 or earlier until we are able to test and release in May 2024.
-
 Welcome to the ICPC Tools web page! This page contains a variety of tools implemented by the International Collegiate Programming Contest (ICPC) Tools Group, most of which were originally developed for use at the ICPC World Finals and have been adapted for use at other programming contests.
 These tools have been used to support a wide variety of programming contests including local contests at Universities world-wide, multiple ICPC Regional Contests around the world, and a number of ICPC World Finals.
 


### PR DESCRIPTION
Move builds to version 2.6, update changelog, and remove warning from website.