### PR TITLE
Update Eclipse support from NAC

### DIFF
--- a/ContestModel/.classpath
+++ b/ContestModel/.classpath
@@ -19,5 +19,6 @@
 	<classpathentry exported="true" kind="lib" path="lib/xml-apis-ext-1.3.04.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/xmlgraphics-commons-2.9.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/batik-all-1.17.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/sentry-opentelemetry-agent-8.12.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/AnalystContest.java
@@ -2,10 +2,8 @@ package org.icpc.tools.contest.model.internal.account;
 
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContestObject;
-import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IPerson;
-import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.internal.Person;
 


### PR DESCRIPTION
Two changes from NAC 'break' the Eclipse support: Sentry jar is not added to the classpath, and there are now unused imports. This just cleans these issues up.