### PR TITLE
Fix dependencies and simplify batch scripts

### DIFF
--- a/BalloonUtility/scripts/balloon.bat
+++ b/BalloonUtility/scripts/balloon.bat
@@ -22,7 +22,7 @@ robocopy "%ROOTDIR%\update" "%ROOTDIR%\" /e /move
 
 :restart
 
-java -jar "%LIBDIR%\swtLauncher.jar" balloonUtil.jar org.icpc.tools.balloon.BalloonUtility %params%
+java -cp "%LIBDIR%\*" org.icpc.tools.balloon.BalloonUtility %params%
 
 if errorlevel 255 goto :restart
 if errorlevel 254 goto :update

--- a/BalloonUtility/scripts/balloon.sh
+++ b/BalloonUtility/scripts/balloon.sh
@@ -18,7 +18,7 @@ LC_ALL=$LC_PAPER
 fi
 
 while true; do
-  java $vmoptions -jar lib/swtLauncher.jar balloonUtil.jar org.icpc.tools.balloon.BalloonUtility "$@"
+  java $vmoptions -cp "lib/*" org.icpc.tools.balloon.BalloonUtility "$@"
   result=$?
   if [ $result = 254 ]
   then

--- a/CDS/.settings/org.eclipse.wst.common.component
+++ b/CDS/.settings/org.eclipse.wst.common.component
@@ -8,6 +8,9 @@
         <dependent-module archiveName="snakeyaml-2.4.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/ContestModel/lib/snakeyaml-2.4.jar">
             <dependency-type>uses</dependency-type>
         </dependent-module>
+        <dependent-module archiveName="sentry-opentelemetry-agent-8.12.0.jar" deploy-path="/WEB-INF/lib" handle="module:/classpath/lib/ContestModel/lib/sentry-opentelemetry-agent-8.12.0.jar">
+            <dependency-type>uses</dependency-type>
+        </dependent-module>
         <property name="java-output-path" value="/CDS/WebContent/WEB-INF/classes"/>
         <property name="context-root" value="CDS"/>
     </wb-module>

--- a/ContestModel/src/META-INF/MANIFEST.MF
+++ b/ContestModel/src/META-INF/MANIFEST.MF
@@ -1,2 +1,2 @@
 Manifest-Version: 1.0
-Class-Path: snakeyaml-2.3.jar
+Class-Path: snakeyaml-2.4.jar

--- a/ProblemSet/scripts/problemSet.bat
+++ b/ProblemSet/scripts/problemSet.bat
@@ -15,4 +15,4 @@ goto :loop
 
 :continue
 
-java -jar "%LIBDIR%\swtLauncher.jar" problemSet.jar,snakeyaml-2.3.jar org.icpc.tools.contest.util.problemset.ProblemSetEditor %params% 
+java -cp "%LIBDIR%\*" org.icpc.tools.contest.util.problemset.ProblemSetEditor %params% 

--- a/ProblemSet/scripts/problemSet.sh
+++ b/ProblemSet/scripts/problemSet.sh
@@ -12,4 +12,4 @@ if [ "$UNAME" == "Darwin" ]; then
    vmoptions=-XstartOnFirstThread
 fi
 
-java $vmoptions -jar "$LIBDIR/swtLauncher.jar" problemSet.jar,snakeyaml-2.3.jar org.icpc.tools.contest.util.problemset.ProblemSetEditor "$@"
+java $vmoptions -cp "$LIBDIR/*" org.icpc.tools.contest.util.problemset.ProblemSetEditor "$@"

--- a/Resolver/scripts/awards.bat
+++ b/Resolver/scripts/awards.bat
@@ -15,4 +15,4 @@ goto :loop
 
 :continue
 
-java -jar "%LIBDIR%\swtLauncher.jar" resolver.jar org.icpc.tools.resolver.awards.Awards %params%
+java -cp "%LIBDIR%\*" org.icpc.tools.resolver.awards.Awards %params%

--- a/Resolver/scripts/awards.sh
+++ b/Resolver/scripts/awards.sh
@@ -12,4 +12,4 @@ if [ "$UNAME" == "Darwin" ]; then
    vmoptions=-XstartOnFirstThread
 fi
 
-java $vmoptions -jar "$LIBDIR/swtLauncher.jar" resolver.jar org.icpc.tools.resolver.awards.Awards "$@"
+java $vmoptions -cp "$LIBDIR/*" org.icpc.tools.resolver.awards.Awards "$@"


### PR DESCRIPTION
When trying to test things on my new machine I found the CDS wouldn't start due to missing sentry library, and two cases where new snakeyaml hadn't been updated.

Most of our batch files use -cp, but these ones used -jar. Switching them over for consistency, and so that we don't to maintain the ones that have versions in the jar name.