### PR TITLE
Change presenter done updating logic to warning

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -505,8 +505,7 @@ public class Resolver {
 			}
 
 			if (finalContest[con].isDoneUpdating() && isPresenter && contestSources[con] instanceof RESTContestSource) {
-				Trace.trace(Trace.ERROR, "Contest is already resolved, nothing to do");
-				System.exit(1);
+				Trace.trace(Trace.WARNING, "Contest is already resolved/public");
 			}
 
 			validateContest(finalContest[con]);


### PR DESCRIPTION
Fixes #958

doneUpdating() means the data is public, but sometimes you still want to test with a feed with this data, which you can't do anymore currently. Changing this into a warning makes it so people still know but you CAN test.