### PR TITLE
Fix svg png same url

### DIFF
--- a/BalloonUtility/BalloonUtility.iml
+++ b/BalloonUtility/BalloonUtility.iml
@@ -12,6 +12,16 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
+          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
           <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-aarch64.jar!/" />
         </CLASSES>
         <JAVADOC />
@@ -21,11 +31,28 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
-        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
       </library>
     </orderEntry>
   </component>

--- a/CDS/CDS.iml
+++ b/CDS/CDS.iml
@@ -83,5 +83,15 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/CDS/README.md
+++ b/CDS/README.md
@@ -375,6 +375,12 @@ folder and are shown in their Linux form; replace the "/" characters with "\" on
 | /bin/server status cds | Displays the current status of the CDS
 | /bin/server list | List the servers which WLP knows about
 
+### Sending errors to Sentry
+
+To ship exceptions to sentry for easier debugging:
+
+* Enable the `<ssl id="defaultSSLConfig>` in `server.xml`
+* Set the `DSN` in `wlp/usr/servers/cds/{server.env,sentry.properties}` or the command line. 
 
 ## Accessing CDS Services
 

--- a/CDS/build.xml
+++ b/CDS/build.xml
@@ -27,6 +27,7 @@
   	<pathelement location="io.openliberty.jakarta.security.3.0_1.0.93.jar"/>
   	<pathelement location="WebContent/WEB-INF/lib/openpdf-1.3.27.jar"/>
     <pathelement location="${contest.model}/bin"/>
+    <pathelement location="${contest.model}/lib/sentry-opentelemetry-agent-8.12.0.jar"/>
   	<pathelement location="${contest.model}/lib/snakeyaml-2.3.jar"/>
   </path>
   <target name="init">

--- a/CDS/config/wlp/cds/sentry.properties
+++ b/CDS/config/wlp/cds/sentry.properties
@@ -1,0 +1,4 @@
+#dsn=https://fill_with_sentry_dsn@replace.sentry.io/identifier"
+# Add data like request headers and IP for users,
+# see https://docs.sentry.io/platforms/java/data-management/data-collected/ for more info
+send-default-pii=false

--- a/CDS/config/wlp/cds/server.env
+++ b/CDS/config/wlp/cds/server.env
@@ -1,0 +1,1 @@
+#SENTRY_DSN="https://fill_with_sentry_dsn@replace.sentry.io/identifier"

--- a/CDS/config/wlp/cds/server.xml
+++ b/CDS/config/wlp/cds/server.xml
@@ -17,6 +17,7 @@
     <httpSession invalidationTimeout="8h" idReuse="true"/>
 
     <keyStore id="defaultKeyStore" password="{xor}FhwPHAswMDMs" />
+    <!--<ssl id="defaultSSLConfig" keyStoreRef="defaultKeyStore" trustDefaultCerts="true" />-->
 
     <jndiEntry jndiName="icpc.cds.config" value="${server.config.dir}/config"/>
 

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.cds.service;
 
+import io.sentry.Sentry;
+
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -61,6 +63,16 @@ public class ContestRESTService extends HttpServlet {
 		String type;
 		ContestType cType;
 		String id;
+	}
+
+	@Override
+	public void init() throws ServletException {
+		super.init();
+		try {
+			Sentry.init();
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Sentry init failed,");
+		}
 	}
 
 	@Override
@@ -128,6 +140,7 @@ public class ContestRESTService extends HttpServlet {
 			contest.getInfo();
 		} catch (Exception e) {
 			response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "Contest not configured");
+			Sentry.captureException(e);
 		}
 
 		if (segments.length == 2) {
@@ -881,6 +894,7 @@ public class ContestRESTService extends HttpServlet {
 				rObj = restSource.postSubmission(obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return null;
 			}
 		}
@@ -1030,6 +1044,7 @@ public class ContestRESTService extends HttpServlet {
 				restSource.patch(ContestType.AWARD, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return;
 			}
 		}
@@ -1062,6 +1077,7 @@ public class ContestRESTService extends HttpServlet {
 				restSource.delete(ContestType.AWARD, id);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error submitting award to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return;
 			}
 		}
@@ -1108,6 +1124,7 @@ public class ContestRESTService extends HttpServlet {
 				return restSource.post(type, obj);
 			} catch (Exception e) {
 				response.sendError(HttpServletResponse.SC_BAD_GATEWAY, "Error POSTing to CCS: " + e.getMessage());
+				Sentry.captureException(e);
 				return null;
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/Trace.java
+++ b/ContestModel/src/org/icpc/tools/contest/Trace.java
@@ -1,5 +1,7 @@
 package org.icpc.tools.contest;
 
+import io.sentry.Sentry;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -201,6 +203,12 @@ public class Trace {
 					writer.print(s + " ");
 				writer.println();
 			}
+			try {
+				Sentry.init();
+			} catch (Exception e) {
+				// Sentry config might be empty.
+			}
+			writer.println("Sentry: " + (Sentry.isEnabled()? "Enabled" : "Disabled"));
 			writer.println("Log started " + sdf.format(new Date()));
 			writer.println();
 			writer.flush();
@@ -235,8 +243,11 @@ public class Trace {
 						// ignore
 					}
 				}
-			} else
+			} else {
+				Sentry.setExtra("trace_debug", s);
+				Sentry.captureException(t);
 				previousErrors.add(hash);
+			}
 		}
 		if (type != INFO || writer == null) {
 			if (type == ERROR)

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -64,7 +64,7 @@ public class Scoreboard {
 			pw.write("\"score\":{");
 			if (ScoreboardType.PASS_FAIL.equals(scoreboardType)) {
 				pw.write("\"num_solved\":" + s.getNumSolved() + ",");
-				if (!isDraftSpec) {
+				if (isDraftSpec) {
 					pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
 				} else {
 					pw.write("\"total_time\":" + ContestUtil.getTime(s.getTime()) + "},\n");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -673,17 +673,17 @@ public class DiskContestSource extends ContestSource {
 		}
 	}
 
-	protected FileReference getMetadata(String href, File file) {
+	protected FileReference getMetadata(File file) {
 		FileReference ref = getFileRef(file);
 		if (ref == null) {
-			Trace.trace(Trace.ERROR, "Null file ref! " + href + " - " + file + " - " + file.exists());
+			Trace.trace(Trace.ERROR, "Null file ref! " + file + " - " + file.exists());
 			ref = getFileRef(file);
 			if (ref == null) {
 				Trace.trace(Trace.ERROR, "Not found second pass");
 				return null;
 			}
 		}
-		ref.href = "contests/" + contestId + "/" + href;
+		ref.href = "contests/" + contestId + "/" + ref.filename;
 		return ref;
 	}
 
@@ -1101,7 +1101,7 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					FileReference ref = getMetadata(pattern.url+file.getName(), file);
+					FileReference ref = getMetadata(file);
 					if (ref != null) {
 						if (urlList.contains(ref.href))
 							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -673,17 +673,17 @@ public class DiskContestSource extends ContestSource {
 		}
 	}
 
-	protected FileReference getMetadata(File file) {
+	protected FileReference getMetadata(String href, File file) {
 		FileReference ref = getFileRef(file);
 		if (ref == null) {
-			Trace.trace(Trace.ERROR, "Null file ref! " + file + " - " + file.exists());
+			Trace.trace(Trace.ERROR, "Null file ref! " + href + " - " + file + " - " + file.exists());
 			ref = getFileRef(file);
 			if (ref == null) {
 				Trace.trace(Trace.ERROR, "Not found second pass");
 				return null;
 			}
 		}
-		ref.href = "contests/" + contestId + "/" + ref.filename;
+		ref.href = "contests/" + contestId + "/" + href;
 		return ref;
 	}
 
@@ -1101,7 +1101,7 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					FileReference ref = getMetadata(file);
+					FileReference ref = getMetadata(pattern.url + diff, file);
 					if (ref != null) {
 						if (urlList.contains(ref.href))
 							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -1092,7 +1092,7 @@ public class DiskContestSource extends ContestSource {
 			folder = new File(root, pattern.folder);
 
 		FileReferenceList refList = new FileReferenceList();
-		ArrayList<String> urlList = new ArrayList<>();
+		List<String> urlList = new ArrayList<>();
 		for (String ext : pattern.extensions) {
 			File[] files = folder.listFiles(
 					(dir, name) -> (name.toLowerCase().startsWith(pattern.name) && name.toLowerCase().endsWith("." + ext)));

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -1092,6 +1092,7 @@ public class DiskContestSource extends ContestSource {
 			folder = new File(root, pattern.folder);
 
 		FileReferenceList refList = new FileReferenceList();
+		ArrayList<String> urlList = new ArrayList<>();
 		for (String ext : pattern.extensions) {
 			File[] files = folder.listFiles(
 					(dir, name) -> (name.toLowerCase().startsWith(pattern.name) && name.toLowerCase().endsWith("." + ext)));
@@ -1101,8 +1102,12 @@ public class DiskContestSource extends ContestSource {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
 					FileReference ref = getMetadata(pattern.url + diff, file);
-					if (ref != null)
+					if (ref != null) {
+						if (urlList.contains(ref.href))
+							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);
 						refList.add(ref);
+						urlList.add(ref.href);
+					}
 					// TODO future: url currently would not be able to handle logo2.svg and logo2.png
 				}
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -673,17 +673,17 @@ public class DiskContestSource extends ContestSource {
 		}
 	}
 
-	protected FileReference getMetadata(File file) {
+	protected FileReference getMetadata(String href, File file) {
 		FileReference ref = getFileRef(file);
 		if (ref == null) {
-			Trace.trace(Trace.ERROR, "Null file ref! " + file + " - " + file.exists());
+			Trace.trace(Trace.ERROR, "Null file ref! " + href + " - " + file + " - " + file.exists());
 			ref = getFileRef(file);
 			if (ref == null) {
 				Trace.trace(Trace.ERROR, "Not found second pass");
 				return null;
 			}
 		}
-		ref.href = "contests/" + contestId + "/" + ref.filename;
+		ref.href = "contests/" + contestId + "/" + href;
 		return ref;
 	}
 
@@ -1101,7 +1101,7 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					FileReference ref = getMetadata(file);
+					FileReference ref = getMetadata(pattern.url+file.getName(), file);
 					if (ref != null) {
 						if (urlList.contains(ref.href))
 							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -673,17 +673,17 @@ public class DiskContestSource extends ContestSource {
 		}
 	}
 
-	protected FileReference getMetadata(String href, File file) {
+	protected FileReference getMetadata(File file) {
 		FileReference ref = getFileRef(file);
 		if (ref == null) {
-			Trace.trace(Trace.ERROR, "Null file ref! " + href + " - " + file + " - " + file.exists());
+			Trace.trace(Trace.ERROR, "Null file ref! " + file + " - " + file.exists());
 			ref = getFileRef(file);
 			if (ref == null) {
 				Trace.trace(Trace.ERROR, "Not found second pass");
 				return null;
 			}
 		}
-		ref.href = "contests/" + contestId + "/" + href;
+		ref.href = "contests/" + contestId + "/" + ref.filename;
 		return ref;
 	}
 
@@ -1101,7 +1101,7 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					FileReference ref = getMetadata(pattern.url + diff, file);
+					FileReference ref = getMetadata(file);
 					if (ref != null) {
 						if (urlList.contains(ref.href))
 							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -1101,7 +1101,7 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					FileReference ref = getMetadata(pattern.url+file.getName(), file);
+					FileReference ref = getMetadata(pattern.url+diff+'.'+ext, file);
 					if (ref != null) {
 						if (urlList.contains(ref.href))
 							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -1101,7 +1101,7 @@ public class DiskContestSource extends ContestSource {
 				for (File file : files) {
 					String diff = file.getName();
 					diff = diff.substring(pattern.name.length(), diff.length() - ext.length() - 1);
-					FileReference ref = getMetadata(pattern.url + diff, file);
+					FileReference ref = getMetadata(pattern.url+file.getName(), file);
 					if (ref != null) {
 						if (urlList.contains(ref.href))
 							Trace.trace(Trace.WARNING, "Found multiple files with same CDS href: " + ref.href + ", " + file);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
@@ -332,8 +332,6 @@ public class ContestData implements Iterable<IContestObject> {
 			IContestObject obj2 = objs[num][arr];
 			if (obj2 != null && rtc[obj2.getType().ordinal()].contains(obj2.getId())) {
 				objs[num][arr] = null;
-				if (!keepHistory)
-					break;
 			}
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/YamlParserTest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/YamlParserTest.java
@@ -79,7 +79,7 @@ public class YamlParserTest {
 		parseTime("5:00");
 	}
 
-	private int parseTime(String s) throws ParseException {
+	private long parseTime(String s) throws ParseException {
 		return RelativeTime.parse(s);
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -25,51 +25,6 @@ public class AnalystContest extends SpectatorContest {
 	}
 
 	@Override
-	public void add(IContestObject obj) {
-		if (obj instanceof IDelete) {
-			addIt(obj);
-			return;
-		}
-
-		IContestObject.ContestType cType = obj.getType();
-		switch (cType) {
-			case RUN: { // TODO - access block for live
-				IRun run = (IRun) obj;
-
-				IJudgement j = getJudgementById(run.getJudgementId());
-				if (j == null)
-					return;
-
-				if (isJudgementHidden(j))
-					return;
-
-				ISubmission s = getSubmissionById(j.getSubmissionId());
-				if (s == null)
-					return;
-
-				// hide runs for submissions outside the contest time
-				long time = s.getContestTime();
-				if (time < 0 || time >= getDuration())
-					return;
-
-				// hide runs for submissions after freeze
-				if (getFreezeDuration() != null) {
-					long freezeTime = getDuration() - getFreezeDuration();
-					if (s.getContestTime() >= freezeTime && getState().getThawed() == null) {
-						freeze.add(run);
-						return;
-					}
-				}
-
-				addIt(run);
-				return;
-			}
-			default:
-				super.add(obj);
-		}
-	}
-
-	@Override
 	protected IPerson filterPerson(IPerson person) {
 		Person p = (Person) ((Person) person).clone();
 		p.add("email", null);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
@@ -3,7 +3,9 @@ package org.icpc.tools.contest.model.internal.account;
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IDelete;
+import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IProblem;
+import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.internal.Problem;
 
@@ -35,6 +37,37 @@ public class SpectatorContest extends PublicContest {
 		switch (cType) {
 			case COMMENTARY: {
 				addIt(obj);
+				return;
+			}
+			case RUN: { // TODO - access block for live
+				IRun run = (IRun) obj;
+
+				IJudgement j = getJudgementById(run.getJudgementId());
+				if (j == null)
+					return;
+
+				if (isJudgementHidden(j))
+					return;
+
+				ISubmission s = getSubmissionById(j.getSubmissionId());
+				if (s == null)
+					return;
+
+				// hide runs for submissions outside the contest time
+				long time = s.getContestTime();
+				if (time < 0 || time >= getDuration())
+					return;
+
+				// hide runs for submissions after freeze
+				if (getFreezeDuration() != null) {
+					long freezeTime = getDuration() - getFreezeDuration();
+					if (s.getContestTime() >= freezeTime && getState().getThawed() == null) {
+						freeze.add(run);
+						return;
+					}
+				}
+
+				addIt(run);
 				return;
 			}
 			default: {

--- a/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC25.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/floor/FloorGeneratorNAC25.java
@@ -1,0 +1,122 @@
+package org.icpc.tools.contest.util.floor;
+
+import java.awt.geom.Point2D;
+import java.io.File;
+import java.util.List;
+
+import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.FloorMap;
+import org.icpc.tools.contest.model.FloorMap.Path;
+import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IPrinter;
+import org.icpc.tools.contest.model.IProblem;
+import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.DiskContestSource;
+
+public class FloorGeneratorNAC25 extends FloorGenerator {
+    // team area width (in meters). ICPC standard is 3.0
+    private static final float taw = 2.2f;
+
+    // team area depth (in meters). ICPC standard is 2.2
+    private static final float tad = 2.0f;
+
+    private static final float aisle = 2f + tad * 3 / 2;
+
+    private static FloorMap floor = new FloorMap(taw, tad, 1.8, 0.8);
+
+    protected static void createAisle(List<Point2D.Double> list, int i, int j) {
+        Point2D.Double p1 = list.get(i);
+        Point2D.Double p2 = list.get(j);
+        floor.createAisle(p1.x, p1.y, p2.x, p2.y);
+    }
+
+    protected static float createAisleOfTeams(int teamNumber, float xx, float yy, int num) {
+        float x = xx;
+        x += aisle / 2;
+        floor.createTeamRow(num, teamNumber, x, yy, FloorMap.E, false, true);
+        x += tad / 2;
+        floor.createTeamRow(num, teamNumber + num * 2 - 1, x, yy, FloorMap.W, true, false);
+        x += aisle / 2;
+
+        return x;
+    }
+
+    public static void main(String[] args) {
+        Trace.init("ICPC Floor Map Generator", "floorMap", args);
+
+        try {
+            float x = 0;
+            float y = -taw;
+
+            floor.createAisle(x, y + 2 * taw, x, y - taw * 6);
+
+            y += taw;
+
+            x = createAisleOfTeams(1, x, y, 6);
+
+            floor.createAisle(x, y + taw, x, y - taw * 7);
+
+            x = createAisleOfTeams(13, x, y, 7);
+
+            floor.createAisle(x, y + taw, x, y - taw * 7);
+
+            float center = x;
+
+            // bottom 1
+            floor.createAisle(0, y + taw, x, y + taw);
+
+            float xx = x;
+
+            x = createAisleOfTeams(27, x, y, 7);
+
+            floor.createAisle(x, y + taw, x, y - taw * 7);
+
+            x = createAisleOfTeams(41, x, y, 6);
+
+            floor.createAisle(x, y + taw, x, y - taw * 7);
+
+            // top
+            floor.createAisle(0, y - taw * 7, x, y - taw * 7);
+
+            // bottom 2
+            floor.createAisle(xx, y + taw, x, y + taw);
+
+            IPrinter p = floor.createPrinter(25, 5);
+
+            // add spares next to 7 and 46
+            ITeam t = createAdjacentTeam(floor, 7, -1, 0, -1 * taw);
+            floor.makeSpare(t);
+            t = createAdjacentTeam(floor, 46, -2, 0, -1 * taw);
+            floor.makeSpare(t);
+
+            if (args != null && args.length > 0) {
+                File f = new File(args[0]);
+                DiskContestSource source = new DiskContestSource(f);
+                IContest contest2 = source.getContest();
+                source.waitForContest(10000);
+                IProblem[] problems = contest2.getProblems();
+
+                double bx = center - problems.length + 1;
+                for (int i = 0; i < problems.length; i++)
+                    floor.createBalloon(problems[i].getId(), bx + i * 2, y - taw * 7.5);
+
+                floor.write(f);
+            }
+
+            long time = System.currentTimeMillis();
+            ITeam t1 = floor.getTeam(10);
+            ITeam t2 = floor.getTeam(47);
+            ITeam t3 = floor.getTeam(11);
+            Path path1 = floor.getPath(t1, t2);
+            Path path2 = floor.getPath(t3, p);
+
+            Trace.trace(Trace.USER, "Time: " + (System.currentTimeMillis() - time));
+
+            show(floor, 11, true, path1, path2);
+            // show(floor, 57, true, null, null);
+            // show(floor, 57, true);
+        } catch (Exception e) {
+            Trace.trace(Trace.ERROR, "Error generating floor map", e);
+        }
+    }
+}

--- a/PresAdmin/PresAdmin.iml
+++ b/PresAdmin/PresAdmin.iml
@@ -18,5 +18,32 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -12,6 +12,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
@@ -20,6 +21,7 @@ import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
+import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.NetworkUtil;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ClientLauncher;
@@ -73,6 +75,15 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 
 	@Override
 	public void init() {
+		IContest myContest = getContest();
+		for (int i = 0; i < 12 && myContest!=null; i++) {
+            try {
+                TimeUnit.SECONDS.sleep(5);
+				myContest = getContest();
+            } catch (InterruptedException e) {
+				// TODO: we delay here as p100 fails
+            }
+        }
 		setTeam(TeamUtil.getTeamId(getContest()), TeamUtil.getTeamMember());
 	}
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -12,7 +12,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.util.concurrent.TimeUnit;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
@@ -21,7 +20,6 @@ import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
-import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.NetworkUtil;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ClientLauncher;
@@ -75,15 +73,6 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 
 	@Override
 	public void init() {
-		IContest myContest = getContest();
-		for (int i = 0; i < 12 && myContest!=null; i++) {
-            try {
-                TimeUnit.SECONDS.sleep(5);
-				myContest = getContest();
-            } catch (InterruptedException e) {
-				// TODO: we delay here as p100 fails
-            }
-        }
 		setTeam(TeamUtil.getTeamId(getContest()), TeamUtil.getTeamMember());
 	}
 

--- a/ProblemSet/ProblemSet.iml
+++ b/ProblemSet/ProblemSet.iml
@@ -26,5 +26,32 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/Resolver/Resolver.iml
+++ b/Resolver/Resolver.iml
@@ -19,5 +19,32 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>


### PR DESCRIPTION
This should fix the the `/organizations/id/logo.{svg,png}` issue. Only opening this to make sure no one else works on this in parallel. Did not test with the presentation client yet if it works out of the box.

- The URLs are resolvable and provide the right file.
- The warning about the re-used URL would run on every check for directory changes. This is a bit verbose as this shouldn't happen in practice I think a bit of verbosity is less of an issue (although ugly).
- There is a remark that the current code wouldn't handle a similar case, I'm not sure if its besides similar really this case so I left the `TODO` for now.
- I suspect the `ext` can be added in a better way, this was the result of a long flight of debugging (and not much changes in the end) but a second pass will be needed.