### PR TITLE
Support for multiple teams and groups in clarification destinations

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -747,9 +747,20 @@ public class ConfiguredContest {
 			ITeam team = contest.getTeamById(clar.getFromTeamId());
 			if (contest.isTeamHidden(team))
 				return null;
-			team = contest.getTeamById(clar.getToTeamId());
-			if (contest.isTeamHidden(team))
-				return null;
+			if (clar.getToTeamIds() != null) {
+				for (String teamId : clar.getToTeamIds()) {
+					team = contest.getTeamById(teamId);
+					if (contest.isTeamHidden(team))
+						return null;
+				}
+			}
+			if (clar.getToGroupIds() != null) {
+				for (String groupId : clar.getToGroupIds()) {
+					IGroup group = contest.getGroupById(groupId);
+					if (group != null && group.isHidden())
+						return null;
+				}
+			}
 		}
 
 		return obj;

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -306,8 +306,19 @@ public class PlaybackContest extends Contest {
 				Clarification clar = (Clarification) obj;
 				if (clar.getFromTeamId() != null && getTeamById(clar.getFromTeamId()) == null)
 					return;
-				if (clar.getToTeamId() != null && getTeamById(clar.getToTeamId()) == null)
-					return;
+
+				if (clar.getToTeamIds() != null) {
+					for (String teamId : clar.getToTeamIds()) {
+						if (getTeamById(teamId) == null)
+							return;
+					}
+				}
+				if (clar.getToGroupIds() != null) {
+					for (String groupId : clar.getToGroupIds()) {
+						if (getGroupById(groupId) == null)
+							return;
+					}
+				}
 				if (clar.getProblemId() != null && getProblemById(clar.getProblemId()) == null)
 					return;
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/IClarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IClarification.java
@@ -12,19 +12,25 @@ public interface IClarification extends IContestObject {
 	String getReplyToId();
 
 	/**
-	 * The id of the team asking this question, may be null if sent from staff.
+	 * The id of the team making the clarification, may be null if sent from staff.
 	 *
 	 * @return the id
 	 */
 	String getFromTeamId();
 
 	/**
-	 * The id of the team receiving this reply, may be null if sent to staff. If both from and to
-	 * are null, this is a broadcast from staff to all teams.
+	 * The id of the team(s) receiving this reply, may be null.
 	 *
-	 * @return the id
+	 * @return the ids
 	 */
-	String getToTeamId();
+	String[] getToTeamIds();
+
+	/**
+	 * The id of the group(s) receiving this reply, may be null.
+	 *
+	 * @return the ids
+	 */
+	String[] getToGroupIds();
 
 	/**
 	 * The id of the associated problem, may be null.
@@ -39,6 +45,13 @@ public interface IClarification extends IContestObject {
 	 * @return the text
 	 */
 	String getText();
+
+	/**
+	 * Returns true if this is a broadcast (sent to everyone)
+	 *
+	 * @return true if this is a broadcast
+	 */
+	boolean isBroadcast();
 
 	/**
 	 * Returns the contest time relative to the start of the contest, in ms.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -4,17 +4,23 @@ import java.util.List;
 
 import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.feed.JSONParser;
 
 public class Clarification extends TimedEvent implements IClarification {
+	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
+
 	private static final String REPLY_TO_ID = "reply_to_id";
 	private static final String FROM_TEAM_ID = "from_team_id";
 	private static final String TO_TEAM_ID = "to_team_id";
+	private static final String TO_TEAM_IDS = "to_team_ids";
+	private static final String TO_GROUP_IDS = "to_group_ids";
 	private static final String PROBLEM_ID = "problem_id";
 	private static final String TEXT = "text";
 
 	private String replyToId;
 	private String fromTeamId;
-	private String toTeamId;
+	private String[] toTeamIds;
+	private String[] toGroupIds;
 	private String problemId;
 	private String text;
 
@@ -34,8 +40,13 @@ public class Clarification extends TimedEvent implements IClarification {
 	}
 
 	@Override
-	public String getToTeamId() {
-		return toTeamId;
+	public String[] getToTeamIds() {
+		return toTeamIds;
+	}
+
+	@Override
+	public String[] getToGroupIds() {
+		return toGroupIds;
 	}
 
 	@Override
@@ -49,6 +60,12 @@ public class Clarification extends TimedEvent implements IClarification {
 	}
 
 	@Override
+	public boolean isBroadcast() {
+		return fromTeamId == null
+				&& ((toTeamIds == null || toTeamIds.length == 0) && (toGroupIds == null || toGroupIds.length == 0));
+	}
+
+	@Override
 	protected boolean addImpl(String name, Object value) throws Exception {
 		if (REPLY_TO_ID.equals(name)) {
 			replyToId = (String) value;
@@ -57,7 +74,27 @@ public class Clarification extends TimedEvent implements IClarification {
 			fromTeamId = (String) value;
 			return true;
 		} else if (TO_TEAM_ID.equals(name)) {
-			toTeamId = (String) value;
+			toTeamIds = new String[] { (String) value };
+			return true;
+		} else if (TO_TEAM_IDS.equals(name)) {
+			if (value == null || "null".equals(value))
+				toTeamIds = null;
+			else {
+				Object[] ob = JSONParser.getOrReadArray(value);
+				toTeamIds = new String[ob.length];
+				for (int i = 0; i < ob.length; i++)
+					toTeamIds[i] = (String) ob[i];
+			}
+			return true;
+		} else if (TO_GROUP_IDS.equals(name)) {
+			if (value == null || "null".equals(value))
+				toGroupIds = null;
+			else {
+				Object[] ob = JSONParser.getOrReadArray(value);
+				toGroupIds = new String[ob.length];
+				for (int i = 0; i < ob.length; i++)
+					toGroupIds[i] = (String) ob[i];
+			}
 			return true;
 		} else if (PROBLEM_ID.equals(name)) {
 			problemId = (String) value;
@@ -75,7 +112,14 @@ public class Clarification extends TimedEvent implements IClarification {
 		props.addLiteralString(ID, id);
 		props.addLiteralString(REPLY_TO_ID, replyToId);
 		props.addLiteralString(FROM_TEAM_ID, fromTeamId);
-		props.addLiteralString(TO_TEAM_ID, toTeamId);
+		if (!isDraftSpec) {
+			if (toTeamIds != null && toTeamIds.length > 0) {
+				props.addLiteralString(TO_TEAM_ID, toTeamIds[0]);
+			}
+		} else {
+			props.addArray(TO_TEAM_IDS, toTeamIds);
+			props.addArray(TO_GROUP_IDS, toGroupIds);
+		}
 		props.addLiteralString(PROBLEM_ID, problemId);
 		props.addString(TEXT, text);
 		super.getProperties(props);
@@ -94,10 +138,23 @@ public class Clarification extends TimedEvent implements IClarification {
 		if (fromTeamId != null && c.getTeamById(fromTeamId) == null)
 			errors.add("Clarification from unknown team " + fromTeamId);
 
-		if (toTeamId != null && c.getTeamById(toTeamId) == null)
-			errors.add("Clarification to unknown team " + toTeamId);
+		if (toTeamIds != null) {
+			for (String teamId : toTeamIds) {
+				if (c.getTeamById(teamId) == null) {
+					errors.add("Clarification to unknown team " + teamId);
+				}
+			}
+		}
 
-		if (fromTeamId != null && toTeamId != null)
+		if (toGroupIds != null) {
+			for (String groupId : toGroupIds) {
+				if (c.getGroupById(groupId) == null) {
+					errors.add("Clarification to unknown group " + groupId);
+				}
+			}
+		}
+
+		if (fromTeamId != null && (toTeamIds != null || toGroupIds != null))
 			errors.add("Clarification between teams");
 
 		if (errors.isEmpty())

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1809,7 +1809,10 @@ public class Contest implements IContest {
 				remove.add(clar);
 				foundClar = true;
 			}
-			teamId = clar.getToTeamId();
+
+			// For now, assume that clarifications to hidden teams are only
+			// sent to hidden teams. (i.e. no complex groups or hidden+non-hidden teams)
+			teamId = (clar.getToTeamIds() != null && clar.getToTeamIds().length > 0) ? clar.getToTeamIds()[0] : null;
 			if (!foundClar && teamId != null && teamIds.contains(teamId)) {
 				remove.add(clar);
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -212,7 +212,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 				IClarification clar = (IClarification) obj;
 
 				// everyone sees broadcasts
-				if (clar.getFromTeamId() == null && clar.getToTeamId() == null) {
+				if (clar.isBroadcast()) {
 					clar = filterClarification(clar);
 					super.add(clar);
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
@@ -86,14 +86,39 @@ public class TeamContest extends PublicContest {
 			case CLARIFICATION: {
 				IClarification clar = (IClarification) obj;
 
-				// teams see messages to or from them
+				boolean isVisible = false;
+
+				// teams see clarifications they've sent
 				if (clar.getFromTeamId() != null && teamId.equals(clar.getFromTeamId())) {
-					clar = filterClarification(clar);
-					addIt(clar);
-					return;
+					isVisible = true;
 				}
 
-				if (clar.getToTeamId() != null && teamId.equals(clar.getToTeamId())) {
+				// ones sent to them
+				if (!isVisible && clar.getToTeamIds() != null) {
+					for (String clarTeamId : clar.getToTeamIds()) {
+						if (teamId.equals(clarTeamId)) {
+							isVisible = true;
+							continue;
+						}
+					}
+				}
+
+				// and ones sent to a group they are in
+				if (!isVisible && clar.getToGroupIds() != null) {
+					ITeam team = getTeamById(teamId);
+					String[] groupIds = team.getGroupIds();
+
+					for (String groupa : clar.getToGroupIds()) {
+						for (String groupb : groupIds) {
+							if (groupa != null && groupa.equals(groupb)) {
+								isVisible = true;
+								continue;
+							}
+						}
+					}
+				}
+
+				if (isVisible) {
 					clar = filterClarification(clar);
 					addIt(clar);
 					return;


### PR DESCRIPTION
Adds support for the draft Contest API ability to send clarifications to multiple teams and/or groups.

This updates the contest model and all client-side support to support multiple teams and groups. The CDS, presentations, and all other tools will work when pointing to a 2023-06 _or_ draft spec server.

By default the CDS will continue to serve the 2023-06 contest API though; if you want the new event feed you need to set the ICPC_CONTEST_API=draft system property as with all other draft spec changes.

CDS web pages will need to be updated as well, that will be a separate PR.