### PR TITLE
Update readmes to Java 17 minimum

### DIFF
--- a/BalloonUtility/README.md
+++ b/BalloonUtility/README.md
@@ -29,7 +29,7 @@ To install the Balloon Utility, download its distribution package from the [ICPC
 and unzip it to any convenient location. 
 The BU is a Java program. The distribution is a self-contained package which contains 
 all the Java libraries and other components necessary to run the Balloon Utility.
-(Note that Java, Version 11 or higher, must also be installed on the machine.)
+(Note that Java version 17 or higher must also be installed on the machine.)
 
 ### Execution
 

--- a/PresAdmin/README.md
+++ b/PresAdmin/README.md
@@ -83,7 +83,7 @@ and unzip it to any convenient location.
 The Presentation Admin itself is a collection of Java programs (components).
 The distribution is a self-contained package which contains 
 all the Java libraries and other components necessary to run the Presentation Admin
-(Java version 1.8 or higher must also be installed on the machine).
+(Java version 17 or higher must also be installed on the machine).
 
 ### Configuration
 

--- a/PresContest/README.md
+++ b/PresContest/README.md
@@ -69,8 +69,7 @@ distribution package to any convenient location.
 The Presentation Client itself is a collection of Java programs (components).
 The distribution is a self-contained package which contains 
 all the Java libraries and other components necessary to run the Presentation Client.
-(Note however that Java itself, version 1.8 or higher, must be installed on the
-machine.)
+(Note however that Java version 17 or higher must be installed on the machine.)
 
 ### Operation
 

--- a/Resolver/README.md
+++ b/Resolver/README.md
@@ -140,7 +140,7 @@ convenient location.
 The Resolver itself is a collection of Java programs (components).
 The distribution is a self-contained package which contains
 all the Java libraries and other components necessary to run the Resolver.
-(Note however, that Java Version 11 or higher must be installed on the machine.)
+(Note however, that Java version 17 or higher must be installed on the machine.)
 
 #### Operation
 
@@ -720,7 +720,7 @@ available from the [ICPCTools website](https://tools.icpc.global) for further in
 
 ### Additional Notes
 
-The Resolver and Award Generator tools are written in Java and will run on any platform supporting Java Version 11 or greater.
+The Resolver and Award Generator tools will run on any platform supporting Java.
 However, the Resolver makes heavy use of screen-level graphics and is therefore heavily dependent on the 
 graphics drivers on the platform.
 In our experience, Linux graphics drivers are substantially less robust than others;


### PR DESCRIPTION
We've required Java 17 for a while now, but missed updating these references. I made them consistent and removed one unnecessary reference to make them easier to find and update in the future.