### PR TITLE
CDS web support for clarifications to multiple teams/groups

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications-admin.jsp
@@ -25,7 +25,8 @@
 			                    <th class="text-center">Time</th>
 			                    <th class="text-center">Problem</th>
 			                    <th>From Team</th>
-			                    <th>To Team</th>
+			                    <th>To Teams</th>
+			                    <th>To Groups</th>
 			                    <th>Reply To</th>
 			                    <th>Text</th>
 			                </tr>
@@ -69,7 +70,8 @@
   <td class="text-center">{{{time}}}</td>
   <td class="text-center">{{#label}}<span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span>{{/label}}</td>
   <td>{{#fromTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/fromTeam}}</td>
-  <td>{{#toTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/toTeam}}</td>
+  <td>{{#toTeams}}{{#array}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/array}}{{/toTeams}}</td>
+  <td>{{#toGroups}}{{#array}}{{id}}: {{name}}{{/array}}{{/toGroups}}</td>
   <td>{{replyTo}}</td>
   <td class="pre-line">{{{text}}}</td>
 </script>
@@ -79,7 +81,7 @@ registerContestObjectTable("clarifications");
 
 function clarificationsRefresh() {
 	contest.clear();
-	$.when(contest.loadClarifications(), contest.loadTeams(), contest.loadOrganizations(), contest.loadProblems()).done(function () {
+	$.when(contest.loadClarifications(), contest.loadTeams(), contest.loadGroups(), contest.loadOrganizations(), contest.loadProblems()).done(function () {
         fillContestObjectTable("clarifications", contest.getClarifications());
     }).fail(function (result) {
     	console.log("Error loading clarifications: " + result);

--- a/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/clarifications.jsp
@@ -23,7 +23,8 @@
 			                    <th class="text-center">Time</th>
 			                    <th class="text-center">Problem</th>
 			                    <th>From Team</th>
-			                    <th>To Team</th>
+			                    <th>To Teams</th>
+			                    <th>To Groups</th>
 			                    <th>Text</th>
 			                </tr>
 			            </thead>
@@ -66,7 +67,8 @@
   <td class="text-center">{{{time}}}</td>
   <td class="text-center">{{#label}}<span class="badge" style="background-color:{{rgb}}; width:25px; border:1px solid {{border}}"><font color={{fg}}>{{label}}</font></span>{{/label}}</td>
   <td>{{#fromTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/fromTeam}}</td>
-  <td>{{#toTeam}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/toTeam}}</td>
+  <td>{{#toTeams}}{{#array}}{{#logo}}<img src="{{{logo}}}" width="20" height="20"/> {{/logo}}{{label}}: {{name}}{{/array}}{{/toTeams}}</td>
+  <td>{{#toGroups}}{{#array}}{{name}}{{/array}}{{/toGroups}}</td>
   <td class="pre-line">{{{text}}}</td>
 </script>
 <script type="text/javascript">
@@ -75,7 +77,7 @@ registerContestObjectTable("clarifications");
 
 function clarificationsRefresh() {
 	contest.clear();
-	$.when(contest.loadClarifications(), contest.loadTeams(), contest.loadOrganizations(), contest.loadProblems()).done(function () {
+	$.when(contest.loadClarifications(), contest.loadTeams(), contest.loadGroups(), contest.loadOrganizations(), contest.loadProblems()).done(function () {
         fillContestObjectTable("clarifications", contest.getClarifications());
         
         var problems = contest.getProblems();

--- a/CDS/WebContent/js/types.js
+++ b/CDS/WebContent/js/types.js
@@ -66,6 +66,9 @@ function problemsTd(problem) {
 }
 
 function groupsTd(group) {
+	if (group == null)
+		return null;
+
 	var hidden = "";
     if (group.hidden != null)
         hidden = "true";
@@ -74,7 +77,7 @@ function groupsTd(group) {
     var logo2 = bestSquareLogo(group.logo, 20);
     if (logo2 != null)
         logoSrc = '/api/' + logo2.href;
-    return { icpc_id: group.icpc_id, name: group.name, type: group.type, hidden: hidden, logo: logoSrc };
+    return { id: group.id, icpc_id: group.icpc_id, name: group.name, type: group.type, hidden: hidden, logo: logoSrc };
 }
 
 function organizationsTd(org) {
@@ -227,8 +230,25 @@ function clarificationsTd(clar) {
         }
     }
     c.fromTeam = teamsTd(findById(contest.getTeams(), clar.from_team_id));
-    c.toTeam = teamsTd(findById(contest.getTeams(), clar.to_team_id));
-    c.replyTo = clar.reply_to_id;
+	c.toTeams = [];
+	if (clar.to_team_ids) {
+	    for (var j = 0; j < clar.to_team_ids.length; j++) {
+	    	c.toTeams.push(teamsTd(findById(contest.getTeams(), clar.to_team_ids[j])));
+		}
+	} else if (clar.to_team_id) {
+		c.toTeams.push(teamsTd(findById(contest.getTeams(), clar.to_team_id)));
+	}
+	c.toTeams = addSeparators(c.toTeams);
+
+	c.toGroups = [];
+    if (clar.to_group_ids) {
+		for (var j = 0; j < clar.to_group_ids.length; j++) {
+			c.toGroups.push(groupsTd(findById(contest.getGroups(), clar.to_group_ids[j])));
+		}
+		c.toGroups = addSeparators(c.toGroups);
+    }
+	
+	c.replyTo = clar.reply_to_id;
     return c;
 }
 
@@ -260,7 +280,7 @@ function awardsTd(award) {
             teamsStr += "<br>";
         teamsStr += getDisplayStr(award.team_ids[j]);
     }
-    return { citation: award.citation, teamsStr: teamsStr };
+    return { citation: award.citation, teams: teamsStr };
 }
 
 function startstatusTd(startStatus) {
@@ -272,4 +292,19 @@ function startstatusTd(startStatus) {
 	else if (startStatus.status == 2)
 		s.c = 'success';
 	return s;
+}
+
+function addSeparators(arr) {
+    var arr2 = [];
+    for (var j = 0; j < arr.length; j++) {
+        if (j > 0)
+            arr2.push({ br: 'true' });
+		if (arr[j]) {
+			arr[j].item = 'true';
+	        arr2.push(arr[j]);
+		} else {
+			arr2.push({ item: 'true' });
+		}
+    }
+    return arr2;
 }

--- a/CDS/WebContent/js/ui.js
+++ b/CDS/WebContent/js/ui.js
@@ -115,6 +115,9 @@ function fillContestObjectTable(name, objs) {
 
 	// load row template
 	var template = $('#' + name + '-template').html();
+	
+	template = template.replaceAll('{{#array}}', '{{#br}}<br/>{{/br}}{{#item}}');
+	template = template.replaceAll('{{/array}}', '{{/item}}');
 
 	// walk through all the current objects and add or replace rows as necessary
     for (var i = 0; i < objs.length; i++) {

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -747,9 +747,20 @@ public class ConfiguredContest {
 			ITeam team = contest.getTeamById(clar.getFromTeamId());
 			if (contest.isTeamHidden(team))
 				return null;
-			team = contest.getTeamById(clar.getToTeamId());
-			if (contest.isTeamHidden(team))
-				return null;
+			if (clar.getToTeamIds() != null) {
+				for (String teamId : clar.getToTeamIds()) {
+					team = contest.getTeamById(teamId);
+					if (contest.isTeamHidden(team))
+						return null;
+				}
+			}
+			if (clar.getToGroupIds() != null) {
+				for (String groupId : clar.getToGroupIds()) {
+					IGroup group = contest.getGroupById(groupId);
+					if (group != null && group.isHidden())
+						return null;
+				}
+			}
 		}
 
 		return obj;

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -306,8 +306,19 @@ public class PlaybackContest extends Contest {
 				Clarification clar = (Clarification) obj;
 				if (clar.getFromTeamId() != null && getTeamById(clar.getFromTeamId()) == null)
 					return;
-				if (clar.getToTeamId() != null && getTeamById(clar.getToTeamId()) == null)
-					return;
+
+				if (clar.getToTeamIds() != null) {
+					for (String teamId : clar.getToTeamIds()) {
+						if (getTeamById(teamId) == null)
+							return;
+					}
+				}
+				if (clar.getToGroupIds() != null) {
+					for (String groupId : clar.getToGroupIds()) {
+						if (getGroupById(groupId) == null)
+							return;
+					}
+				}
 				if (clar.getProblemId() != null && getProblemById(clar.getProblemId()) == null)
 					return;
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/IClarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IClarification.java
@@ -12,19 +12,25 @@ public interface IClarification extends IContestObject {
 	String getReplyToId();
 
 	/**
-	 * The id of the team asking this question, may be null if sent from staff.
+	 * The id of the team making the clarification, may be null if sent from staff.
 	 *
 	 * @return the id
 	 */
 	String getFromTeamId();
 
 	/**
-	 * The id of the team receiving this reply, may be null if sent to staff. If both from and to
-	 * are null, this is a broadcast from staff to all teams.
+	 * The id of the team(s) receiving this reply, may be null.
 	 *
-	 * @return the id
+	 * @return the ids
 	 */
-	String getToTeamId();
+	String[] getToTeamIds();
+
+	/**
+	 * The id of the group(s) receiving this reply, may be null.
+	 *
+	 * @return the ids
+	 */
+	String[] getToGroupIds();
 
 	/**
 	 * The id of the associated problem, may be null.
@@ -39,6 +45,13 @@ public interface IClarification extends IContestObject {
 	 * @return the text
 	 */
 	String getText();
+
+	/**
+	 * Returns true if this is a broadcast (sent to everyone)
+	 *
+	 * @return true if this is a broadcast
+	 */
+	boolean isBroadcast();
 
 	/**
 	 * Returns the contest time relative to the start of the contest, in ms.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -4,17 +4,23 @@ import java.util.List;
 
 import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.feed.JSONParser;
 
 public class Clarification extends TimedEvent implements IClarification {
+	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
+
 	private static final String REPLY_TO_ID = "reply_to_id";
 	private static final String FROM_TEAM_ID = "from_team_id";
 	private static final String TO_TEAM_ID = "to_team_id";
+	private static final String TO_TEAM_IDS = "to_team_ids";
+	private static final String TO_GROUP_IDS = "to_group_ids";
 	private static final String PROBLEM_ID = "problem_id";
 	private static final String TEXT = "text";
 
 	private String replyToId;
 	private String fromTeamId;
-	private String toTeamId;
+	private String[] toTeamIds;
+	private String[] toGroupIds;
 	private String problemId;
 	private String text;
 
@@ -34,8 +40,13 @@ public class Clarification extends TimedEvent implements IClarification {
 	}
 
 	@Override
-	public String getToTeamId() {
-		return toTeamId;
+	public String[] getToTeamIds() {
+		return toTeamIds;
+	}
+
+	@Override
+	public String[] getToGroupIds() {
+		return toGroupIds;
 	}
 
 	@Override
@@ -49,6 +60,12 @@ public class Clarification extends TimedEvent implements IClarification {
 	}
 
 	@Override
+	public boolean isBroadcast() {
+		return fromTeamId == null
+				&& ((toTeamIds == null || toTeamIds.length == 0) && (toGroupIds == null || toGroupIds.length == 0));
+	}
+
+	@Override
 	protected boolean addImpl(String name, Object value) throws Exception {
 		if (REPLY_TO_ID.equals(name)) {
 			replyToId = (String) value;
@@ -57,7 +74,27 @@ public class Clarification extends TimedEvent implements IClarification {
 			fromTeamId = (String) value;
 			return true;
 		} else if (TO_TEAM_ID.equals(name)) {
-			toTeamId = (String) value;
+			toTeamIds = new String[] { (String) value };
+			return true;
+		} else if (TO_TEAM_IDS.equals(name)) {
+			if (value == null || "null".equals(value))
+				toTeamIds = null;
+			else {
+				Object[] ob = JSONParser.getOrReadArray(value);
+				toTeamIds = new String[ob.length];
+				for (int i = 0; i < ob.length; i++)
+					toTeamIds[i] = (String) ob[i];
+			}
+			return true;
+		} else if (TO_GROUP_IDS.equals(name)) {
+			if (value == null || "null".equals(value))
+				toGroupIds = null;
+			else {
+				Object[] ob = JSONParser.getOrReadArray(value);
+				toGroupIds = new String[ob.length];
+				for (int i = 0; i < ob.length; i++)
+					toGroupIds[i] = (String) ob[i];
+			}
 			return true;
 		} else if (PROBLEM_ID.equals(name)) {
 			problemId = (String) value;
@@ -75,7 +112,14 @@ public class Clarification extends TimedEvent implements IClarification {
 		props.addLiteralString(ID, id);
 		props.addLiteralString(REPLY_TO_ID, replyToId);
 		props.addLiteralString(FROM_TEAM_ID, fromTeamId);
-		props.addLiteralString(TO_TEAM_ID, toTeamId);
+		if (!isDraftSpec) {
+			if (toTeamIds != null && toTeamIds.length > 0) {
+				props.addLiteralString(TO_TEAM_ID, toTeamIds[0]);
+			}
+		} else {
+			props.addArray(TO_TEAM_IDS, toTeamIds);
+			props.addArray(TO_GROUP_IDS, toGroupIds);
+		}
 		props.addLiteralString(PROBLEM_ID, problemId);
 		props.addString(TEXT, text);
 		super.getProperties(props);
@@ -94,10 +138,23 @@ public class Clarification extends TimedEvent implements IClarification {
 		if (fromTeamId != null && c.getTeamById(fromTeamId) == null)
 			errors.add("Clarification from unknown team " + fromTeamId);
 
-		if (toTeamId != null && c.getTeamById(toTeamId) == null)
-			errors.add("Clarification to unknown team " + toTeamId);
+		if (toTeamIds != null) {
+			for (String teamId : toTeamIds) {
+				if (c.getTeamById(teamId) == null) {
+					errors.add("Clarification to unknown team " + teamId);
+				}
+			}
+		}
 
-		if (fromTeamId != null && toTeamId != null)
+		if (toGroupIds != null) {
+			for (String groupId : toGroupIds) {
+				if (c.getGroupById(groupId) == null) {
+					errors.add("Clarification to unknown group " + groupId);
+				}
+			}
+		}
+
+		if (fromTeamId != null && (toTeamIds != null || toGroupIds != null))
 			errors.add("Clarification between teams");
 
 		if (errors.isEmpty())

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1809,7 +1809,10 @@ public class Contest implements IContest {
 				remove.add(clar);
 				foundClar = true;
 			}
-			teamId = clar.getToTeamId();
+
+			// For now, assume that clarifications to hidden teams are only
+			// sent to hidden teams. (i.e. no complex groups or hidden+non-hidden teams)
+			teamId = (clar.getToTeamIds() != null && clar.getToTeamIds().length > 0) ? clar.getToTeamIds()[0] : null;
 			if (!foundClar && teamId != null && teamIds.contains(teamId)) {
 				remove.add(clar);
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -212,7 +212,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 				IClarification clar = (IClarification) obj;
 
 				// everyone sees broadcasts
-				if (clar.getFromTeamId() == null && clar.getToTeamId() == null) {
+				if (clar.isBroadcast()) {
 					clar = filterClarification(clar);
 					super.add(clar);
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/TeamContest.java
@@ -86,14 +86,39 @@ public class TeamContest extends PublicContest {
 			case CLARIFICATION: {
 				IClarification clar = (IClarification) obj;
 
-				// teams see messages to or from them
+				boolean isVisible = false;
+
+				// teams see clarifications they've sent
 				if (clar.getFromTeamId() != null && teamId.equals(clar.getFromTeamId())) {
-					clar = filterClarification(clar);
-					addIt(clar);
-					return;
+					isVisible = true;
 				}
 
-				if (clar.getToTeamId() != null && teamId.equals(clar.getToTeamId())) {
+				// ones sent to them
+				if (!isVisible && clar.getToTeamIds() != null) {
+					for (String clarTeamId : clar.getToTeamIds()) {
+						if (teamId.equals(clarTeamId)) {
+							isVisible = true;
+							continue;
+						}
+					}
+				}
+
+				// and ones sent to a group they are in
+				if (!isVisible && clar.getToGroupIds() != null) {
+					ITeam team = getTeamById(teamId);
+					String[] groupIds = team.getGroupIds();
+
+					for (String groupa : clar.getToGroupIds()) {
+						for (String groupb : groupIds) {
+							if (groupa != null && groupa.equals(groupb)) {
+								isVisible = true;
+								continue;
+							}
+						}
+					}
+				}
+
+				if (isVisible) {
 					clar = filterClarification(clar);
 					addIt(clar);
 					return;


### PR DESCRIPTION
Updates the clarifications table in the CDS web ui to show teams and groups.
If you use a current feed the groups column will always be empty; if you use
the ICPC_CONTEST_API=draft system property then

Introduces better support for array properties. You have to pre-process arrays
using addSeparators() and use {{#array}}content{{/array}} in the template, but
then the objects are automatically separated by line breaks. Award team ids and
any other array properties should be updated to use this (in a separate PR).

Based on #1164, will be rebased once that's in.