### PR TITLE
Fix object casting error, NPE

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.text.NumberFormat;
 import java.util.Base64;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -404,7 +405,10 @@ public class RESTContestSource extends DiskContestSource {
 		// check if the newly downloaded file matches an existing local one
 		// (this can only happen if the server had missing or incorrect file reference data)
 		FileReference newRef = readMetadata(temp);
-		FileReferenceList localFiles = new FileReferenceList(getCache(localFile.getParentFile()));
+		List<FileReference> localCache = getCache(localFile.getParentFile());
+		FileReferenceList localFiles = new FileReferenceList();
+		for (FileReference ref : localCache)
+			localFiles.add(ref);
 		if (localFiles.containsFile(newRef)) {
 			Trace.trace(Trace.WARNING, href + " matches existing local file " + newRef);
 		}

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/TextHelper.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/TextHelper.java
@@ -427,6 +427,9 @@ public class TextHelper {
 	}
 
 	public void addString(String s, boolean outline) {
+		if (s == null)
+			return;
+
 		char[] c = s.toCharArray();
 
 		int fontBegin = -1;


### PR DESCRIPTION
The fix in #1152 fails in many cases due to a casting issue passing a list to FileReferenceList. Fixes that by adding the objects manually.

Also noticed an NPE when a team name is null. Won't happen in a real contest, but currently exists in baku data.