### PR TITLE
Handle the case when an honors awards has an empty list

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -662,6 +662,9 @@ public class AwardUtil {
 			}
 		}
 
+		if (t >= b)
+			return;
+
 		String[] teamIds = new String[b - t];
 		for (int i = 0; i < b - t; i++) {
 			teamIds[i] = teams[t + i].getId();


### PR DESCRIPTION
If you have an award where the top is `solvedTop` and the bottom is an `percentileBottom` and the percentile team is *above* the solved team, you could get indices which would create a list with negative size. In that case, don't create the award.