### PR TITLE
Adjust number of rows to avoid orphans

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/ScrollingTileScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/ScrollingTileScoreboardPresentation.java
@@ -226,6 +226,7 @@ public abstract class ScrollingTileScoreboardPresentation extends AbstractTileSc
 
 	@Override
 	protected void paintImpl(Graphics2D g) {
+		orphanAdjustRows();
 		Graphics2D gg = (Graphics2D) g.create();
 		if (header == Header.LEFT)
 			gg.translate(margin, 0);


### PR DESCRIPTION
Make the adjustment for all tile scoreboards,
do not adjust if number of rows is explicitly set,
reset to default number of rows with adjustment if rows is set to zero