### PR TITLE
fix: removeFromHistory

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestData.java
@@ -332,8 +332,6 @@ public class ContestData implements Iterable<IContestObject> {
 			IContestObject obj2 = objs[num][arr];
 			if (obj2 != null && rtc[obj2.getType().ordinal()].contains(obj2.getId())) {
 				objs[num][arr] = null;
-				if (!keepHistory)
-					break;
 			}
 		}
 


### PR DESCRIPTION
Always null out entries in the main array

Otherwise, the resolver will only remove the first object when removing multiple objects.

So there will be almost nothing removed by `removeHiddenTeams` and `removeSubmissionsOutsideOfContestTime`.

https://github.com/icpctools/icpctools/blob/4cff5734e0d7fdbba78fdd94dd29d14fbd8bc6e8/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java#L845-L850

Example [event-feed.json](https://github.com/user-attachments/files/20482673/event-feed.json)

Hidden team makes some submissions. In the resolver logic filter, the team is removed from the history, but some submissions are not.

In the given small event-feed, it will output an error before launch resolver UI, but in a larger event-feed, it will flood the terminal.

```
Invalid submission: submissions
  id: 10688
  problem_id: genshin-impact-trading
  team_id: domjudge
  language_id: cpp
  files: File Reference List [1]
  contest_time: 3:02:28.223
  time: 2024-11-10T12:02:28.223+08:00
```
![demo](https://github.com/user-attachments/assets/e63164ea-fe67-4ae9-949e-425274e2004e)

