### PR TITLE
P100 boots presentation too fast

### DIFF
--- a/BalloonUtility/BalloonUtility.iml
+++ b/BalloonUtility/BalloonUtility.iml
@@ -12,6 +12,16 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
+          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
           <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-aarch64.jar!/" />
         </CLASSES>
         <JAVADOC />
@@ -21,11 +31,28 @@
     <orderEntry type="module-library">
       <library>
         <CLASSES>
-          <root url="file://$MODULE_DIR$/../ContestModel/lib" />
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
         </CLASSES>
         <JAVADOC />
         <SOURCES />
-        <jarDirectory url="file://$MODULE_DIR$/../ContestModel/lib" recursive="false" />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
       </library>
     </orderEntry>
   </component>

--- a/PresAdmin/PresAdmin.iml
+++ b/PresAdmin/PresAdmin.iml
@@ -18,5 +18,32 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -12,6 +12,7 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.FloorMap;
@@ -20,6 +21,7 @@ import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
+import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.NetworkUtil;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ClientLauncher;
@@ -73,6 +75,15 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 
 	@Override
 	public void init() {
+		IContest myContest = getContest();
+		for (int i = 0; i < 12 && myContest!=null; i++) {
+            try {
+                TimeUnit.SECONDS.sleep(5);
+				myContest = getContest();
+            } catch (InterruptedException e) {
+				// TODO: we delay here as p100 fails
+            }
+        }
 		setTeam(TeamUtil.getTeamId(getContest()), TeamUtil.getTeamMember());
 	}
 

--- a/ProblemSet/ProblemSet.iml
+++ b/ProblemSet/ProblemSet.iml
@@ -26,5 +26,32 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/Resolver/Resolver.iml
+++ b/Resolver/Resolver.iml
@@ -19,5 +19,32 @@
         <SOURCES />
       </library>
     </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-win32-win32-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-gtk-linux-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../SWTLauncher/lib/swt-cocoa-macosx-x86_64.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>


### PR DESCRIPTION
When machines are rebooted after contest the tmp gets lost, we tried storing the temp between reboots but this yields other problems. When observing the log we see that the teamid is correctly found but the floor map data is not available yet (which we need) and the `contestfeed done` log entry is only given later. So we think we're too fast starting the presentation while startup is not done yet.

The other fix is to restart the presentation with the admin (which was the Luxor solution) but this might be a temporary fix.