### PR TITLE
Add composite presentations in a single dialog and enable editing

### DIFF
--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationDialog.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationDialog.java
@@ -412,11 +412,26 @@ public class CompositePresentationDialog extends Dialog {
 				enableOk();
 			}
 		});
+		final Label props = new Label(buildComp, SWT.NONE);
+		props.setLayoutData(new GridData(SWT.LEFT, SWT.CENTER, true, false));
+
 		buildList.addSelectionListener(new SelectionAdapter() {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				remove.setEnabled(buildList.getSelection() != null);
 				removeAll.setEnabled(!buildList.getPresentationInfos().isEmpty());
+				if (buildList.getSelection() != null) {
+					PresentationInfo info = buildList.getSelection();
+					if (info.getData() != null) {
+						String text = String.join(", ", info.getData());
+						props.setText(text);
+					} else {
+						props.setText("-");
+					}
+				} else {
+					props.setText("");
+				}
+				buildComp.layout();
 				enableOk();
 			}
 		});

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationDialog.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationDialog.java
@@ -31,6 +31,7 @@ public class CompositePresentationDialog extends Dialog {
 	private PresentationInfoListControl buildList;
 
 	protected String name, description, category;
+	protected CompositePresentationInfo info;
 	protected CompositePresentationSaveDialog saveDialog;
 
 	public CompositePresentationDialog(Shell parent, List<PresentationInfo> presentations,
@@ -44,8 +45,8 @@ public class CompositePresentationDialog extends Dialog {
 	public CompositePresentationDialog(Shell parent, List<PresentationInfo> presentations,
 			List<PresentationInfo> transitions, CompositePresentationInfo info) {
 		this(parent, presentations, transitions);
-		// TODO - for edit
-
+		// for edit
+		this.info = info;
 	}
 
 	public CompositePresentationInfo getPresentation() {
@@ -110,7 +111,7 @@ public class CompositePresentationDialog extends Dialog {
 		GridLayout saveLayout = new GridLayout(1, false);
 		saveSection.setLayout(saveLayout);
 
-		saveDialog = new CompositePresentationSaveDialog(comp.getShell());
+		saveDialog = new CompositePresentationSaveDialog(comp.getShell(), info);
 		Composite saveInput = new Composite(saveSection, SWT.NONE);
 		saveInput.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
 		saveDialog.createUI(saveInput);
@@ -168,6 +169,38 @@ public class CompositePresentationDialog extends Dialog {
 		// TODO contestText.setFocus();
 		comp.getShell().setDefaultButton(cancel);
 		 */
+
+		if (info != null) {
+			buildListFromInfo();
+		}
+	}
+
+	private void buildListFromInfo() {
+		for (PresentationInfo part : info.infos) {
+			PresentationInfo found = null;
+			for (PresentationInfo pres : presentations) {
+				if (pres.equals(part)) {
+					found = pres;
+					break;
+				}
+			}
+			if (found == null) {
+				for (PresentationInfo trans : transitions) {
+					if (trans.equals(part)) {
+						found = trans;
+						break;
+					}
+				}
+			}
+
+			if (found != null) {
+				String data = null;
+				if (part.getData() != null) {
+					data = String.join(",", part.getData());
+				}
+				addToBuild(found, data);
+			}
+		}
 	}
 
 	private void createPresentationSection(Composite parent2) {

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationDialog.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationDialog.java
@@ -19,7 +19,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Shell;
-import org.icpc.tools.contest.Trace;
 import org.icpc.tools.presentation.admin.internal.PresentationInfoListControl.DisplayStyle;
 import org.icpc.tools.presentation.core.internal.PresentationInfo;
 
@@ -31,9 +30,8 @@ public class CompositePresentationDialog extends Dialog {
 	private PresentationInfoListControl transitionList;
 	private PresentationInfoListControl buildList;
 
-	protected Button ok;
-	protected boolean save;
 	protected String name, description, category;
+	protected CompositePresentationSaveDialog saveDialog;
 
 	public CompositePresentationDialog(Shell parent, List<PresentationInfo> presentations,
 			List<PresentationInfo> transitions) {
@@ -87,6 +85,12 @@ public class CompositePresentationDialog extends Dialog {
 			if (!display.readAndDispatch())
 				display.sleep();
 		}
+
+		boolean save = saveDialog.isSaveOk();
+		name = saveDialog.getName();
+		description = saveDialog.getDescription();
+		category = saveDialog.getCategory();
+
 		return save;
 	}
 
@@ -100,8 +104,19 @@ public class CompositePresentationDialog extends Dialog {
 		createTransitionSection(comp);
 		createDisplayPlanSection(comp);
 
-		// buttons
-		Composite buttonBar = new Composite(comp, SWT.NONE);
+		// save panel
+		Composite saveSection = new Composite(comp, SWT.NONE);
+		saveSection.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+		GridLayout saveLayout = new GridLayout(1, false);
+		saveSection.setLayout(saveLayout);
+
+		saveDialog = new CompositePresentationSaveDialog(comp.getShell());
+		Composite saveInput = new Composite(saveSection, SWT.NONE);
+		saveInput.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
+		saveDialog.createUI(saveInput);
+		saveDialog.createButtons(saveSection);
+
+		/*Composite buttonBar = new Composite(comp, SWT.NONE);
 		GridData data = new GridData(SWT.RIGHT, SWT.CENTER, false, false);
 		data.verticalIndent = 15;
 		buttonBar.setLayoutData(data);
@@ -152,6 +167,7 @@ public class CompositePresentationDialog extends Dialog {
 
 		// TODO contestText.setFocus();
 		comp.getShell().setDefaultButton(cancel);
+		 */
 	}
 
 	private void createPresentationSection(Composite parent2) {
@@ -237,10 +253,12 @@ public class CompositePresentationDialog extends Dialog {
 		if (properties != null && properties.length() > 0)
 			newInfo.setData(properties);
 		buildList.add(newInfo);
+		enableOk();
 	}
 
 	protected void enableOk() {
-		ok.setEnabled(!buildList.getPresentationInfos().isEmpty());
+		boolean hasPresentations = !buildList.getPresentationInfos().isEmpty();
+		saveDialog.setPresentationsOk(hasPresentations);
 	}
 
 	private static Button createButton(Composite parent, String text, String tooltip) {
@@ -358,6 +376,7 @@ public class CompositePresentationDialog extends Dialog {
 			@Override
 			public void widgetSelected(SelectionEvent e) {
 				buildList.clear();
+				enableOk();
 			}
 		});
 		buildList.addSelectionListener(new SelectionAdapter() {

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationSaveDialog.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/CompositePresentationSaveDialog.java
@@ -31,18 +31,17 @@ public class CompositePresentationSaveDialog {
 	public CompositePresentationSaveDialog(Shell parent) {
 		this.shell = parent;
 	}
-	/*public CompositePresentationSaveDialog(Shell parent) {
-		super(parent);
-	}
 
 	public CompositePresentationSaveDialog(Shell parent, CompositePresentationInfo info) {
-		super(parent);
-		name = info.getName();
-		description = info.getDescription();
-		category = info.getCategory();
+		this(parent);
+		if (info != null) {
+			name = info.getName();
+			description = info.getDescription();
+			category = info.getCategory();
+		}
 	}
 
-	public boolean open() {
+	/*public boolean open() {
 		shell = new Shell(getParent());
 		shell.setImage(getParent().getImage());
 		shell.setText("Save Presentation");

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/View.java
@@ -782,15 +782,21 @@ public class View {
 		registerAction(createButton(comp, "Edit...", "Edit a composite presentation"), new RemoteAction() {
 			@Override
 			public boolean isEnabled() {
-				return false; // !presentations.isEmpty(); // TODO and custom
+				return getSelectedPresentation() instanceof CompositePresentationInfo;
 			}
 
 			@Override
 			public void run() throws Exception {
+				CompositePresentationInfo oldInfo = (CompositePresentationInfo) getSelectedPresentation();
 				CompositePresentationDialog dialog = new CompositePresentationDialog(parent.getShell(), presentations,
-						transitions);
+						transitions, oldInfo);
 				if (dialog.open()) {
 					CompositePresentationInfo newInfo = dialog.getPresentation();
+					if (oldInfo.getName().equals(newInfo.getName())) {
+						// overwrite with same name, duplicate with new name
+						composites.remove(oldInfo);
+						presentationList.remove(oldInfo);
+					}
 					presentationList.add(newInfo);
 					composites.add(newInfo);
 					try {


### PR DESCRIPTION
- Combines the composite presentation setup dialog and its save dialog.
- Enables editing composite presentations, and duplicating them by choosing a new name

<img width="685" height="302" alt="Screenshot 2025-08-30 at 15 57 55" src="https://github.com/user-attachments/assets/1ce1f437-19a7-4ea9-bb11-643da9ccb2bb" />
