### PR TITLE
Remove extraneous photo property

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -85,8 +85,8 @@ public class DiskContestSource extends ContestSource {
 	private Validation configValidation = new Validation();
 	private Map<String, List<FileReference>> cache = new HashMap<>();
 
-	private static Team defaultTeam = new Team();
-	private static Person defaultPerson = new Person();
+	private Team defaultTeam = new Team();
+	private Person defaultPerson = new Person();
 
 	static class FilePattern {
 		// the folder containing the file
@@ -183,8 +183,12 @@ public class DiskContestSource extends ContestSource {
 
 		cleanUpTempDir();
 
-		defaultTeam.setPhoto(getDefaultFilesWithPattern(defaultTeam, PHOTO));
-		defaultPerson.setPhoto(getDefaultFilesWithPattern(defaultPerson, PHOTO));
+		FileReferenceList list = getDefaultFilesWithPattern(defaultTeam, PHOTO);
+		if (list != null && !list.isEmpty())
+			defaultTeam.setPhoto(list);
+		list = getDefaultFilesWithPattern(defaultPerson, PHOTO);
+		if (list != null && !list.isEmpty())
+			defaultPerson.setPhoto(list);
 
 		instance = this;
 	}
@@ -1210,6 +1214,9 @@ public class DiskContestSource extends ContestSource {
 	 */
 	private static FileReferenceList mergeRefs(FileReferenceList curList, FileReferenceList localList,
 			FileReferenceList defaultList) {
+		if (defaultList == null || defaultList.isEmpty())
+			return mergeRefs(curList, localList);
+
 		FileReferenceList list = mergeRefs(curList, localList);
 		if (curList == defaultList)
 			list = localList;


### PR DESCRIPTION
While testing the Baku data I noticed that all teams and persons had a photo property '"photo": []' even when they didn't have any photo. This shouldn't hurt anything, but it's an extraneous/unnecessary property (minor memory/http overhead) so I was curious.

The support for default (backup) photos shouldn't be static (it's per-contest) and was always setting the photo property even when there was no default photo (99% of the time). This change just adds some extra if statements to avoid setting the property and optimize for the typical case where it's not set.