### PR TITLE
Request wider logos in balloon printout

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonPrinter.java
@@ -304,7 +304,7 @@ public class BalloonPrinter {
 		try {
 			IOrganization org = c.getOrganizationById(team.getOrganizationId());
 			if (org != null) {
-				BufferedImage logo = org.getLogoImage(fm.getHeight(), fm.getHeight(), true, true);
+				BufferedImage logo = org.getLogoImage(fm.getHeight() * 2, fm.getHeight(), true, true);
 				int h = fm.getHeight();
 				int w = (logo.getWidth() * h) / logo.getHeight();
 				g.drawImage(logo, px + gap, 0, w, h, null);


### PR DESCRIPTION
Organization logos are supposed to be 'square-ish', but when they are more horizontal they don't look great in the balloon printouts because we don't give them any more space. We don't want to give these logos too much additional real-estate or squeeze the title either, so this just bumps the width to 2x height.

Fixes #1124.