### PR TITLE
Default to released spec and change how we handle draft spec

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -151,6 +151,12 @@ public class CDSConfig {
 		lastModified = file.lastModified();
 		try {
 			Element e = readElement(file);
+
+			if (e.hasAttribute("contest-api")) {
+				String spec = getString(e, "contest-api");
+				System.setProperty("ICPC_CONTEST_API", spec);
+			}
+
 			loadContests(e);
 			loadOtherConfig(e);
 

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -53,6 +53,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet(urlPatterns = { "/api", "/api/", "/api/*" }, asyncSupported = true)
 public class ContestRESTService extends HttpServlet {
+	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
 	private static final long serialVersionUID = 1L;
 
 	static class EndpointInfo {
@@ -274,8 +275,13 @@ public class ContestRESTService extends HttpServlet {
 		je.encode("name", "Contest Data Server");
 		je.encodePrimitive("logo", "[{\"href\":\"/cdsIcon.png\",\"filename\":\"logo.png\","
 				+ "\"mime\":\"image/png\",\"width\":512,\"height\":512}]");
-		je.encode("version", "2025-draft");
-		je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
+		if (isDraftSpec) {
+			je.encode("version", "2025-draft");
+			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
+		} else {
+			je.encode("version", "2023-06");
+			je.encode("version_url", "https://ccs-specs.icpc.io/2023-06/contest_api");
+		}
 		je.close();
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -10,7 +10,7 @@ import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.State;
 
 public class Scoreboard {
-	private static final boolean is202306 = "2023-06".equals(System.getProperty("ICPC_CONTEST_API"));
+	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
 
 	private static double round(double d) {
 		return Math.round(d * 100_000.0) / 100_000.0;
@@ -64,18 +64,18 @@ public class Scoreboard {
 			pw.write("\"score\":{");
 			if (ScoreboardType.PASS_FAIL.equals(scoreboardType)) {
 				pw.write("\"num_solved\":" + s.getNumSolved() + ",");
-				if (is202306) {
-					pw.write("\"total_time\":" + ContestUtil.getTime(s.getTime()) + "},\n");
-				} else {
+				if (!isDraftSpec) {
 					pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
+				} else {
+					pw.write("\"total_time\":" + ContestUtil.getTime(s.getTime()) + "},\n");
 				}
 			} else if (ScoreboardType.SCORE.equals(scoreboardType)) {
 				pw.write("\"score\":" + round(s.getScore()));
 				if (s.getLastSolutionTime() >= 0) {
-					if (is202306) {
-						pw.write(",\"time\":" + ContestUtil.getTime(s.getLastSolutionTime()) + "},\n");
-					} else {
+					if (isDraftSpec) {
 						pw.write(",\"time\":\"" + RelativeTime.format(s.getLastSolutionTime()) + "\"},\n");
+					} else {
+						pw.write(",\"time\":" + ContestUtil.getTime(s.getLastSolutionTime()) + "},\n");
 					}
 				} else
 					pw.write("},\n");
@@ -101,10 +101,10 @@ public class Scoreboard {
 								pw.write(",\"first_to_solve\":true");
 						} else if (ScoreboardType.SCORE.equals(scoreboardType))
 							pw.write("\"score\":" + round(r.getScore()));
-						if (is202306) {
-							pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
-						} else {
+						if (isDraftSpec) {
 							pw.write(",\"time\":\"" + RelativeTime.format(r.getContestTime()) + "\"");
+						} else {
+							pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
 						}
 					} else
 						pw.write("\"solved\":false");

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -14,7 +14,7 @@ import org.icpc.tools.contest.model.feed.RelativeTime;
 import org.icpc.tools.contest.model.feed.Timestamp;
 
 public class Info extends ContestObject implements IInfo {
-	private static final boolean is202306 = "2023-06".equals(System.getProperty("ICPC_CONTEST_API"));
+	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
 
 	private static final String NAME = "name";
 	private static final String FORMAL_NAME = "formal_name";
@@ -341,10 +341,10 @@ public class Info extends ContestObject implements IInfo {
 			props.addLiteralString(SCOREBOARD_THAW_TIME, Timestamp.format(thawTime.longValue()));
 
 		if (penalty != null) {
-			if (is202306)
-				props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
-			else
+			if (isDraftSpec)
 				props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
+			else
+				props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
 		}
 
 		if (!Double.isNaN(timeMultiplier))


### PR DESCRIPTION
On the main branch the CDS has moved up to the draft spec, but for NAC and Baku we will be running on the 2023_06 spec and there's no target to finalize the current draft. In order to safely run these contests and release the CDS in the interim, the default should be the 2023_06 spec.

This PR:

- Switches the default spec back to 2023_06.
- Changes the system property to 'ICPC_CONTEST_API=draft' in order to use the new/draft spec - the idea being that we always support the current released spec with an option to enable the new draft.
- Adds support to the /access endpoint to return the correct spec version.
- Adds a 'contest-api' property to the cdsConfig to make it easy to switch between specs, e.g. `<cds contest-api="draft" ...`