### PR TITLE
Avoid divide by zero when <4 teams in org logo pres

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoSlidePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/OrgLogoSlidePresentation.java
@@ -78,6 +78,9 @@ public class OrgLogoSlidePresentation extends AbstractICPCPresentation {
 		for (int row = 0; row < 4; row++) {
 			int y = dy + row * size;
 			for (int col = 0; col <= numW + 1; col++) {
+				if (numInRow[row] == 0)
+					continue;
+
 				double x = col * size;
 				int num = 0;
 				if (row % 2 == 0) {


### PR DESCRIPTION
If you have less than 4 teams in a contest (or this is the first pres and contest data hasn't loaded yet) you get a divide by zero because there are no teams in the row.