### PR TITLE
Specify which registry to trust

### DIFF
--- a/build/builder.Dockerfile
+++ b/build/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-bullseye
+FROM docker.io/openjdk:17-bullseye
 LABEL maintainer="ICPC Tools Team"
 LABEL org.opencontainers.image.description="ICPC Tools code builder"
 LABEL org.opencontainers.image.source=https://github.com/icpctools/icpctools

--- a/build/website.Dockerfile
+++ b/build/website.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM docker.io/ubuntu:22.04
 LABEL maintainer="Tim deBoer"
 LABEL org.opencontainers.image.description="ICPC Tools website builder"
 LABEL org.opencontainers.image.source=https://github.com/icpctools/icpctools


### PR DESCRIPTION
The Docker binary defaults to docker.io as registry. Podman as alternative doesn't and might ship with no default registry so can't build this container.

By explicit specifying the registry the risk for inconsistent builds is also decreased in case the GHA ever encounters a similar named container on the GHCR and would not use docker.