### PR TITLE
Support draft spec REL_TIME in scoreboard

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -123,7 +123,7 @@
                                     <%= st.getNumSolved() %>
                                 </td>
                                 <td class="text-right">
-                                    <%= st.getTime() %>
+                                    <%= ContestUtil.getTime(st.getTime()) %>
                                 </td>
                             </tr>
                         </tbody>

--- a/CDS/src/org/icpc/tools/cds/service/ProjectionScoreboardService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ProjectionScoreboardService.java
@@ -182,9 +182,9 @@ public class ProjectionScoreboardService {
 		IStanding nextS = contest.getStanding(order[i + 1]);
 		if (nextS.getNumSolved() == s.getNumSolved())
 			return Math.min((contestTimeMs - contestTimeMs2) + (nextS.getTime() - s.getTime()),
-					(contest.getDuration() - contestTimeMs2) / 60_000);
+					(contest.getDuration() - contestTimeMs2));
 
-		return (contest.getDuration() - contestTimeMs2) / 60_000;
+		return (contest.getDuration() - contestTimeMs2);
 	}
 
 	private static Submission solveAProblem(Contest contest, ITeam team, IProblem problem, long contestTimeMs,

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -362,7 +362,7 @@ public class CoachView extends Panel {
 		s = standing.getNumSolved() + "";
 		int col2 = d.width - BORDER - fm.stringWidth(" 1999") - fm.stringWidth("99") / 2;
 		g.drawString(s, col2 - fm.stringWidth(s) / 2, d.height - BORDER);
-		s = standing.getTime() + "";
+		s = ContestUtil.getTime(standing.getTime());
 		int col3 = d.width - BORDER - fm.stringWidth("1999") / 2;
 		g.drawString(s, col3 - fm.stringWidth(s) / 2, d.height - BORDER);
 

--- a/ContestModel/src/org/icpc/tools/contest/model/IStanding.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IStanding.java
@@ -19,14 +19,14 @@ public interface IStanding {
 	double getScore();
 
 	/**
-	 * Return the total time this team has (sum of solution times + penalty), in minutes.
+	 * Return the total time this team has (sum of solution times + penalty), in ms.
 	 *
 	 * @return the total time of this team
 	 */
 	long getTime();
 
 	/**
-	 * Returns the time of the last (most recent) solution, in minutes.
+	 * Returns the time of the last (most recent) solution, in ms.
 	 *
 	 * @return the time of last solution
 	 */

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -10,6 +10,8 @@ import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.State;
 
 public class Scoreboard {
+	private static final boolean is202306 = "2023-06".equals(System.getProperty("ICPC_CONTEST_API"));
+
 	private static double round(double d) {
 		return Math.round(d * 100_000.0) / 100_000.0;
 	}
@@ -62,12 +64,20 @@ public class Scoreboard {
 			pw.write("\"score\":{");
 			if (ScoreboardType.PASS_FAIL.equals(scoreboardType)) {
 				pw.write("\"num_solved\":" + s.getNumSolved() + ",");
-				pw.write("\"total_time\":" + s.getTime() + "},\n");
+				if (is202306) {
+					pw.write("\"total_time\":" + ContestUtil.getTime(s.getTime()) + "},\n");
+				} else {
+					pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
+				}
 			} else if (ScoreboardType.SCORE.equals(scoreboardType)) {
 				pw.write("\"score\":" + round(s.getScore()));
-				if (s.getLastSolutionTime() >= 0)
-					pw.write(",\"time\":" + s.getLastSolutionTime() + "},\n");
-				else
+				if (s.getLastSolutionTime() >= 0) {
+					if (is202306) {
+						pw.write(",\"time\":" + ContestUtil.getTime(s.getLastSolutionTime()) + "},\n");
+					} else {
+						pw.write(",\"time\":\"" + RelativeTime.format(s.getLastSolutionTime()) + "\"},\n");
+					}
+				} else
 					pw.write("},\n");
 			}
 			pw.write("  \"problems\":[");
@@ -91,7 +101,11 @@ public class Scoreboard {
 								pw.write(",\"first_to_solve\":true");
 						} else if (ScoreboardType.SCORE.equals(scoreboardType))
 							pw.write("\"score\":" + round(r.getScore()));
-						pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
+						if (is202306) {
+							pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
+						} else {
+							pw.write(",\"time\":\"" + RelativeTime.format(r.getContestTime()) + "\"");
+						}
 					} else
 						pw.write("\"solved\":false");
 					pw.write("}");

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1049,14 +1049,14 @@ public class Contest implements IContest {
 						double scoreForThisProblem = tempResults[i][j].getScore();
 						if (scoreForThisProblem > 0) {
 							score += scoreForThisProblem;
-							long time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime());
+							long time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime()) * 60 * 1000L;
 							if (time > lastSolution)
 								lastSolution = time;
 						}
 					}
 				}
 
-				tempStandings[i].init(numSolved, (int) (penalty / (60 * 1000L)), score, lastSolution);
+				tempStandings[i].init(numSolved, penalty, score, lastSolution);
 			}
 
 			for (int i = 0; i < numTeams; i++) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
@@ -134,6 +134,7 @@ public class Ranking {
 				standingNext = standings[order[next]];
 
 			// find a group
+			// round last solution time to minutes for ICPC rules?
 			while (next < numTeams && ((standingN.getNumSolved() == standingNext.getNumSolved()
 					&& standingN.getTime() == standingNext.getTime()
 					&& standingN.getLastSolutionTime() == standingNext.getLastSolutionTime())

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Standing.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Standing.java
@@ -1,9 +1,10 @@
 package org.icpc.tools.contest.model.internal;
 
 import org.icpc.tools.contest.model.IStanding;
+import org.icpc.tools.contest.model.feed.RelativeTime;
 
 public class Standing implements IStanding {
-	private int penalty;
+	private long penalty;
 	private int numSolved;
 	private long lastSolution;
 	private String rank;
@@ -13,14 +14,14 @@ public class Standing implements IStanding {
 		// do nothing
 	}
 
-	public void init(int numSolved2, int penalty2, double score2, long lastSolution2) {
+	public void init(int numSolved2, long penalty2, double score2, long lastSolution2) {
 		this.numSolved = numSolved2;
 		this.penalty = penalty2;
 		this.score = score2;
 		this.lastSolution = lastSolution2;
 	}
 
-	public void setPenalty(int penalty) {
+	public void setPenalty(long penalty) {
 		this.penalty = penalty;
 	}
 
@@ -59,6 +60,7 @@ public class Standing implements IStanding {
 
 	@Override
 	public String toString() {
-		return "Standing [" + rank + ", " + numSolved + ", " + penalty + ", " + lastSolution + ", " + score + "]";
+		return "Standing [" + rank + ", " + numSolved + ", " + RelativeTime.format(penalty) + ", "
+				+ RelativeTime.format(lastSolution) + ", " + score + "]";
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -1,6 +1,13 @@
 package org.icpc.tools.contest.model.util;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
@@ -124,7 +131,8 @@ public class AwardUtil {
 			if (numPerGroup < 1)
 				throw new IllegalArgumentException("Cannot assign group awards to less than one team");
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Could not parse group parameter numPerGroup: " + template.getParameters().get("numPerGroup"));
+			throw new IllegalArgumentException(
+					"Could not parse group parameter numPerGroup: " + template.getParameters().get("numPerGroup"));
 		}
 
 		DisplayMode mode = template.getDisplayMode();
@@ -163,7 +171,8 @@ public class AwardUtil {
 
 		List<String> teamIdsNumMedalsSolved = new ArrayList<>();
 
-		if (template.getParameters() != null && template.getParameters().containsKey("mode") && template.getParameters().get("mode").equals("less-than-medals")) {
+		if (template.getParameters() != null && template.getParameters().containsKey("mode")
+				&& template.getParameters().get("mode").equals("less-than-medals")) {
 			int lowestMedalNumSolved = Integer.MAX_VALUE;
 			for (IAward a : awards) {
 				if (a.getAwardType() == IAward.MEDAL) {
@@ -341,7 +350,8 @@ public class AwardUtil {
 			if (template.getParameters() != null && template.getParameters().containsKey("numTeams"))
 				numTeams = Integer.parseInt(template.getParameters().get("numTeams"));
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Could not parse rank parameter: " + template.getParameters().get("numTeams"));
+			throw new IllegalArgumentException(
+					"Could not parse rank parameter: " + template.getParameters().get("numTeams"));
 		}
 
 		if (numTeams < 1)
@@ -439,7 +449,8 @@ public class AwardUtil {
 			if (numTeams < 1)
 				throw new IllegalArgumentException("Cannot assign medals to less than one team");
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Could not parse medal parameter: " + award.getParameters().get("numTeams"));
+			throw new IllegalArgumentException(
+					"Could not parse medal parameter: " + award.getParameters().get("numTeams"));
 		}
 
 		numTeams = Math.min(numTeams, teams.length - firstTeamIndex);
@@ -521,7 +532,8 @@ public class AwardUtil {
 			if (template.getParameters() != null && template.getParameters().containsKey("percent"))
 				percent = Integer.parseInt(template.getParameters().get("percent"));
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Could not parse top parameter: " + template.getParameters().get("percent"));
+			throw new IllegalArgumentException(
+					"Could not parse top parameter: " + template.getParameters().get("percent"));
 		}
 		if (percent < 1 || percent > 100)
 			throw new IllegalArgumentException(percent + " is not a valid top percentage");
@@ -595,7 +607,8 @@ public class AwardUtil {
 
 		IAward[] awards = contest.getAwards();
 
-		// Determine how many problems the lowest medalist solved. We need this for the solvedTop/solvedBottom case.
+		// Determine how many problems the lowest medalist solved. We need this for the
+		// solvedTop/solvedBottom case.
 		int lowestMedalNumSolved = Integer.MAX_VALUE;
 		Set<String> medalTeams = new HashSet<>();
 		for (IAward a : awards) {
@@ -675,7 +688,8 @@ public class AwardUtil {
 		award.add("id", template.getId());
 		IStanding standing = contest.getStanding(teams[t]);
 
-		// If the top of our list is just below the medalists or in the medalists, show it before the medalists
+		// If the top of our list is just below the medalists or in the medalists, show it before the
+		// medalists
 		if (t <= numMedalists) {
 			award.setParameter("before", numMedalists + "");
 		} else {
@@ -747,7 +761,8 @@ public class AwardUtil {
 			if (numTeams < 1)
 				throw new IllegalArgumentException("Cannot assign expected to advance awards to less than one team");
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Could not parse numTeams parameter: " + template.getParameters().get("numTeams"));
+			throw new IllegalArgumentException(
+					"Could not parse numTeams parameter: " + template.getParameters().get("numTeams"));
 		}
 
 		assignExpectedToAdvance(contest, (Award) template, numTeams);
@@ -761,7 +776,8 @@ public class AwardUtil {
 
 		IAward[] awards = contest.getAwards();
 
-		// Determine the position of the lowest medalist, which we need to display this award corrrectly
+		// Determine the position of the lowest medalist, which we need to display this award
+		// corrrectly
 		// Also keep track of all teams that have a group award
 		Set<String> groupWinners = new HashSet<>();
 		Set<String> medalWinners = new HashSet<>();
@@ -787,9 +803,9 @@ public class AwardUtil {
 		Award award = new Award(IAward.ALL_GROUP_WINNERS, template.getId(), teamIds, citation, mode);
 
 		award.setParameter("before", numMedalists + "");
-		award.setParameter("showGroupName",  "true");
-		award.setParameter("highlight",  "false");
-		award.setParameter("showScoreboardBefore",  "false");
+		award.setParameter("showGroupName", "true");
+		award.setParameter("highlight", "false");
+		award.setParameter("showScoreboardBefore", "false");
 		contest.add(award);
 	}
 
@@ -853,14 +869,16 @@ public class AwardUtil {
 			createMedalAwards(contest, gold, silver, bronze);
 		}
 
-		// We need to do this after the medals are created, because we need to know the number of solved problems for the lowest medalist
+		// We need to do this after the medals are created, because we need to know the number of
+		// solved problems for the lowest medalist
 		if (!honors.isEmpty()) {
 			for (IAward award : honors) {
 				createHonorsAwards(contest, award);
 			}
 		}
 
-		// We need to do this after both the medals are created and the individual group winners are known
+		// We need to do this after both the medals are created and the individual group winners are
+		// known
 		if (groupWinnersAward != null) {
 			createAllGroupWinnersAward(contest, groupWinnersAward);
 		}
@@ -945,7 +963,7 @@ public class AwardUtil {
 		IStanding standing = contest.getStanding(team);
 		if (hasMedal) {
 			String s = Messages.getString("awardSolving").replace("{0}", sb.toString())
-					.replace("{1}", standing.getNumSolved() + "").replace("{2}", standing.getTime() + "");
+					.replace("{1}", standing.getNumSolved() + "").replace("{2}", ContestUtil.getTime(standing.getTime()));
 			sb = new StringBuilder(s);
 		}
 

--- a/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
@@ -256,8 +256,8 @@ public class EventFeedUtil {
 			for (int i = 0; i < num; i++) {
 				ITeam team = teams[i];
 				IStanding standing = contest.getStanding(team);
-				Trace.trace(Trace.USER,
-						"  " + standing.getRank() + " " + standing.getNumSolved() + " " + standing.getTime());
+				Trace.trace(Trace.USER, "  " + standing.getRank() + " " + standing.getNumSolved() + " "
+						+ ContestUtil.getTime(standing.getTime()));
 				Trace.trace(Trace.USER, "    " + team.getLabel() + ": " + team.getActualDisplayName() + " ("
 						+ getGroupLabel(contest, team) + ")");
 			}
@@ -382,7 +382,7 @@ public class EventFeedUtil {
 		IStanding standing = contest.getStanding(team);
 		Trace.trace(Trace.USER, "Rank: " + standing.getRank());
 		Trace.trace(Trace.USER, "Solved: " + standing.getNumSolved());
-		Trace.trace(Trace.USER, "Total time: " + standing.getTime());
+		Trace.trace(Trace.USER, "Total time: " + ContestUtil.getTime(standing.getTime()));
 		Trace.trace(Trace.USER, "");
 
 		Trace.trace(Trace.USER, "Problem Summary:");
@@ -393,9 +393,9 @@ public class EventFeedUtil {
 			if (r.getStatus() != Status.UNATTEMPTED) {
 				s += " (submissions: " + r.getNumSubmissions();
 				if (r.getStatus() == Status.SOLVED) {
-					s += ", time: " + ContestUtil.getTimeInMin(r.getContestTime());
+					s += ", time: " + ContestUtil.getTime(r.getContestTime());
 					if (r.getPenaltyTime() > 0)
-						s += ", penalty: " + ContestUtil.getTimeInMin(r.getPenaltyTime()) + "";
+						s += ", penalty: " + ContestUtil.getTime(r.getPenaltyTime());
 					s += ")";
 				}
 			}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/LeaderTickerPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/old/LeaderTickerPresentation.java
@@ -7,6 +7,7 @@ import java.awt.FontMetrics;
 import java.awt.Graphics2D;
 import java.awt.geom.Dimension2D;
 
+import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IStanding;
 import org.icpc.tools.contest.model.ITeam;
@@ -56,7 +57,7 @@ public class LeaderTickerPresentation extends AbstractTickerPresentation {
 			g.setColor(Color.WHITE);
 			Utility.drawString3D(g, solved + "", cube * 3f / 4 - fm.stringWidth(solved + "") / 2f,
 					height3 - BORDER2 - fm.getDescent() - 1);
-			g.drawString(penalty + "", cube * 3f / 2 + 7, height3 - BORDER2 - fm.getDescent() - 1);
+			g.drawString(ContestUtil.getTime(penalty), cube * 3f / 2 + 7, height3 - BORDER2 - fm.getDescent() - 1);
 			g.translate(-x, 0);
 		}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import javax.imageio.ImageIO;
 
 import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IAward.AwardType;
 import org.icpc.tools.contest.model.IAward.DisplayMode;
@@ -376,7 +377,7 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			g.drawString(s, width - fm.stringWidth(s) - BORDER, height - h - BORDER - fm.getHeight() * 3);
 			s = "Solved: " + st.getNumSolved();
 			g.drawString(s, width - fm.stringWidth(s) - BORDER, height - h - BORDER - fm.getHeight() * 2);
-			s = "Time: " + st.getTime();
+			s = "Time: " + ContestUtil.getTime(st.getTime());
 			g.drawString(s, width - fm.stringWidth(s) - BORDER, height - h - BORDER - fm.getHeight());
 		}
 	}
@@ -423,7 +424,8 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 		String[] teamIds = new String[] { currentCache.teamId };
 		int numFTS = fts.size();
 		if (numFTS == 1) {
-			list.add(new Award(IAward.FIRST_TO_SOLVE, fts.get(0), teamIds, Messages.getString("awardFTSOne").replace("{0}", fts.get(0)), mode));
+			list.add(new Award(IAward.FIRST_TO_SOLVE, fts.get(0), teamIds,
+					Messages.getString("awardFTSOne").replace("{0}", fts.get(0)), mode));
 		} else if (numFTS >= 2) {
 			fts.sort((s1, s2) -> s1.compareTo(s2));
 			fts.set(numFTS - 1, Messages.getString("and") + " " + fts.get(numFTS - 1));

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/AbstractScoreboardPresentation.java
@@ -466,7 +466,7 @@ public abstract class AbstractScoreboardPresentation extends TitledPresentation 
 			g.setColor(isLightMode() ? Color.BLACK : Color.WHITE);
 			g.setFont(rowFont);
 			if (t > 0) {
-				s = t + "";
+				s = ContestUtil.getTime(t);
 				TextImage.drawString(g, s, width - BORDER - (fm.stringWidth("9999") + fm.stringWidth(s)) / 2, 5);
 			}
 		} else {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/JudgePresentation.java
@@ -345,7 +345,7 @@ public class JudgePresentation extends AbstractScoreboardPresentation {
 		long t = standing.getTime();
 		g.setFont(rowFont);
 		if (t > 0) {
-			String s = t + "";
+			String s = ContestUtil.getTime(t);
 			TextImage.drawString(g, s, width - BORDER - (fm.stringWidth("9999") + fm.stringWidth(s)) / 2, 5);
 		}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/ScoreboardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/scoreboard/ScoreboardPresentation.java
@@ -254,7 +254,7 @@ public class ScoreboardPresentation extends AbstractScrollingScoreboardPresentat
 
 		int jj = 0;
 		for (int i = numRunsBefore; i < numRuns - skipAfter; i++) {
-			String s = ContestUtil.getTime(submissions2[i].getContestTime()) + "";
+			String s = ContestUtil.getTime(submissions2[i].getContestTime());
 
 			ShadedRectangle.drawRoundRect(g2, xx, y, cubeWidth, cubeHeight, contest, submissions2[i], 0, s);
 
@@ -265,7 +265,7 @@ public class ScoreboardPresentation extends AbstractScrollingScoreboardPresentat
 					s = "# " + standing.getRank();
 					g2.drawString(s, xx + (cubeWidth - fm.stringWidth(s)) / 2, yy);
 					yy += fm.getHeight() + GAP;
-					s = standing.getNumSolved() + " - " + standing.getTime();
+					s = standing.getNumSolved() + " - " + ContestUtil.getTime(standing.getTime());
 					g2.drawString(s, xx + (cubeWidth - fm.stringWidth(s)) / 2, yy);
 				}
 
@@ -274,7 +274,7 @@ public class ScoreboardPresentation extends AbstractScrollingScoreboardPresentat
 					s = "# " + standing.getRank();
 					yy += fm.getHeight() + GAP;
 					g2.drawString(s, xx + (cubeWidth - fm.stringWidth(s)) / 2, yy);
-					s = standing.getNumSolved() + " - " + standing.getTime();
+					s = standing.getNumSolved() + " - " + ContestUtil.getTime(standing.getTime());
 					yy += fm.getHeight() + GAP;
 					g2.drawString(s, xx + (cubeWidth - fm.stringWidth(s)) / 2, yy);
 				}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/tile/TeamTileHelper.java
@@ -291,7 +291,7 @@ public class TeamTileHelper {
 			g.setColor(lightMode ? Color.DARK_GRAY : Color.LIGHT_GRAY);
 			g.setFont(penaltyFont);
 			if (standing.getTime() > 0) {
-				s = standing.getTime() + "";
+				s = ContestUtil.getTime(standing.getTime());
 				g.drawString(s, tileDim.width - IN_TILE_GAP * 2 - penaltyFm.stringWidth(s),
 						tileDim.height * 17 / 20 + penaltyFm.getAscent() / 2 - 3);
 			}

--- a/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
@@ -592,7 +592,7 @@ public class AwardUI {
 			String awardStr = getAwardString(team);
 			String groupName = getGroupLabel(team);
 			ti.setText(new String[] { standing.getRank(), team.getLabel(), team.getActualDisplayName(), groupName,
-					standing.getNumSolved() + "", standing.getTime() + "", awardStr });
+					standing.getNumSolved() + "", ContestUtil.getTime(standing.getTime()), awardStr });
 		}
 	}
 


### PR DESCRIPTION
In the current draft spec, times in the /scoreboard endpoint have been updated to use REL_TIME to match the updated REL_TIME penalty in contest. All ICPC tools can read the new format (#1078), but the CDS does not output in the new format.

The ICPC tools currently store the scoreboard values as integer minutes. Although we could support the new spec by simply converting minutes to REL_TIME (i.e. always end in ':00.000'), this would leave these two values inconsistent and defer support for non-minute penalties down the road (and kind of miss the point).

This PR makes all the underlying changes in order to correctly support different penalties in the future, without breaking current ICPC compatibility:
- Change datatype for time and last solution in standings from minutes to ms.
- Adjust all places that were outputting standing time externally to use ContestUtil.getTime() to convert back to minutes.
- Use the ICPC_CONTEST_API system property to maintain backward compatibility for the /scoreboard. When this isn't set, scoreboard outputs in the new draft spec format.

So after this:
- There should be no UI change.
- ICPC scoring algorithm in CDS and resolver are unchanged (any penalty will be applied correctly, but submission time and tie-breakers are still based on minutes).
- CDS scoreboard supports the new spec (and has backward compatibility).