### PR TITLE
Client-side support for draft spec REL_TIME changes

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -252,11 +252,16 @@ public class Info extends ContestObject implements IInfo {
 			return true;
 		} else if (name2.equals(PENALTY_TIME)) {
 			try {
+				// parse as integer
 				penalty = parseInt(value) * (60 * 1000L);
-				// TODO future relative time
-				// penalty = parseRelativeTime(value);
 			} catch (Exception e) {
-				return false;
+				try {
+					// parse as REL_TIME
+					penalty = parseRelativeTime(value);
+					return true;
+				} catch (Exception ex) {
+					return false;
+				}
 			}
 			return true;
 		} else if (name2.equals(TIME_MULTIPLIER)) {


### PR DESCRIPTION
Support reading REL_TIME penalty times as per the draft spec. Luckily, penalty time was already in ms so we can just try reading the property as an integer or REL_TIME. The tools never read the scoreboard directly, so thats implicitly covered as well.

Server-side / CDS support for the draft spec will come via future PRs.