### PR TITLE
Update contest objects directly in the contest

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -939,7 +939,7 @@ public class DiskContestSource extends ContestSource {
 				}
 
 				if (changed)
-					contest.add(newOrg);
+					contest.addDirect(newOrg);
 			}
 
 			ITeam[] teams = contest.getTeams();
@@ -981,7 +981,7 @@ public class DiskContestSource extends ContestSource {
 				}
 
 				if (changed)
-					contest.add(newTeam);
+					contest.addDirect(newTeam);
 			}
 
 			ISubmission[] subs = contest.getSubmissions();
@@ -1004,7 +1004,7 @@ public class DiskContestSource extends ContestSource {
 				}
 
 				if (changed)
-					contest.add(newOrg);
+					contest.addDirect(newOrg);
 			}
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Scanning failed", e);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -133,6 +133,10 @@ public class Contest implements IContest {
 		}
 	}
 
+	public void addDirect(IContestObject obj) {
+		add(obj);
+	}
+
 	public void add(IContestObject obj) {
 		if (obj == null)
 			return;


### PR DESCRIPTION
When we update contest objects on the CDS they're going back through the playback contest, which strips the file references again. Adds a shortcut to add objects to the contest model directly.