### PR TITLE
Trace when server provides image with duplicate metadata

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -204,24 +204,15 @@ public class PlaybackContest extends Contest {
 		} else {
 			// more complex matching
 			// for now, only download new images that have a different width & height or mime type
-			// than
-			// local images
+			// than local images
 			for (FileReference sourceFile : sourceFiles) {
 				if (sourceFile.height <= 0 || sourceFile.width <= 0)
 					continue;
 
-				boolean found = false;
-				for (FileReference currentRef : localFiles) {
-					if (currentRef.height == sourceFile.height && currentRef.width == sourceFile.width
-							&& (currentRef.mime == null || currentRef.mime.equals(sourceFile.mime))) {
-						found = true;
-						continue;
-					}
-				}
-
 				try {
-					if (!found)
+					if (!localFiles.containsFile(sourceFile)) {
 						src.downloadFile(obj, sourceFile, property);
+					}
 				} catch (Exception e) {
 					Trace.trace(Trace.ERROR, "Error downloading file: " + obj.getType() + ": " + obj.getId(), e);
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -534,7 +534,7 @@ public class DiskContestSource extends ContestSource {
 		return list;
 	}
 
-	private List<FileReference> getCache(File folder) {
+	protected List<FileReference> getCache(File folder) {
 		List<FileReference> list = cache.get(folder.getAbsolutePath());
 		if (list != null)
 			return list;

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -44,6 +44,7 @@ import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.FileReference;
+import org.icpc.tools.contest.model.internal.FileReferenceList;
 
 /**
  * A REST contest source for loading a contest over HTTP. The contest may be backed by data in a
@@ -399,6 +400,14 @@ public class RESTContestSource extends DiskContestSource {
 		String size = nf.format(temp.length() / 1024.0);
 		sb.append(" (" + size + "kb in " + time + "ms)");
 		Trace.trace(Trace.INFO, sb.toString());
+
+		// check if the newly downloaded file matches an existing local one
+		// (this can only happen if the server had missing or incorrect file reference data)
+		FileReference newRef = readMetadata(temp);
+		FileReferenceList localFiles = new FileReferenceList(getCache(localFile.getParentFile()));
+		if (localFiles.containsFile(newRef)) {
+			Trace.trace(Trace.WARNING, href + " matches existing local file " + newRef);
+		}
 
 		if (!localFile.exists() || mod == 0 || localFile.lastModified() != mod) {
 			try {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReferenceList.java
@@ -121,6 +121,20 @@ public class FileReferenceList implements Iterable<FileReference> {
 		return null;
 	}
 
+	/**
+	 * Returns true if the source file matches a file in this list - i.e. has the same height,
+	 * width, and mime type.
+	 */
+	public boolean containsFile(FileReference sourceFile) {
+		for (FileReference ref : refs) {
+			if (ref.height == sourceFile.height && ref.width == sourceFile.width
+					&& (ref.mime == null || ref.mime.equals(sourceFile.mime))) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	@Override
 	public String toString() {
 		return "File Reference List [" + refs.size() + "]";


### PR DESCRIPTION
The CDS will repeatedly download 'duplicate' images if the Contest API server says the file is different than what the CDS determines it to be after downloading. For example, if the server says it has an image that's 50x50, the CDS downloads it, and reads it as 51x51, then the next time you restart we'll have a 51x51 image, see that the source has a 'different' one, and download it a second time. This will happen every time the CDS restarts, leading to many duplicate images.

The most obvious solution is to fix the bug in determining image size or file reference data in the CDS or the upstream server, but that takes time and is hard to track down, so this just starts by logging whenever this occurs to make it easier to track. In the future this code would make it easy to take the next step and delete the file after download, but I want to run it in a few contests before making that step. This change:

- Moves the logic of whether a file reference matches an existing one from PlaybackContest to FileReferenceList.
- Exposes the local file cache information from DiskContestSource.
- After downloading in RestContestSource, check if the file matches one we already have.

Most of #1125.