### PR TITLE
Use URIs to load svgs

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/SVGUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/SVGUtil.java
@@ -39,7 +39,7 @@ public class SVGUtil {
 	public static SVGDocument loadSVG(File svgFile) throws Exception {
 		String parser = XMLResourceDescriptor.getXMLParserClassName();
 		SAXSVGDocumentFactory factory = new SAXSVGDocumentFactory(parser);
-		return factory.createSVGDocument(svgFile.getAbsolutePath());
+		return factory.createSVGDocument(svgFile.toURI().toString());
 	}
 
 	public static SVGDocument loadSVG(String svgFile, InputStream in) throws Exception {


### PR DESCRIPTION
When I started testing the WF laptops (Windows) I noticed that SVG logos were not loading... at all. They were working fine on other platforms though.

I eventually traced this down to Apache Batik using (file) URIs to load the image, but we were passing in a file path. The difference in file:// vs file:/// doesn't cause problems on other platforms, but of course is required on Windows.