### PR TITLE
Update shebangs to more generic version

### DIFF
--- a/BalloonUtility/scripts/balloon.sh
+++ b/BalloonUtility/scripts/balloon.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: run the balloon utility
 #

--- a/CoachView/scripts/coachView.sh
+++ b/CoachView/scripts/coachView.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: launch the coach view
 #

--- a/ContestModel/doc.sh
+++ b/ContestModel/doc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo 1 - $1
 pandoc "$1"/README.md -f gfm -V linkcolor:blue -V geometry:margin=1in -o "$1"/README.pdf
 echo 2

--- a/ContestUtil/scripts/contestUtil.sh
+++ b/ContestUtil/scripts/contestUtil.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 libdir=`dirname "$0"`/lib
 

--- a/ContestUtil/scripts/eventFeed.sh
+++ b/ContestUtil/scripts/eventFeed.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 libdir=`dirname "$0"`/lib
 

--- a/ContestUtil/scripts/eventFeedSplitter.sh
+++ b/ContestUtil/scripts/eventFeedSplitter.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 libdir=`dirname "$0"`/lib
 

--- a/ContestUtil/scripts/scoreboardUtil.sh
+++ b/ContestUtil/scripts/scoreboardUtil.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 libdir=`dirname "$0"`/lib
 

--- a/PresAdmin/scripts/presAdmin.sh
+++ b/PresAdmin/scripts/presAdmin.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: run a Presentation Admin
 #

--- a/PresContest/scripts/client.sh
+++ b/PresContest/scripts/client.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: display presentations controlled by a CDS
 #

--- a/PresContest/scripts/standalone.sh
+++ b/PresContest/scripts/standalone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: display presentations in standalone mode
 #

--- a/ProblemSet/scripts/problemSet.sh
+++ b/ProblemSet/scripts/problemSet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: to edit problemset.yaml
 #

--- a/Resolver/scripts/awards.sh
+++ b/Resolver/scripts/awards.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: to apply awards to an event feed 
 #

--- a/Resolver/scripts/resolver.sh
+++ b/Resolver/scripts/resolver.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Purpose: to run a standalone resolver
 #   or to connect to a CDS and control the resolution


### PR DESCRIPTION
As described in #1002, the `#!/usr/bin/env bash` shebang is more generic and looks for bash in `PATH`, instead of assuming `/bin/bash` is present. This makes it so that the scripts work on, NixOS, OpenBSD, ...