### PR TITLE
Move SVG utility to it's own class

### DIFF
--- a/ContestModel/.classpath
+++ b/ContestModel/.classpath
@@ -16,9 +16,9 @@
 			<attribute name="org.eclipse.jst.component.dependency" value="../"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry exported="true" kind="lib" path="lib/xml-apis-ext-1.3.04.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/xmlgraphics-commons-2.11.jar"/>
-	<classpathentry exported="true" kind="lib" path="lib/batik-all-1.19.jar"/>
+	<classpathentry kind="lib" path="lib/xml-apis-ext-1.3.04.jar"/>
+	<classpathentry kind="lib" path="lib/xmlgraphics-commons-2.11.jar"/>
+	<classpathentry kind="lib" path="lib/batik-all-1.19.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/sentry-opentelemetry-agent-8.12.0.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/SVGUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/SVGUtil.java
@@ -1,0 +1,84 @@
+package org.icpc.tools.contest.model.internal;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.InputStream;
+
+import org.apache.batik.anim.dom.SAXSVGDocumentFactory;
+import org.apache.batik.transcoder.SVGAbstractTranscoder;
+import org.apache.batik.transcoder.TranscoderInput;
+import org.apache.batik.transcoder.TranscoderOutput;
+import org.apache.batik.transcoder.image.ImageTranscoder;
+import org.apache.batik.util.XMLResourceDescriptor;
+import org.icpc.tools.contest.Trace;
+import org.w3c.dom.svg.SVGDocument;
+
+public class SVGUtil {
+	private static class BufferedImageTranscoder extends ImageTranscoder {
+		private BufferedImage img = null;
+
+		@Override
+		public BufferedImage createImage(int w, int h) {
+			return new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+		}
+
+		@Override
+		public void writeImage(BufferedImage img2, TranscoderOutput output) {
+			this.img = img2;
+		}
+
+		public BufferedImage getBufferedImage() {
+			return img;
+		}
+	}
+
+	private SVGUtil() {
+		// use static methods
+	}
+
+	public static SVGDocument loadSVG(File svgFile) throws Exception {
+		String parser = XMLResourceDescriptor.getXMLParserClassName();
+		SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
+		return factory.createSVGDocument(svgFile.getAbsolutePath());
+	}
+
+	public static SVGDocument loadSVG(String svgFile, InputStream in) throws Exception {
+		String parser = XMLResourceDescriptor.getXMLParserClassName();
+		SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
+		return factory.createSVGDocument(svgFile, in);
+	}
+
+	public static BufferedImage convertSVG(SVGDocument svg, int width, int height) {
+		try {
+			String ws;
+			String hs;
+			String viewBox = svg.getDocumentElement().getAttribute("viewBox");
+			String[] viewBoxValues = viewBox.split(" ");
+			if (viewBoxValues.length == 4) {
+				ws = viewBoxValues[2];
+				hs = viewBoxValues[3];
+			} else {
+				ws = svg.getDocumentElement().getAttribute("width");
+				hs = svg.getDocumentElement().getAttribute("height");
+				if (ws.isBlank() || hs.isBlank())
+					return null;
+			}
+
+			float w = Float.parseFloat(ws);
+			float h = Float.parseFloat(hs);
+			float scale = Math.min(width / w, height / h);
+
+			BufferedImageTranscoder imageTranscoder = new BufferedImageTranscoder();
+			imageTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_WIDTH, w * scale);
+			imageTranscoder.addTranscodingHint(SVGAbstractTranscoder.KEY_HEIGHT, h * scale);
+
+			TranscoderInput input = new TranscoderInput(svg);
+			imageTranscoder.transcode(input, null);
+
+			return imageTranscoder.getBufferedImage();
+		} catch (Exception e) {
+			Trace.trace(Trace.ERROR, "Invalid SVG", e);
+			return null;
+		}
+	}
+}

--- a/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/ImagesGenerator.java
@@ -35,7 +35,8 @@ import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.DiskContestSource;
 import org.icpc.tools.contest.model.internal.Contest;
-import org.icpc.tools.contest.model.internal.ContestObject;
+import org.icpc.tools.contest.model.internal.SVGUtil;
+import org.w3c.dom.svg.SVGDocument;
 
 /**
  * Helps convert logos and other images from raw source (from the CMS export or hand-built contest
@@ -391,7 +392,7 @@ public class ImagesGenerator {
 		for (File ff : files) {
 			// skip generated files
 			Matcher matcher = pattern.matcher(ff.getName());
-			if(!matcher.find()) {
+			if (!matcher.find()) {
 				return ff;
 			}
 		}
@@ -458,9 +459,11 @@ public class ImagesGenerator {
 
 					BufferedImage img;
 					if (imgFile.getName().endsWith(".svg")) {
-						img = ContestObject.readSVG2BufferedImage(imgFile);
+						SVGDocument svg = SVGUtil.loadSVG(imgFile);
+						// convert to 4k image, no need for more at the moment
+						img = SVGUtil.convertSVG(svg, 3840, 1920);
 						if (img == null)
-							Trace.trace(Trace.ERROR, "Warning: couldn't resize SVG: " + imgFile.getAbsolutePath());
+							Trace.trace(Trace.ERROR, "Warning: couldn't read SVG: " + imgFile.getAbsolutePath());
 					} else {
 						img = ImageIO.read(imgFile);
 					}
@@ -638,7 +641,7 @@ public class ImagesGenerator {
 			warn++;
 		}
 
-		if (checkForBadRatio(img))  {
+		if (checkForBadRatio(img)) {
 			warn(name, "bad aspect ratio (" + img.getWidth() + "x" + img.getHeight() + ")");
 			warn++;
 		}
@@ -904,14 +907,14 @@ public class ImagesGenerator {
 					s[3] = "X";
 				} else {
 					s[3] = "";
-					BufferedImage logo = ImageIO.read(org.getLogo().first().file);
-					if (checkForTransparency(logo)) {
+					BufferedImage logo2 = ImageIO.read(org.getLogo().first().file);
+					if (checkForTransparency(logo2)) {
 						s[3] += "T";
 					}
-					if (checkForSmallSize(logo)) {
+					if (checkForSmallSize(logo2)) {
 						s[3] += "S";
 					}
-					if (checkForBadRatio(logo)) {
+					if (checkForBadRatio(logo2)) {
 						s[3] += "R";
 					}
 					if (s[3].isEmpty()) {


### PR DESCRIPTION
We had 3 places reading/converting SVGs, with multiple copies of the image transcoder and parsing w/h info. This moves it all to a shared SVGUtil class with only 2 public functions: loading SVGs (2 versions) and converting to BufferedImages.

Since all the work is now done in the model jar the batik jar and its dependencies no longer need to be exported.

Some minor formatting and variable overriding cleanup was automatically applied to the image generator.