### PR TITLE
Do not show scoreboard before showing group winners photo screen

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
@@ -219,6 +219,13 @@ public class ResolutionUtil {
 			return "Team List " + award.getId();
 		}
 
+		public boolean showScoreboardBefore() {
+			if (award.getParameters() != null && award.getParameters().containsKey("showScoreboardBefore")) {
+				return Boolean.parseBoolean(award.getParameters().get("showScoreboardBefore"));
+			}
+			return true;
+		}
+
 		public boolean shouldHighlight() {
 			if (award.getParameters() != null && award.getParameters().containsKey("highlight"))
 				return Boolean.parseBoolean(award.getParameters().get("highlight"));
@@ -295,3 +302,4 @@ public class ResolutionUtil {
 		}
 	}
 }
+

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -562,12 +562,15 @@ public class ResolverLogic {
 						Trace.trace(Trace.INFO, "Team list at row after: " + currentRow + " " + step);
 						teamLists.remove(step);
 
-						if (backToScoreboard)
+						if (step.showScoreboardBefore() && backToScoreboard)
 							steps.add(new PresentationStep(PresentationStep.Presentations.SCOREBOARD));
 
 						if (step.shouldHighlight())
 							steps.add(new TeamSelectionStep(step.teams));
-						steps.add(new PauseStep());
+						// Note: if this ever is false for an award that doesn't happen AFTER another list award, we'll
+						// need to change the logic here to pause before showing the list award
+						if (step.showScoreboardBefore())
+							steps.add(new PauseStep());
 						steps.add(new ScrollTeamListStep(true));
 						steps.add(step);
 

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -789,6 +789,7 @@ public class AwardUtil {
 		award.setParameter("before", numMedalists + "");
 		award.setParameter("showGroupName",  "true");
 		award.setParameter("highlight",  "false");
+		award.setParameter("showScoreboardBefore",  "false");
 		contest.add(award);
 	}
 


### PR DESCRIPTION
Initially we wanted to not show the scoreboard between two 'list' awards. However, this is not true in general. Imagine we want to show a list with all the silver medalists after resolving fifth place, but also a list of all gold medalists just after that. Then we DO want to show the scoreboard in between, since we want to show the highlighted teams. This made me decide to simplify things a lot: add a parameter to indicate whether we show the scoreboard in between. For now, we know this always comes AFTER another list, so we know we do not have to pause in between. I did add a note so we know what to change if that assumption ever changes.