### PR TITLE
Increase counter when duplicate href is found

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -1107,6 +1107,7 @@ public class DiskContestSource extends ContestSource {
 						int count = 2;
 						while (hrefs.contains(ref.href)) {
 							ref.href = "contests/" + contestId + "/" + pattern.url + diff + count;
+							count += 1;
 						}
 						refList.add(ref);
 						hrefs.add(ref.href);


### PR DESCRIPTION
In the past we handled logo.{svg,png} but not logo.{svg,png,3xt}

I did not actually check, I just remembered I thought this was broken at NAC.