### PR TITLE
Set Eclipse project encoding

### DIFF
--- a/BalloonUtility/.settings/org.eclipse.core.resources.prefs
+++ b/BalloonUtility/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/CDS/.settings/org.eclipse.core.resources.prefs
+++ b/CDS/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/CoachView/.settings/org.eclipse.core.resources.prefs
+++ b/CoachView/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ContestModel/.settings/org.eclipse.core.resources.prefs
+++ b/ContestModel/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ContestUtil/.settings/org.eclipse.core.resources.prefs
+++ b/ContestUtil/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/PresAdmin/.settings/org.eclipse.core.resources.prefs
+++ b/PresAdmin/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/PresContest/.settings/org.eclipse.core.resources.prefs
+++ b/PresContest/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/PresCore/.settings/org.eclipse.core.resources.prefs
+++ b/PresCore/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/ProblemSet/.settings/org.eclipse.core.resources.prefs
+++ b/ProblemSet/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/Resolver/.settings/org.eclipse.core.resources.prefs
+++ b/Resolver/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/SWTLauncher/.settings/org.eclipse.core.resources.prefs
+++ b/SWTLauncher/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8


### PR DESCRIPTION
Recent Eclipse versions require you to explicitly set a project encoding instead of relying on the workspace default (which could be different on different machines). Annoying, but just applies the minimal .settings change.