### PR TITLE
Upgrade ubuntu from 20.04 to 22.04

### DIFF
--- a/build/cds/Docker/Dockerfile
+++ b/build/cds/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:focal
+FROM ubuntu:jammy
 
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL org.opencontainers.image.description="ICPC Tools Contest Data Server"


### PR DESCRIPTION
Ubuntu 20.04 has been EOL since May 2025. This commit upgrades the Ubuntu version to prevent CI from failing.