### PR TITLE
Autocorrect presentation admin CDS root with path

### DIFF
--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
@@ -57,8 +57,8 @@ public class Admin {
 		try {
 			URL url2 = new URL(url);
 			if (url2.getPath() != null && url2.getPath().length() > 1) {
-				Trace.trace(Trace.ERROR, "URL should not contain a path");
-				return;
+				url = url.substring(0, url.length() - url2.getPath().length());
+				Trace.trace(Trace.WARNING, "CDS URL should not contain a path, trying " + url + " instead");
 			}
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Could not parse URL");


### PR DESCRIPTION
Since the presentation admin is 'global' and can control multiple contests /presentations at once, the correct path to access the CDS is the CDS root, e.g. something like http://cds/ or https://10.3.3.207:8443. People frequently include the contest api in the url though, e.g. https://cds/api/contests.

Although giving an error is 'correct', we've had a few requests to just make it work. So instead of an error, this output a warning and tries the url without the path.