### PR TITLE
Pass the correct image to the extracted function

### DIFF
--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -545,7 +545,7 @@ public class ImagesGenerator {
 
 		g.dispose();
 
-		writeJPEGImage(img, file);
+		writeJPEGImage(newImg, file);
 		// ImageIO.write(newImg, "jpg", hdFile);
 	}
 


### PR DESCRIPTION
Extraction of the function resulted in failure in generating the background images.

No idea why I didn't catch that when actually testing the extraction.