### PR TITLE
Implement new honors awards

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IAward.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAward.java
@@ -52,7 +52,7 @@ public interface IAward extends IContestObject {
 	AwardType GROUP_HIGHLIGHT = new AwardType("Group Highlight", "group-highlight-.*");
 	AwardType SOLVED = new AwardType("Solved", "solved-.*");
 	AwardType TOP = new AwardType("Top", "top-.*");
-	AwardType HONORS = new AwardType("Honors", "honors-.*");
+	AwardType HONORS = new AwardType("Honors", "(honors-.*|.*-honors|honors)");
 	// AwardType HONORABLE_MENTION = new AwardType("Honorable Mention", "honorable-mention");
 	AwardType EXPECTED_TO_ADVANCE = new AwardType("Expected to Advance", "expected-to-advance");
 	AwardType OTHER = new AwardType("Other", ".*");

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -562,10 +562,7 @@ public class AwardUtil {
 		int percentileBottom = -1;
 		DisplayMode mode = template.getDisplayMode();
 		if (!template.hasDisplayMode())
-			if (template.getId().equals("highest-honors"))
-				mode = DisplayMode.IGNORE;
-			else
-				mode = IAward.DisplayMode.LIST;
+			mode = IAward.DisplayMode.LIST;
 
 		// find teams we're going to base this on
 		ITeam[] teams = contest.getOrderedTeams();
@@ -634,10 +631,12 @@ public class AwardUtil {
 				t++;
 			}
 		} else if (solvedTop > 0) {
-			// Note: if solvedTop == 0, we include all medalists
 			while (t < n && contest.getStanding(teams[t]).getNumSolved() > lowestMedalNumSolved - solvedTop) {
 				t++;
 			}
+		} else {
+			// solvedTop == 0, start just below the medalists.
+			t = numMedalists;
 		}
 
 		// find the bottom team

--- a/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/messages.properties
@@ -25,4 +25,7 @@ awardSolving={0}, and solving {1} problems in {2} minutes
 awardTop=Top {0}% of teams
 awardHonors={0}% Honors
 awardHonorableMention=Honorable mention
+awardHighestHonors=Highest Honors
+awardHighHonors=High Honors
+awardHonors2=Honors
 teamListSubtitle=Solving {0} problems

--- a/ContestModel/src/org/icpc/tools/contest/model/util/messages_es.properties
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/messages_es.properties
@@ -25,4 +25,7 @@ awardSolving={0}, y resueltos {1} problemas en {2} minutos
 awardTop={0}% mejores equipos
 awardHonors={0}% Honors
 awardHonorableMention=Mención de honor
+awardHighestHonors=Honores máximos
+awardHighHonors=Honores altos
+awardHonors2=Honores
 teamListSubtitle=Resueltos {0} problemas

--- a/Resolver/src/org/icpc/tools/resolver/awards/TemplateAwardDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/TemplateAwardDialog.java
@@ -32,10 +32,11 @@ public class TemplateAwardDialog extends AbstractAwardDialog {
 			"{\"id\":\"silver-medal\",\"parameter\":\"4\"}\n" + // silver medals
 			"{\"id\":\"bronze-medal\",\"parameter\":\"4\"}\n" + // bronze medals
 			"{\"id\":\"first-to-solve-*\"}\n" + // first to solve awards
-			"{\"id\":\"top-25\",\"parameter\":\"25\"}\n" + // top 25% of teams
-			"{\"id\":\"honors-mention\",\"parameter\":\"50-100\"}\n" + // honorable mention for teams
+			"{\"id\":\"highest-honors\",\"parameter\":\"0-1\"}\n" + // All medalists + all solving the same number of problems as the lowest medalist
+			"{\"id\":\"high-honors\",\"parameter\":\"1-2\"}\n" + // All teams solving one fewer than the lowest medalist
+			"{\"id\":\"honors\",\"parameter\":\"2-p50\"}\n" + // All teams not receiving highest honors or high honors solving the same or more problems than the median scoring team
+			"{\"id\":\"honors-mention\",\"parameter\":\"p50-p100\"}\n" + // honorable mention for teams
 			// scoring below 50th percentile
-			"{\"id\":\"solved-*\"}\n" + // solution awards
 			"{\"id\":\"group-winner-*\"}"; // group winners
 
 	protected Text text;


### PR DESCRIPTION
Update the old honorable mention award template to support both percentiles and 'number of solved problems compared to the lowest medalist'.

Fixes #994.

Add some special cases:
* The highest honors should not be displayed as a list or anything
* Any list that overlaps or is just below the medalists, should be displayed before resolving medalists