### PR TITLE
Reduce CDS console output

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -307,10 +307,13 @@ public class ConfiguredContest {
 		// but by then some data could be accessible to clients
 		if (id == null && path != null) {
 			try {
-				Info info = YamlParser.importContestInfo(new File(path, "contest.yaml"), false);
-				id = info.getId();
+				File f = new File(path, "contest.yaml");
+				if (f.exists()) {
+					Info info = YamlParser.importContestInfo(f, false);
+					id = info.getId();
+				}
 			} catch (Exception ex) {
-				Trace.trace(Trace.ERROR, "Could not read default contest id from contest yaml", ex);
+				Trace.trace(Trace.WARNING, "Could not read default contest id from contest yaml", ex);
 			}
 		}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -1034,8 +1034,8 @@ public class DiskContestSource extends ContestSource {
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Scanning failed", e);
 		}
-		Trace.trace(Trace.INFO, "Finished scanning " + this.contestId + " for changed resources in "
-				+ (System.currentTimeMillis() - time) + "ms");
+		Trace.trace(Trace.INFO,
+				"Scanned " + this.contestId + " for changes in " + (System.currentTimeMillis() - time) + "ms");
 	}
 
 	@Override


### PR DESCRIPTION
These are pretty minor, but we output an error on startup if there is no specified id and no contest.yaml (and hence we have to use the path to default the id instead). This isn't really an error, so check if the file exists before trying, and reduce it to warning.

I've also reduced:
  Finished scanning astana for changed resources in 94ms
to:
  Scanned astana for changes in 94ms
just to reduce the constant output a little bit.