### PR TITLE
Update CI checkout action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/icpctools/builder
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
          fetch-depth: 0
       - name: Build
@@ -26,7 +26,7 @@ jobs:
     needs: build
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
          fetch-depth: 0
       - uses: actions/download-artifact@v4.1.8
@@ -79,8 +79,8 @@ jobs:
     needs: push-release
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v4.1.7
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4.1.8
         with:
           name: build
           path: dist
@@ -112,7 +112,7 @@ jobs:
     needs: push-release
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
          fetch-depth: 0
       - name: Set up QEMU


### PR DESCRIPTION
The checkout action is old and getting a node warning, update to v4.