### PR TITLE
Stop background scanning after removing contest

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -279,7 +279,7 @@ public class CDSConfig {
 					}
 				}
 				if (!stillInUse) {
-					Trace.trace(Trace.USER, "Removing " + oldHashes[i]);
+					Trace.trace(Trace.USER, "Removing " + oldContests[i].getId());
 					oldContests[i].close();
 				}
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import javax.imageio.ImageIO;
@@ -87,6 +88,8 @@ public class DiskContestSource extends ContestSource {
 
 	private Team defaultTeam = new Team();
 	private Person defaultPerson = new Person();
+
+	private ScheduledFuture<?> backgroundScanningTask;
 
 	static class FilePattern {
 		// the folder containing the file
@@ -851,7 +854,8 @@ public class DiskContestSource extends ContestSource {
 	}
 
 	public void setExecutor(ScheduledExecutorService executor) {
-		executor.scheduleWithFixedDelay(() -> scanForResourceChanges(), 15L, 15L, TimeUnit.SECONDS);
+		backgroundScanningTask = executor.scheduleWithFixedDelay(() -> scanForResourceChanges(), 15L, 15L,
+				TimeUnit.SECONDS);
 	}
 
 	private static boolean hasChange(FileReferenceList list, FileReferenceList foundList, List<File> changed) {
@@ -1046,6 +1050,9 @@ public class DiskContestSource extends ContestSource {
 	public void close() throws Exception {
 		if (parser != null)
 			parser.close();
+
+		if (backgroundScanningTask != null)
+			backgroundScanningTask.cancel(false);
 	}
 
 	/**


### PR DESCRIPTION
While testing I noticed that when I removed a contest from cdsConfig.xml it correctly disappeared from the web/API, but the background task was still periodically scanning for resource changes in the background.

This just keeps track of the background task and correctly cleans it up when the contest is closed.

I also improved the message so that when you remove a contest from the config it says "Removing baku" (the contest id) instead of "Removing 87384679265" (the internal hash).