### PR TITLE
Event feed support for REL_TIME penalty

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -14,6 +14,8 @@ import org.icpc.tools.contest.model.feed.RelativeTime;
 import org.icpc.tools.contest.model.feed.Timestamp;
 
 public class Info extends ContestObject implements IInfo {
+	private static final boolean is202306 = "2023-06".equals(System.getProperty("ICPC_CONTEST_API"));
+
 	private static final String NAME = "name";
 	private static final String FORMAL_NAME = "formal_name";
 	private static final String START_TIME = "start_time";
@@ -338,9 +340,12 @@ public class Info extends ContestObject implements IInfo {
 		if (thawTime != null)
 			props.addLiteralString(SCOREBOARD_THAW_TIME, Timestamp.format(thawTime.longValue()));
 
-		if (penalty != null)
-			props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
-		// TODO: future - props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
+		if (penalty != null) {
+			if (is202306)
+				props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
+			else
+				props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
+		}
 
 		if (!Double.isNaN(timeMultiplier))
 			props.addDouble(TIME_MULTIPLIER, timeMultiplier);


### PR DESCRIPTION
The draft spec changes contest penalty time to REL_TIME. Support for reading in either old or new format was already added via PR #1078, this adds support for the CDS to output the new format as well. A new ICPC_CONTEST_API system property is added in order to maintain backward compatibility, e.g. add the following to jvm.options to return to the old behaviour: `-DICPC_CONTEST_API=2023-06`.

Support for REL_TIME in the scoreboard will come via another PR.