### PR TITLE
Experimental support for simplified judgement types

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IJudgementType.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IJudgementType.java
@@ -24,4 +24,11 @@ public interface IJudgementType extends IContestObject {
 	 * @return if this judgement represents a correct solution
 	 */
 	boolean isSolved();
+
+	/**
+	 * Returns the simplified judgement type id.
+	 *
+	 * @return the simplified judgement type id
+	 */
+	String getSimplifiedJudgementTypeId();
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/JudgementType.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/JudgementType.java
@@ -9,10 +9,12 @@ public class JudgementType extends ContestObject implements IJudgementType {
 	private static final String NAME = "name";
 	private static final String PENALTY = "penalty";
 	private static final String SOLVED = "solved";
+	private static final String SIMPLIFIED_JUDGEMENT_TYPE_ID = "simplified_judgement_type_id";
 
 	private String name;
 	private boolean penalty;
 	private boolean solved;
+	private String simplifiedJudgementTypeId;
 
 	@Override
 	public ContestType getType() {
@@ -35,6 +37,11 @@ public class JudgementType extends ContestObject implements IJudgementType {
 	}
 
 	@Override
+	public String getSimplifiedJudgementTypeId() {
+		return simplifiedJudgementTypeId;
+	}
+
+	@Override
 	protected boolean addImpl(String name2, Object value) throws Exception {
 		if (NAME.equals(name2)) {
 			name = (String) value;
@@ -44,6 +51,9 @@ public class JudgementType extends ContestObject implements IJudgementType {
 			return true;
 		} else if (SOLVED.equals(name2)) {
 			solved = parseBoolean(value);
+			return true;
+		} else if (SIMPLIFIED_JUDGEMENT_TYPE_ID.equals(name2)) {
+			simplifiedJudgementTypeId = (String) value;
 			return true;
 		}
 
@@ -56,6 +66,7 @@ public class JudgementType extends ContestObject implements IJudgementType {
 		props.addString(NAME, name);
 		props.add(PENALTY, penalty);
 		props.add(SOLVED, solved);
+		props.addLiteralString(SIMPLIFIED_JUDGEMENT_TYPE_ID, simplifiedJudgementTypeId);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -11,6 +11,7 @@ import org.icpc.tools.contest.model.IContestObject.ContestType;
 import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IJudgement;
+import org.icpc.tools.contest.model.IJudgementType;
 import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.IProblem;
@@ -344,6 +345,12 @@ public class PublicContest extends Contest implements IFilteredContest {
 	protected IJudgement filterJudgement(IJudgement jud) {
 		Judgement j = (Judgement) ((Judgement) jud).clone();
 		j.add("max_run_time", null);
+
+		// use simplified judgement type (if it exists)
+		IJudgementType jt = getJudgementTypeById(j.getJudgementTypeId());
+		if (jt != null && jt.getSimplifiedJudgementTypeId() != null) {
+			j.setJudgementTypeId(jt.getSimplifiedJudgementTypeId());
+		}
 		return j;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
@@ -7,6 +7,7 @@ import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
+import org.icpc.tools.contest.model.internal.Judgement;
 import org.icpc.tools.contest.model.internal.Problem;
 
 /**
@@ -81,6 +82,16 @@ public class SpectatorContest extends PublicContest {
 		Problem p = (Problem) ((Problem) problem).clone();
 		p.setPackage(null);
 		return p;
+	}
+
+	@Override
+	protected IJudgement filterJudgement(IJudgement jud) {
+		Judgement j = (Judgement) ((Judgement) jud).clone();
+		j.add("max_run_time", null);
+
+		// doesn't filter simplified judgement types
+
+		return j;
 	}
 
 	@Override


### PR DESCRIPTION
Adds a new optional property to judgement types, 'simplified_judgement_type_id'. If this is set, any judgements with this type are changed to the simplified judgement type for other teams or anyone who is unauthenticated. (i.e. you can see the detail on your judgements, but not for other teams)

To try this out, set up a contest with a bunch of submissions and judgements, and at least one team account. Create a judgement-types.json in the contest root by capturing the current output of /judgement-types (or just create the content manually). Then add the new property to some of the judgements, e.g.:

```json
  [{"id":"OLE","name":"output limit","penalty":true,"solved":false,"simplified_judgement_type_id":"FAIL"},
  {"id":"PE","name":"presentation error","penalty":true,"solved":false,"simplified_judgement_type_id":"FAIL"},
  {"id":"WA","name":"wrong answer","penalty":true,"solved":false,"simplified_judgement_type_id":"FAIL"}]
```

The id can point to one of the existing judgement types, or you can create a new one for this purpose, e.g.:

```json
  [{"id":"FAIL","name":"just plain wrong","penalty":true,"solved":false}]
```

I didn't do any optimization yet, this is just an PoC to see if this is where the Contest API should go.