### PR TITLE
Fix web scoreboard formatting

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -106,7 +106,7 @@ function getRow(scr, type) {
                     obj.scoreClass = 'table-danger';
                 obj.num = prob.num_judged + prob.num_pending;
                 obj.solved = prob.solved;
-                obj.time = prob.time;
+                obj.time = formatTimeInMin(parseIntegerOrRelTime(prob.time));
                 obj.score = prob.score;
             }
         }
@@ -118,12 +118,12 @@ function getRow(scr, type) {
     obj = { };
     if (scr.score.num_solved > 0)
     	obj.numSolved = scr.score.num_solved;
-    if (scr.score.total_time > 0)
-    	obj.totalTime = scr.score.total_time;
+    if (scr.score.total_time)
+    	obj.totalTime = formatTimeInMin(parseIntegerOrRelTime(scr.score.total_time));
     if (scr.score.score != 0)
     	obj.score = scr.score.score;
     if (scr.score.time > 0)
-    	obj.time = scr.score.time;
+    	obj.time = formatTimeInMin(parseIntegerOrRelTime(scr.score.time));
     if ("score" == type)
     	row.append(toHtml("row-end-score", obj));
     else

--- a/CDS/WebContent/js/model.js
+++ b/CDS/WebContent/js/model.js
@@ -93,6 +93,32 @@ function bestLogo(logos, width, height) {
   return best;
 }
 
+function parseIntegerOrRelTime(contestTime) {
+	if (!contestTime)
+		return '?';
+	
+	if (Number.isInteger(contestTime))
+		return parseInt(contestTime) * 60 * 1000;
+
+	match = contestTime.match("-?([0-9]+):([0-9]{2}):([0-9]{2})(\\.[0-9]{3})?");
+	
+	if (match == null || match.length < 4)
+		return null;
+
+	h = parseInt(match[1]);
+	m = parseInt(match[2]);
+	s = parseInt(match[3]);	
+	ms = 0;
+	if (match.length == 5)
+		ms = parseInt(match[4].substring(1));
+
+	ret = h * 60 * 60 * 1000 + m * 60 * 1000 + s * 1000 + ms;
+	if (contestTime.startsWith("-"))
+	  return -ret
+
+	return ret;
+}
+
 function parseTime(contestTime) {
 	if (!contestTime)
 		return '?';

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -241,6 +241,28 @@ function formatTime(time2) {
 	return sb.join("");
 }
 
+function formatTimeInMin(time2) {
+	if (time2 >= 0 && time2 < 1000)
+		return "0";
+
+	var sb = [];
+	if (time2 < 0) {
+		sb.push("-");
+		time2 = -time2;
+	}
+	time = Math.floor(time2 / 1000);
+
+	days = Math.floor(time / 86400.0);
+	if (days > 0)
+		sb.push(days + "d");
+
+	mins = Math.floor(time / 60.0);
+	if (mins > 0)
+		sb.push(mins);
+
+	return sb.join("");
+}
+
 function formatContestTime(time, floor) {
 	var sb = [];
 	if (time < 0)


### PR DESCRIPTION
With penalties changed to reltime in the draft spec, the web client side needs to handle either integer or reltime. This adds a new parseIntegerOrRelTime() to parse either value into ms, and formats them correctly in the scoreboard.

Fixes #1092.