### PR TITLE
Do not highlight group winners photo list teams

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
@@ -218,6 +218,12 @@ public class ResolutionUtil {
 		public String toString() {
 			return "Team List " + award.getId();
 		}
+
+		public boolean shouldHighlight() {
+			if (award.getParameters() != null && award.getParameters().containsKey("highlight"))
+				return Boolean.parseBoolean(award.getParameters().get("highlight"));
+			return true;
+		}
 	}
 
 	public static class ScrollStep implements ResolutionStep {

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -437,7 +437,8 @@ public class ResolverLogic {
 					Trace.trace(Trace.INFO, "Team list at row: " + currentRow + " " + step);
 					teamLists.remove(step);
 
-					steps.add(new TeamSelectionStep(step.teams));
+					if (step.shouldHighlight())
+						steps.add(new TeamSelectionStep(step.teams));
 					steps.add(new PauseStep());
 					steps.add(new ScrollTeamListStep(true));
 					steps.add(step);
@@ -564,7 +565,8 @@ public class ResolverLogic {
 						if (backToScoreboard)
 							steps.add(new PresentationStep(PresentationStep.Presentations.SCOREBOARD));
 
-						steps.add(new TeamSelectionStep(step.teams));
+						if (step.shouldHighlight())
+							steps.add(new TeamSelectionStep(step.teams));
 						steps.add(new PauseStep());
 						steps.add(new ScrollTeamListStep(true));
 						steps.add(step);

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -787,6 +787,7 @@ public class AwardUtil {
 
 		award.setParameter("before", numMedalists + "");
 		award.setParameter("showGroupName",  "true");
+		award.setParameter("highlight",  "false");
 		contest.add(award);
 	}
 


### PR DESCRIPTION
Even though we plan on not showing the scoreboard between the two list awards, we do NOT want to highlight them, since that would show them AFTER the award, which is weird.