### PR TITLE
Streaming, and resolved file ref should (only) be file

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContestObject.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.contest.model;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
@@ -126,7 +127,7 @@ public interface IContestObject {
 	 */
 	List<String> validate(IContest contest);
 
-	default Object resolveFileReference(String url) {
+	default File resolveFileReference(String url) {
 		return null;
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
@@ -1,5 +1,6 @@
 package org.icpc.tools.contest.model.internal;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -81,13 +82,11 @@ public class FileReferenceList implements Iterable<FileReference> {
 		return refs.iterator();
 	}
 
-	public Object resolve(String url) {
+	public File resolve(String url) {
 		for (FileReference ref : refs) {
 			if (ref.getURL().endsWith(url)) {
 				if (ref.file != null && ref.file.exists())
 					return ref.file;
-
-				return ref.data;
 			}
 		}
 		return null;
@@ -111,12 +110,12 @@ public class FileReferenceList implements Iterable<FileReference> {
 		return s;
 	}
 
-	public static Object resolve(String url, FileReferenceList... lists) {
+	public static File resolve(String url, FileReferenceList... lists) {
 		for (FileReferenceList list : lists) {
 			if (list != null) {
-				Object obj = list.resolve(url);
-				if (obj != null)
-					return obj;
+				File f = list.resolve(url);
+				if (f != null)
+					return f;
 			}
 		}
 		return null;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -81,7 +81,7 @@ public class Group extends ContestObject implements IGroup {
 	}
 
 	@Override
-	public Object resolveFileReference(String url2) {
+	public File resolveFileReference(String url2) {
 		return FileReferenceList.resolve(url2, logo);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -220,7 +220,7 @@ public class Info extends ContestObject implements IInfo {
 	}
 
 	@Override
-	public Object resolveFileReference(String url) {
+	public File resolveFileReference(String url) {
 		return FileReferenceList.resolve(url, logo, banner);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -160,7 +160,7 @@ public class Organization extends ContestObject implements IOrganization {
 	}
 
 	@Override
-	public Object resolveFileReference(String url2) {
+	public File resolveFileReference(String url2) {
 		return FileReferenceList.resolve(url2, logo, countryFlag);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -122,7 +122,7 @@ public class Person extends ContestObject implements IPerson {
 	}
 
 	@Override
-	public Object resolveFileReference(String url) {
+	public File resolveFileReference(String url) {
 		return FileReferenceList.resolve(url, photo);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -350,7 +350,7 @@ public class Problem extends ContestObject implements IProblem {
 	}
 
 	@Override
-	public Object resolveFileReference(String url2) {
+	public File resolveFileReference(String url2) {
 		return FileReferenceList.resolve(url2, statement, package_);
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -97,7 +97,7 @@ public class Submission extends TimedEvent implements ISubmission {
 	}
 
 	@Override
-	public Object resolveFileReference(String url) {
+	public File resolveFileReference(String url) {
 		return FileReferenceList.resolve(url, files, reaction);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -296,7 +296,7 @@ public class Team extends ContestObject implements ITeam {
 	}
 
 	@Override
-	public Object resolveFileReference(String url) {
+	public File resolveFileReference(String url) {
 		return FileReferenceList.resolve(url, photo, video, backup, desktop, webcam, audio, keylog, tooldata);
 	}
 


### PR DESCRIPTION
Found this while working on #1133.

When resolving a file reference, the only possible type should be file, not the data (contents) of the file. The original choice of Object was to allow submission reactions to be streamed before the reaction video was done recording, but this path was changed years ago and the current streaming code (sending reactions while they were still being recorded) wasn't even working (and didn't support multiple streams).

This fixes the reaction streaming in ContestRESTService (moving it to a common helper on HttpHelper) and then correctly types all resolved file to File to improve typing/readability.