### PR TITLE
Fix error when deleting configuration objects

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -1125,13 +1125,12 @@ public class ContestRESTService extends HttpServlet {
 
 		try {
 			Trace.trace(Trace.USER, "Deleting contest object: " + ei.type + "/" + ei.id);
-			Deletion d = new Deletion(ei.id, ei.cType);
 			Contest contest = ei.cc.getContest();
 			if (contest.getObjectByTypeAndId(ei.cType, ei.id) == null) {
 				response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Object does not exist");
 				return;
 			}
-			contest.add(d);
+			contest.add(new Deletion(ei.id, ei.cType));
 		} catch (Exception e) {
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Could not remove object");
 			Trace.trace(Trace.ERROR, "Could not remove from contest! " + ei.id, e);

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -17,6 +17,7 @@ import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IContestObject.ContestType;
+import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
@@ -521,6 +522,10 @@ public class PlaybackContest extends Contest {
 	}
 
 	private void applyDefaults(IContestObject obj) {
+		// don't apply defaults to objects being deleted
+		if (obj instanceof IDelete)
+			return;
+
 		IContestObject.ContestType type = obj.getType();
 		IContestObject def = null;
 		if (IContestObject.isSingleton(type)) {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/NDJSONFeedParser.java
@@ -95,8 +95,7 @@ public class NDJSONFeedParser implements Closeable {
 		if ("delete".equals(op)) {
 			String id = data.getString("id");
 			IContestObject.ContestType cType = IContestObject.getTypeByName(type);
-			Deletion d = new Deletion(id, cType);
-			contest.add(d);
+			contest.add(new Deletion(id, cType));
 		} else {
 			IContestObject.ContestType cType = IContestObject.getTypeByName(type);
 			if (cType == null) {
@@ -140,6 +139,9 @@ public class NDJSONFeedParser implements Closeable {
 					Trace.trace(Trace.ERROR, "Could not add event to contest: " + s, e);
 				}
 			} else {
+				// get the current objects
+				IContestObject[] allObjs = contest.getObjects(cType);
+
 				// add/replace set
 				Object[] objs = (Object[]) data;
 				List<String> ids = new ArrayList<>();
@@ -154,11 +156,9 @@ public class NDJSONFeedParser implements Closeable {
 				}
 
 				// delete any objects not included
-				IContestObject[] allObjs = contest.getObjects(cType);
 				for (IContestObject co : allObjs) {
 					if (!ids.contains(co.getId())) {
-						Deletion d = new Deletion(co.getId(), cType);
-						contest.add(d);
+						contest.add(new Deletion(co.getId(), cType));
 					}
 				}
 			}


### PR DESCRIPTION
Deleting contest objects like runs or submissions was working, but deleting configuration/registration objects like teams or groups is failing. e.g. if you have some groups and use a set in the event feed to replace with a different set, it fails with the following in the log:

 R Error adding property: problems/test_data_count:null
 R    java.lang.NumberFormatException: null
 R    at org.icpc.tools.contest.model.internal.ContestObject.parseInt(ContestObject.java:142)
 R Could not parse event feed line: {"type":"groups","token":"...","id": null,"data": [{...},{...}]}
 R    java.lang.NullPointerException: null
 R    at org.icpc.tools.cds.util.PlaybackContest.applyDefaults(PlaybackContest.java:538)

The fix is in PlaybackContest - we shouldn't try to apply default values to something we're deleting.

While I was debugging I changed a few cases to contest.add(new Deletion()) solely because the syntax looked nicer :) , and moved the line 'IContestObject[] allObjs' higher up because it's more efficient to remove deleted items from the list prior to adding new ones (e.g. if you have 5 groups and set it to 8, you only need to look through the original 5 to see if any were deleted. Likewise, if you have no groups and set it to 7, there aren't any you need to delete)