### PR TITLE
Add Sentry logging for client tools

### DIFF
--- a/ContestUtil/ContestUtil.iml
+++ b/ContestUtil/ContestUtil.iml
@@ -8,5 +8,15 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="ContestModel" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.contest.util;
 
+import io.sentry.Sentry;
+
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
@@ -82,6 +84,8 @@ public class ImagesGenerator {
 	public static void main(String[] args) {
 		Trace.init("ICPC Image Generator", "imageGenerator", args);
 
+		Sentry.init();
+
 		if (args == null || args.length != 1) {
 			Trace.trace(Trace.ERROR, "Missing argument, must point to a contest location");
 			System.exit(0);
@@ -128,6 +132,7 @@ public class ImagesGenerator {
 					Files.copy(from.toPath(), to.toPath(), StandardCopyOption.COPY_ATTRIBUTES);
 			}
 		} catch (Exception e) {
+			Sentry.captureException(e);
 			e.printStackTrace();
 		}*/
 
@@ -145,6 +150,7 @@ public class ImagesGenerator {
 		try {
 			generator.createRibbon();
 		} catch (Exception e) {
+			Sentry.captureException(e);
 			e.printStackTrace();
 		}*/
 
@@ -152,12 +158,14 @@ public class ImagesGenerator {
 		try {
 			generator.createPreview();
 		} catch (Exception e) {
+			Sentry.captureException(e);
 			e.printStackTrace();
 		}
 
 		try {
 			generator.createContestPreview();
 		} catch (Exception e) {
+			Sentry.captureException(e);
 			e.printStackTrace();
 		}
 
@@ -942,6 +950,7 @@ public class ImagesGenerator {
 
 			bw.close();
 		} catch (Exception e) {
+			Sentry.captureException(e);
 			e.printStackTrace();
 		}
 

--- a/PresContest/PresContest.iml
+++ b/PresContest/PresContest.iml
@@ -29,5 +29,15 @@
         <jarDirectory url="file://$MODULE_DIR$/staging" recursive="false" />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.presentation.contest.internal.standalone;
 
+import io.sentry.Sentry;
+
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -27,6 +29,8 @@ public class StandaloneLauncher {
 	public static void main(String[] args) {
 		Trace.init("ICPC Standalone Presentations", "standalone", args);
 		System.setProperty("apple.awt.application.name", "Presentation Client");
+
+		Sentry.init();
 
 		List<PresentationInfo> presentations = PresentationHelper.getPresentations();
 		if (presentations.isEmpty()) {
@@ -316,6 +320,7 @@ public class StandaloneLauncher {
 
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "      Could not load presentation");
+				Sentry.captureException(e);
 				return;
 			}
 		}
@@ -325,6 +330,7 @@ public class StandaloneLauncher {
 			window.setDisplayConfig(new DisplayConfig(displayStr[0], displayStr[1]));
 		} catch (Exception e) {
 			Trace.trace(Trace.WARNING, "Invalid display option: " + displayStr + " " + e.getMessage());
+			Sentry.captureException(e);
 		}
 		if (lightMode)
 			((PresentationWindowImpl) window).setLightMode(true);

--- a/sentry.properties
+++ b/sentry.properties
@@ -1,0 +1,4 @@
+dsn=sentry_URL
+# Add data like request headers and IP for users,
+# see https://docs.sentry.io/platforms/java/data-management/data-collected/ for more info
+send-default-pii=false


### PR DESCRIPTION
We use this often for DOMjudge so it helps to detect some of the raised issues automatically.

I didn't update the eclipse part as I don't know (yet) how to set that one up. I think this can be extended to send the error to Sentry each time that the Trace has a level of `ERROR` and merging the `Trace` & `Sentry` calls in a custom wrapper. Before I put in that time I would like to know if this is even something which is wanted.