### PR TITLE
URL() deprecation

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/ContestConnectionDialog.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/ContestConnectionDialog.java
@@ -1,6 +1,5 @@
 package org.icpc.tools.balloon;
 
-import java.io.IOException;
 import java.util.prefs.Preferences;
 
 import org.eclipse.swt.SWT;
@@ -83,7 +82,7 @@ public class ContestConnectionDialog extends Dialog {
 		return rc;
 	}
 
-	public ContestSource getContestSource() throws IOException {
+	public ContestSource getContestSource() throws Exception {
 		if (method == ConnectMethod.CONTEST_API)
 			return new RESTContestSource(url, user, password);
 		else if (method == ConnectMethod.CONTEST_PACKAGE)

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -159,7 +159,7 @@ public class ContestWebService extends HttpServlet {
 
 	private static InputStream getHTTPInputStream(String url, String user, String password) throws Exception {
 		try {
-			HttpURLConnection conn = HTTPSSecurity.createConnection(new URL(url), user, password);
+			HttpURLConnection conn = HTTPSSecurity.createConnection(new URI(url).toURL(), user, password);
 			conn.setReadTimeout(15 * 1000); // 15s timeout
 			return new BufferedInputStream(conn.getInputStream());
 		} catch (Exception e) {

--- a/CDS/src/org/icpc/tools/cds/video/VideoStream.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStream.java
@@ -4,7 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.ArrayList;
@@ -43,7 +43,11 @@ public class VideoStream implements IStore {
 	private ReadThread thread;
 	private List<VideoStreamListener> listeners = new ArrayList<>(3);
 
-	public VideoStream(String name, String url, StreamType type, String teamId, String... handlerType) {
+	public VideoStream(String name, String url, StreamType type, String teamId) {
+		this(name, url, type, teamId, null);
+	}
+
+	public VideoStream(String name, String url, StreamType type, String teamId, String handlerType) {
 		if (handlerType != null) {
 			for (VideoHandler vh : VideoAggregator.HANDLERS) {
 				if (vh.getName().equals(handlerType)) {
@@ -300,8 +304,8 @@ public class VideoStream implements IStore {
 
 		URL url2 = null;
 		try {
-			url2 = new URL(url);
-		} catch (MalformedURLException e) {
+			url2 = new URI(url).toURL();
+		} catch (Exception e) {
 			try {
 				File sample = new File(url);
 				if (sample.exists())

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
@@ -7,7 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -118,7 +118,7 @@ public class HLSFileCache {
 
 			long time = System.currentTimeMillis();
 			try {
-				URLConnection conn = HTTPSSecurity.createURLConnection(new URL(url + "/" + name), null, null);
+				URLConnection conn = HTTPSSecurity.createURLConnection(new URI(url + "/" + name).toURL(), null, null);
 				conn.setConnectTimeout(15000);
 				conn.setReadTimeout(10000);
 				conn.setRequestProperty("Content-Type", "video/mp4");

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSHandler.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
@@ -113,9 +113,9 @@ public class HLSHandler extends VideoServingHandler {
 		try {
 			URLConnection conn = null;
 			if (query != null)
-				conn = HTTPSSecurity.createURLConnection(new URL(url + "/stream.m3u8?" + query), null, null);
+				conn = HTTPSSecurity.createURLConnection(new URI(url + "/stream.m3u8?" + query).toURL(), null, null);
 			else
-				conn = HTTPSSecurity.createURLConnection(new URL(url + "/stream.m3u8"), null, null);
+				conn = HTTPSSecurity.createURLConnection(new URI(url + "/stream.m3u8").toURL(), null, null);
 
 			conn.setConnectTimeout(15000);
 			conn.setReadTimeout(10000);

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -31,6 +31,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
+import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
@@ -792,7 +793,7 @@ public class CoachView extends Panel {
 			return null;
 
 		try {
-			URL url = new URL(urlStr);
+			URL url = new URI(urlStr).toURL();
 			StringBuilder sb = new StringBuilder(url.getProtocol());
 			sb.append("://");
 			if (user != null)

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/CDSUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/CDSUtil.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -114,7 +115,7 @@ public class CDSUtil {
 			throw new IOException("Invalid url");
 
 		try {
-			HttpURLConnection conn = HTTPSSecurity.createConnection(new URL(url), user, password);
+			HttpURLConnection conn = HTTPSSecurity.createConnection(new URI(url).toURL(), user, password);
 			int response = conn.getResponseCode();
 			if ("CDS".equals(conn.getHeaderField("ICPC-Tools")))
 				return;
@@ -132,9 +133,9 @@ public class CDSUtil {
 
 	private HttpURLConnection createConnection(String href) throws IOException {
 		try {
-			URL url3 = new URL(url);
+			URL url3 = new URI(url).toURL();
 			String url2 = url3.getProtocol() + "://" + url3.getAuthority() + href;
-			return HTTPSSecurity.createConnection(new URL(url2), user, password);
+			return HTTPSSecurity.createConnection(new URI(url2).toURL(), user, password);
 		} catch (IOException e) {
 			throw e;
 		} catch (Exception e) {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 
 import org.icpc.tools.contest.Trace;
@@ -31,12 +31,12 @@ public class ContestAPIHelper {
 				+ ContestUtil.formatStartTime(info.getStartTime());
 	}
 
-	private static URL getChildURL(URL url, String path) throws MalformedURLException {
+	private static URL getChildURL(URL url, String path) throws Exception {
 		String u = url.toExternalForm();
 		if (u.endsWith("/"))
-			return new URL(u + path);
+			return new URI(u + path).toURL();
 
-		return new URL(u + "/" + path);
+		return new URI(u + "/" + path).toURL();
 	}
 
 	/**
@@ -54,7 +54,7 @@ public class ContestAPIHelper {
 	public static String validateContestURL(String url2, String user, String password) throws IllegalArgumentException {
 		URL url = null;
 		try {
-			url = new URL(url2);
+			url = new URI(url2).toURL();
 			Result result = getContent(url, user, password, 0);
 			String content = result.content;
 			url = result.url;
@@ -116,7 +116,7 @@ public class ContestAPIHelper {
 			try {
 				URL testURL = null;
 				if (path.startsWith("/"))
-					testURL = new URL(url.getProtocol() + "://" + url.getAuthority() + path);
+					testURL = new URI(url.getProtocol() + "://" + url.getAuthority() + path).toURL();
 				else
 					testURL = getChildURL(url, path);
 				String content = getContent(testURL, user, password, 0).content;
@@ -160,7 +160,7 @@ public class ContestAPIHelper {
 		else if (RESTContestSource.hasMoved(response)) {
 			if (redirects > 3)
 				throw new IllegalArgumentException("Too many URL redirects");
-			URL newURL = new URL(conn.getHeaderField("Location"));
+			URL newURL = new URI(conn.getHeaderField("Location")).toURL();
 			return getContent(newURL, user, password, redirects + 1);
 		} else if (response == HttpURLConnection.HTTP_NOT_FOUND) {
 			throw new IllegalArgumentException("Invalid, URL not found (404)");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -79,9 +79,9 @@ public abstract class ContestSource {
 	 * @return
 	 * @throws IOException
 	 */
-	public static ContestSource parseSource(String source, String user, String password) throws IOException {
+	public static ContestSource parseSource(String source, String user, String password) throws Exception {
 		if (source == null)
-			throw new IOException("No contest source");
+			throw new Exception("No contest source");
 
 		if (source.startsWith("http")) {
 			String source2 = ContestAPIHelper.validateContestURL(source, user, password);
@@ -92,7 +92,7 @@ public abstract class ContestSource {
 		if (f.exists())
 			return new RESTContestSource(f, user, password);
 
-		throw new IOException("Could not parse or resolve contest source");
+		throw new Exception("Could not parse or resolve contest source");
 	}
 
 	public String getContestId() {
@@ -106,7 +106,7 @@ public abstract class ContestSource {
 	 * @return
 	 * @throws IOException
 	 */
-	public File getFile(String path) throws IOException {
+	public File getFile(String path) throws Exception {
 		return null;
 	}
 
@@ -117,14 +117,14 @@ public abstract class ContestSource {
 	 * @return
 	 * @throws IOException
 	 */
-	public File getFile(IContestObject obj, FileReference ref, String property) throws IOException {
+	public File getFile(IContestObject obj, FileReference ref, String property) throws Exception {
 		return null;
 	}
 
 	/**
 	 * @throws IOException
 	 */
-	public String[] getDirectory(String path) throws IOException {
+	public String[] getDirectory(String path) throws Exception {
 		return null;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -310,7 +310,7 @@ public class DiskContestSource extends ContestSource {
 	}
 
 	@Override
-	public File getFile(IContestObject obj, FileReference ref, String property) throws IOException {
+	public File getFile(IContestObject obj, FileReference ref, String property) throws Exception {
 		if (obj == null)
 			return null;
 
@@ -394,7 +394,7 @@ public class DiskContestSource extends ContestSource {
 	}
 
 	@Override
-	public File getFile(String path) throws IOException {
+	public File getFile(String path) throws Exception {
 		String path2 = path;
 		if (path.endsWith("/"))
 			path2 += "listing.dir";
@@ -406,7 +406,7 @@ public class DiskContestSource extends ContestSource {
 	}
 
 	@Override
-	public String[] getDirectory(String path) throws IOException {
+	public String[] getDirectory(String path) throws Exception {
 		File f = null;
 		if (root != null)
 			f = new File(root, path);

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/HTTPSSecurity.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/HTTPSSecurity.java
@@ -9,7 +9,13 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Base64;
 
-import javax.net.ssl.*;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
 
 public class HTTPSSecurity {
 	private static class AllHostnameVerifier implements HostnameVerifier {
@@ -40,49 +46,32 @@ public class HTTPSSecurity {
 		}
 
 		@Override
-		public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+		public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+				throws CertificateException {
 			// ignore
 		}
 
 		@Override
-		public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
+		public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+				throws CertificateException {
 			// ignore
 		}
 
 		@Override
-		public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+		public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+				throws CertificateException {
 			// ignore
 		}
 
 		@Override
-		public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
+		public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+				throws CertificateException {
 			// ignore
 		}
 	}
 
 	public static HttpURLConnection createConnection(URL url, String user, String password) throws IOException {
-		try {
-			SSLContext ctx = SSLContext.getInstance("TLS");
-			ctx.init(null, new TrustManager[] { new ContestTrustManager() }, null);
-			SSLContext.setDefault(ctx);
-
-			HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-			if (conn instanceof HttpsURLConnection) {
-				((HttpsURLConnection) conn).setHostnameVerifier(new AllHostnameVerifier());
-				((HttpsURLConnection) conn).setSSLSocketFactory(ctx.getSocketFactory());
-			}
-			if (user != null) {
-				String auth = Base64.getEncoder().encodeToString((user + ":" + password).getBytes("UTF-8"));
-				conn.setRequestProperty("Authorization", "Basic " + auth);
-			}
-			conn.setConnectTimeout(10000);
-
-			return conn;
-		} catch (IOException e) {
-			throw e;
-		} catch (Exception e) {
-			throw new IOException("Connection error", e);
-		}
+		return (HttpURLConnection) createURLConnection(url, user, password);
 	}
 
 	public static URLConnection createURLConnection(URL url, String user, String password) throws IOException {

--- a/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
@@ -10,7 +10,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.text.NumberFormat;
@@ -298,7 +298,7 @@ public class EventFeedUtil {
 			url2 += "/";
 		url2 += "event-feed";
 		try {
-			HttpURLConnection conn = HTTPSSecurity.createConnection(new URL(url2), user, password);
+			HttpURLConnection conn = HTTPSSecurity.createConnection(new URI(url2).toURL(), user, password);
 			conn.setReadTimeout(15 * 1000); // 15s timeout
 			BufferedInputStream in = new BufferedInputStream(conn.getInputStream());
 			BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream("events.json"));
@@ -329,7 +329,7 @@ public class EventFeedUtil {
 
 		long last = 0;
 		try {
-			HttpURLConnection conn = HTTPSSecurity.createConnection(new URL(url2), user, password);
+			HttpURLConnection conn = HTTPSSecurity.createConnection(new URI(url2).toURL(), user, password);
 			conn.setReadTimeout(180 * 1000); // 3 min timeout
 			BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), "UTF-8"));
 

--- a/ContestUtil/src/org/icpc/tools/contest/util/SubmissionGrabber.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/SubmissionGrabber.java
@@ -7,7 +7,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.feed.HTTPSSecurity;
@@ -33,7 +33,7 @@ public class SubmissionGrabber {
 
 	private HttpURLConnection createConnection(int run) throws IOException {
 		try {
-			return HTTPSSecurity.createConnection(new URL(url + run), user, password);
+			return HTTPSSecurity.createConnection(new URI(url + run).toURL(), user, password);
 		} catch (IOException e) {
 			throw e;
 		} catch (Exception e) {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/SinglePhotoPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/SinglePhotoPresentation.java
@@ -7,7 +7,6 @@ import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.IOException;
 
 import javax.imageio.ImageIO;
 
@@ -32,7 +31,7 @@ public class SinglePhotoPresentation extends Presentation {
 			File f = ContestSource.getInstance().getFile("/presentation/photo.jpg");
 			if (f != null && f.exists())
 				image = ImageScaler.scaleImage(ImageIO.read(f), width, height);
-		} catch (IOException e) {
+		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Error reading image", e);
 		}
 		return image;

--- a/Resolver/src/org/icpc/tools/resolver/awards/ContestConnectionDialog.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/ContestConnectionDialog.java
@@ -1,6 +1,5 @@
 package org.icpc.tools.resolver.awards;
 
-import java.io.IOException;
 import java.util.prefs.Preferences;
 
 import org.eclipse.swt.SWT;
@@ -83,7 +82,7 @@ public class ContestConnectionDialog extends Dialog {
 		return rc;
 	}
 
-	public ContestSource getContestSource() throws IOException {
+	public ContestSource getContestSource() throws Exception {
 		if (method == ConnectMethod.CONTEST_API)
 			return new RESTContestSource(url, user, password);
 		else if (method == ConnectMethod.CONTEST_PACKAGE)


### PR DESCRIPTION
The constructor 'new URL(x)' has been deprecated in Java 20 because it never correctly handled encoding & decoding. The simplest switch is just to use 'new URI(x).toURL()': https://stackoverflow.com/questions/75966165/how-to-replace-the-deprecated-url-constructors-in-java-20

The bigger ripple is the exception for a bad url isn't MalformedURLException (an IOException) anymore. Switched to using a generic Exception instead.