### PR TITLE
Define codestyle for editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = false
+trim_trailing_whitespace = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,java}]
+charset = utf-8
+indent_style = tab


### PR DESCRIPTION
My editor has a strong preference for 4-space indentation. This should take precedence and also nudge the editors of other contributors IIRC.

This does not work with Eclipse without a plugin though: https://editorconfig.org/ but as Tim has 4x more commits as the next most contributor I would say that his editor already defines the code standard.