### PR TITLE
Add Sentry support for the CDS

### DIFF
--- a/CDS/CDS.iml
+++ b/CDS/CDS.iml
@@ -83,5 +83,15 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/CDS/README.md
+++ b/CDS/README.md
@@ -375,6 +375,12 @@ folder and are shown in their Linux form; replace the "/" characters with "\" on
 | /bin/server status cds | Displays the current status of the CDS
 | /bin/server list | List the servers which WLP knows about
 
+### Sending errors to Sentry
+
+To ship exceptions to sentry for easier debugging:
+
+* Enable the `<ssl id="defaultSSLConfig>` in `server.xml`
+* Set the `DSN` in `wlp/usr/servers/cds/{server.env,sentry.properties}` or the command line. 
 
 ## Accessing CDS Services
 

--- a/CDS/build.xml
+++ b/CDS/build.xml
@@ -27,6 +27,7 @@
   	<pathelement location="io.openliberty.jakarta.security.3.0_1.0.93.jar"/>
   	<pathelement location="WebContent/WEB-INF/lib/openpdf-1.3.27.jar"/>
     <pathelement location="${contest.model}/bin"/>
+    <pathelement location="${contest.model}/lib/sentry-opentelemetry-agent-8.12.0.jar"/>
   	<pathelement location="${contest.model}/lib/snakeyaml-2.3.jar"/>
   </path>
   <target name="init">

--- a/CDS/config/wlp/cds/sentry.properties
+++ b/CDS/config/wlp/cds/sentry.properties
@@ -1,0 +1,4 @@
+#dsn=https://fill_with_sentry_dsn@replace.sentry.io/identifier"
+# Add data like request headers and IP for users,
+# see https://docs.sentry.io/platforms/java/data-management/data-collected/ for more info
+send-default-pii=false

--- a/CDS/config/wlp/cds/server.env
+++ b/CDS/config/wlp/cds/server.env
@@ -1,0 +1,1 @@
+#SENTRY_DSN="https://fill_with_sentry_dsn@replace.sentry.io/identifier"

--- a/CDS/config/wlp/cds/server.xml
+++ b/CDS/config/wlp/cds/server.xml
@@ -17,6 +17,7 @@
     <httpSession invalidationTimeout="8h" idReuse="true"/>
 
     <keyStore id="defaultKeyStore" password="{xor}FhwPHAswMDMs" />
+    <!--<ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustDefaultCerts="true" />-->
 
     <jndiEntry jndiName="icpc.cds.config" value="${server.config.dir}/config"/>
 

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.cds.service;
 
+import io.sentry.Sentry;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -61,6 +63,16 @@ public class ContestRESTService extends HttpServlet {
 		String type;
 		ContestType cType;
 		String id;
+	}
+
+	@Override
+	public void init() throws ServletException {
+		super.init();
+		try {
+			Sentry.init();
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Sentry init failed,");
+		}
 	}
 
 	@Override
@@ -128,6 +140,7 @@ public class ContestRESTService extends HttpServlet {
 			contest.getInfo();
 		} catch (Exception e) {
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Contest not configured");
+			Sentry.captureException(e);
 		}
 
 		if (segments.length == 2) {
@@ -881,6 +894,7 @@ public class ContestRESTService extends HttpServlet {
 				rObj = restSource.postSubmission(obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return null;
 			}
 		}
@@ -1030,6 +1044,7 @@ public class ContestRESTService extends HttpServlet {
 				restSource.patch(ContestType.AWARD, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return;
 			}
 		}
@@ -1062,6 +1077,7 @@ public class ContestRESTService extends HttpServlet {
 				restSource.delete(ContestType.AWARD, id);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return;
 			}
 		}
@@ -1108,6 +1124,7 @@ public class ContestRESTService extends HttpServlet {
 				return restSource.post(type, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error POSTing to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return null;
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/Trace.java
+++ b/ContestModel/src/org/icpc/tools/contest/Trace.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.contest;
 
+import io.sentry.Sentry;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -201,6 +203,12 @@ public class Trace {
 					writer.print(s + " ");
 				writer.println();
 			}
+			try {
+				Sentry.init();
+			} catch (Exception e) {
+				// Sentry config might be empty.
+			}
+			writer.println("Sentry: " + (Sentry.isEnabled()? "Enabled" : "Disabled"));
 			writer.println("Log started " + sdf.format(new Date()));
 			writer.println();
 			writer.flush();
@@ -235,8 +243,11 @@ public class Trace {
 						// ignore
 					}
 				}
-			} else
+			} else {
+				Sentry.setExtra("trace_debug", s);
+				Sentry.captureException(t);
 				previousErrors.add(hash);
+			}
 		}
 		if (type != INFO || writer == null) {
 			if (type == ERROR)


### PR DESCRIPTION
I think this one should be merged before: https://github.com/icpctools/icpctools/pull/1112 as it already implements some of the improvements for that one.

I choose to also raise errors when another system has issues, mostly because those events are important in a contest but might go unnoticed. If this is accepted I can squash the commits but I didn't want to lose progress if changes are requested.