### PR TITLE
Fix aspect ratio

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -53,7 +53,7 @@
 <th class="text-center"><span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span></th>
 </script>
 <script type="text/html" id="row-start">
-  <td class="text-right">{{rank}}</td><td class="text-center"><img src="{{logo}}" class="scoreboard_logo"/></td><td>{{team}}</td>
+  <td class="text-right">{{rank}}</td><td class="text-center logo_table_cell"><div class="boundary_scoreboard_logo"><img src="{{logo}}" class="scoreboard_logo"/></div></td><td>{{team}}</td>
 </script>
 <script type="text/html" id="row-end">
   <td class="text-right">{{numSolved}}</td><td class="text-right">{{totalTime}}</td>

--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -53,7 +53,7 @@
 <th class="text-center"><span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span></th>
 </script>
 <script type="text/html" id="row-start">
-  <td class="text-right">{{rank}}</td><td class="text-center"><img src="{{logo}}" width="20" height="20"/></td><td>{{team}}</td>
+  <td class="text-right">{{rank}}</td><td class="text-center"><img src="{{logo}}" class="scoreboard_logo"/></td><td>{{team}}</td>
 </script>
 <script type="text/html" id="row-end">
   <td class="text-right">{{numSolved}}</td><td class="text-right">{{totalTime}}</td>

--- a/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/scoreboard.jsp
@@ -41,7 +41,7 @@
 <script src="${pageContext.request.contextPath}/js/types.js"></script>
 <script src="${pageContext.request.contextPath}/js/mustache.min.js"></script>
 <script type="text/html" id="header-start">
-  <th class="text-right">Rank</th><th></th><th>Team</th>
+  <th class="text-right">Rank</th><th class="logo_table_header"></th><th>Team</th>
 </script>
 <script type="text/html" id="header-end">
   <th class="text-right">Solved</th><th class="text-right">Time</th>

--- a/CDS/WebContent/css/cds.css
+++ b/CDS/WebContent/css/cds.css
@@ -34,6 +34,10 @@ body.dark-mode .table-warning {
 }
 
 .scoreboard_logo {
-    height: var(--logo-size);
-    width: var(--logo-size);
+    max-height: var(--logo-size);
+    max-width: var(--logo-size);
+}
+
+.logo_table_header {
+    width: var(--logo-size)
 }

--- a/CDS/WebContent/css/cds.css
+++ b/CDS/WebContent/css/cds.css
@@ -41,3 +41,20 @@ body.dark-mode .table-warning {
 .logo_table_header {
     width: var(--logo-size)
 }
+
+.logo_table_cell {
+    position: relative;
+}
+
+.boundary_scoreboard_logo {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: var(--logo-size)
+}

--- a/CDS/WebContent/css/cds.css
+++ b/CDS/WebContent/css/cds.css
@@ -28,3 +28,12 @@ body.dark-mode .table-danger {
 body.dark-mode .table-warning {
     background-color: #f39c12 !important;
 }
+
+:root {
+    --logo-size: 20px;
+}
+
+.scoreboard_logo {
+    height: var(--logo-size);
+    width: var(--logo-size);
+}

--- a/CDS/WebContent/js/model.js
+++ b/CDS/WebContent/js/model.js
@@ -46,7 +46,7 @@ function bestSquareLogo(logos, size) {
       continue;
     if (best == null)
       best = ref;
-    else if (best != null) {
+    else {
       if (best.width < size && best.height < size) {
         // current best image is too small - is this one better (larger than current)?
         if (ref.width > best.width || ref.height > best.height)

--- a/ContestUtil/ContestUtil.iml
+++ b/ContestUtil/ContestUtil.iml
@@ -8,5 +8,20 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="ContestModel" />
+    <orderEntry type="module-library">
+      <library>
+        <CLASSES>
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/snakeyaml-2.4.jar!/" />
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/batik-all-1.19.jar!/" />
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/qrcodegen-1.8.0.jar!/" />
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/xml-apis-1.4.01.jar!/" />
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/xml-apis-ext-1.3.04.jar!/" />
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/xmlgraphics-commons-2.11.jar!/" />
+          <root url="jar://$MODULE_DIR$/../ContestModel/lib/sentry-opentelemetry-agent-8.12.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>


### PR DESCRIPTION
In case someone provides logo's which are far from squarish the aspect ratio gets lost as the logo is stretched. As I'm not 100% how far we want to go we should just pick the right commits and squash those as the solution.

commit: Move image size to CSS (shows the problem):
<img width="232" height="331" alt="image" src="https://github.com/user-attachments/assets/0a1e723a-7dee-4827-93d0-ab9c37cea30e" />


commit: Keep original aspect ratio
<img width="232" height="331" alt="image" src="https://github.com/user-attachments/assets/a782960f-95d3-41d6-bfaf-ce40e8238da9" />


commit: Center the logo over the cell
<img width="264" height="417" alt="image" src="https://github.com/user-attachments/assets/91f4e8fa-6c60-4474-8493-9f1abb182391" />
For the last one I think it only works when all cells get centered like this. Maybe there should just be a maximum on the lenght of the display name of the team to get a more consistent scoreboard.
