### PR TITLE
Fix odd font/text in timeline presentation

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/TextImage.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/TextImage.java
@@ -15,16 +15,16 @@ import java.util.HashMap;
  * Utility class from drawing text.
  */
 public class TextImage {
-	private static HashMap<Integer, Image> map = new HashMap<>();
+	private static HashMap<String, Image> map = new HashMap<>();
 
 	public static void drawString(Graphics2D g, String s, int x, int y) {
 		Color c = g.getColor();
 		Font f = g.getFont();
-		int key = f.hashCode();
+		String key = f.hashCode() + "";
 		if (s != null)
-			key = key * 31 + s.hashCode();
+			key = key + '-' + s.hashCode();
 		if (c != null)
-			key = key * 31 + c.hashCode();
+			key = key + '-' + c.hashCode();
 
 		Image image = map.get(key);
 		if (image == null) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -84,8 +84,7 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 		final float dpi = 96;
 
 		float size = (int) (height * 72.0 * 0.028 / dpi);
-		headerFont = ICPCFont.deriveFont(Font.BOLD, size);
-		headerItalicsFont = ICPCFont.deriveFont(Font.BOLD, size);
+		float headerFontSize = size;
 
 		headerHeight = (int) (height / 50.0);
 
@@ -112,6 +111,10 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 				newCubeWidth -= 2;
 		}
 		cubeWidth = newCubeWidth;
+
+		headerFontSize = Math.min(headerFontSize, size * 0.85f);
+		headerFont = ICPCFont.deriveFont(Font.BOLD, headerFontSize);
+		headerItalicsFont = ICPCFont.deriveFont(Font.BOLD, headerFontSize);
 
 		super.setup();
 	}


### PR DESCRIPTION
It was using an int hash that collided, causing the wrong images to be shown when you change font size (num rows).

Make the header font at most 80% of the size of the row font so that Solved and Time don't overlap (unless you _really_ have lots of rows).