### PR TITLE
fix test data count in public feed

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -134,6 +134,10 @@ public class Problem extends ContestObject implements IProblem {
 		return testDataCount;
 	}
 
+	public void clearTestDataCount() {
+		testDataCount = Integer.MIN_VALUE;
+	}
+
 	@Override
 	public int getTimeLimit() {
 		return timeLimit;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -259,7 +259,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 	 */
 	protected IProblem filterProblem(IProblem problem) {
 		Problem p = (Problem) ((Problem) problem).clone();
-		p.add("test_data_count", null);
+		p.clearTestDataCount();
 		p.setPackage(null);
 		return p;
 	}


### PR DESCRIPTION
We try to strip the test data count in the public feed by setting it to null, but the property is an integer so you get this in the log instead:

 R Error adding property: problems/test_data_count:null
 R    java.lang.NumberFormatException: null
 R    at org.icpc.tools.contest.model.internal.ContestObject.parseInt(ContestObject.java:142)

This just adds a method to correctly clear the property back to the default value, and uses that.