### PR TITLE
Rename analyst to staff

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/VideoStream.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStream.java
@@ -272,7 +272,7 @@ public class VideoStream implements IStore {
 		// TODO sync lock issue List<VideoStreamListener>
 		synchronized (listeners) {
 			for (VideoStreamListener vsl : listeners) {
-				if (!vsl.isAnalyst()) {
+				if (!vsl.isStaff()) {
 					removeListener(vsl);
 				}
 			}

--- a/CDS/src/org/icpc/tools/cds/video/VideoStreamListener.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStreamListener.java
@@ -6,12 +6,12 @@ import java.io.OutputStream;
 public class VideoStreamListener {
 	private OutputStream out;
 	private long startTime;
-	private boolean analyst;
+	private boolean staff;
 	private boolean done;
 
-	public VideoStreamListener(OutputStream out, boolean analyst) {
+	public VideoStreamListener(OutputStream out, boolean staff) {
 		this.out = out;
-		this.analyst = analyst;
+		this.staff = staff;
 		startTime = System.currentTimeMillis();
 	}
 
@@ -23,8 +23,8 @@ public class VideoStreamListener {
 		return done;
 	}
 
-	public boolean isAnalyst() {
-		return analyst;
+	public boolean isStaff() {
+		return staff;
 	}
 
 	public void write(byte[] b) throws IOException {


### PR DESCRIPTION
There is no analyst role anymore; rename to staff (which matches how it is set).