### PR TITLE
Add submission score to team summary page

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -161,15 +161,20 @@
                                         IJudgementType jt = contest.getJudgementTypeById(j.getJudgementTypeId());
                                         if (jt != null) {
                                             judgeStr += jt.getName();
-                                            if (jt.isSolved())
+                                            if (jt.isSolved()) {
                                                 judgeClass = "table-success";
-                                            else if (jt.isPenalty())
+                                                
+                                                if (j.getScore() != null) {
+                                                	judgeStr += " " + ContestUtil.formatScore(j.getScore());
+                                                }
+                                            } else if (jt.isPenalty())
                                                 judgeClass = "table-danger";
                                         } else {
                                             judgeClass = "table-warning";
                                             judgeStr += "...";
                                         }
-                                        judgeStr += " (<a href=\"" + apiRoot + "/judgements/" + j.getId() + "\">" + j.getId() + "</a>) ";
+                                        judgeStr += " (<a href=\"" + apiRoot + "/judgements/" + j.getId() + "\">" + j.getId() + "</a>)";
+                                        
            /*IRun[] runs = contest.getRunsByJudgementId(j.getId());
            if (runs != null) {
               //judgeStr += runs.length;


### PR DESCRIPTION
Adds the score to the team summary submissions page to support scoring contests. The scoreboard row is still broken, but I found this minor initial change useful when debugging.