### PR TITLE
Never pass through cursor sizes smaller than 1x1.

### DIFF
--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -1174,8 +1174,10 @@ public class PresentationWindowImpl extends PresentationWindow {
 		GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
 		GraphicsDevice gd = ge.getDefaultScreenDevice();
 		GraphicsConfiguration gc = gd.getDefaultConfiguration();
-		BufferedImage image = gc.createCompatibleImage(d.width, d.height, Transparency.TRANSLUCENT);
-		// im = alphaMultiply(im, 0.0);*/
+		BufferedImage image = gc.createCompatibleImage(
+				// Never pass in a cursor size smaller than 1x1.
+				Math.max(1, d.width), Math.max(1, d.height),
+				Transparency.TRANSLUCENT);
 		return t.createCustomCursor(image, new Point(0, 0), "no cursor");
 	}
 


### PR DESCRIPTION
This apparently is triggered via KVM in Proxmox where it would otherwise crash with:
```
Exception in thread "main" java.lang.IllegalArgumentException: Width (0) and height (0) cannot be <= 0
        at java.desktop/java.awt.image.DirectColorModel.createCompatibleWritableRaster(DirectColorModel.java:1016)
        at java.desktop/java.awt.GraphicsConfiguration.createCompatibleImage(GraphicsConfiguration.java:184)
        at org.icpc.tools.presentation.core.internal.PresentationWindowImpl.getCustomCursor(PresentationWindowImpl.java:1177)
        at org.icpc.tools.presentation.core.internal.PresentationWindowImpl.<init>(PresentationWindowImpl.java:299)
        at org.icpc.tools.presentation.core.PresentationWindow.create(PresentationWindow.java:144)
        at org.icpc.tools.presentation.core.PresentationWindow.open(PresentationWindow.java:148)
        at org.icpc.tools.presentation.core.PresentationWindow.open(PresentationWindow.java:162)
        at org.icpc.tools.presentation.contest.internal.standalone.StandaloneLauncher.launch(StandaloneLauncher.java:323)
        at org.icpc.tools.presentation.contest.internal.standalone.StandaloneLauncher.main(StandaloneLauncher.java:114)
```