### PR TITLE
Use soft references for file reference data

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -2,6 +2,7 @@ package org.icpc.tools.contest.model.internal;
 
 import java.awt.image.BufferedImage;
 import java.io.File;
+import java.lang.ref.SoftReference;
 import java.text.ParseException;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -439,13 +440,13 @@ public abstract class ContestObject implements IContestObject {
 		if (ref == null)
 			return null;
 
-		if (ref.data != null)
-			data = ref.data;
+		if (ref.data != null && ref.data.get() != null)
+			data = ref.data.get();
 		else if (forceLoad) {
 			data = loadImage(getFile(ref, property, true));
 			if (data == null)
 				data = MISSING_IMAGE;
-			ref.data = data;
+			ref.data = new SoftReference<Object>(data);
 		}
 
 		if (data == MISSING_IMAGE)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
@@ -1,6 +1,7 @@
 package org.icpc.tools.contest.model.internal;
 
 import java.io.File;
+import java.lang.ref.SoftReference;
 
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 
@@ -13,7 +14,7 @@ public class FileReference {
 	public String etag;
 	public int width = -1;
 	public int height = -1;
-	public Object data;
+	public SoftReference<Object> data;
 
 	public FileReference() {
 		// do nothing


### PR DESCRIPTION
Use soft references to hold on to file data loaded from file references. This should allow images that are loaded to be cached as long as possible, but freed if available memory gets low.

Pros: If you have lots of huge logos, they should be loaded, scaled down, and only the scaled versions used; the originals will be kept in memory in case we need other resolutions, but thrown out if memory gets low. Memory use will be much better when images are only used once / at one resolution.

Cons: If we have presentations that use different resolutions of an image in sequence, there will be less caching and initial (re)load for each presentation will be slower.

I tested with a similar change several years ago and the results weren't great: especially on HDDs the performance of loading images was slow and files weren't huge so the best tradeoff for smooth UI was almost always 'just use a bit more memory'. With faster SSDs and CPU but photos often > 4k the balance seems to have shifted: with this change I see images being reloaded that would have been cached before, but memory use is more consistent / less spikes, and the cache doesn't grow indefinitely (until all file references have been loaded - which is potentially a lot).

Should help with #1133 and avoid related out of memory errors.