### PR TITLE
World map logo ratio

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -430,6 +430,10 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 		}
 
 		text.addString(pos.label);
+		if (text.getWidth() > width - 2 * border) {
+			text = new TextHelper(g);
+			text.addString(pos.label);
+		}
 		int h = Math.max(border, height / 12) + border;
 		int y = height - border - h;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/map/TeamIntroPresentation.java
@@ -430,10 +430,7 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 		}
 
 		text.addString(pos.label);
-		if (text.getWidth() > width - 2 * border) {
-			text = new TextHelper(g);
-			text.addString(pos.label);
-		}
+
 		int h = Math.max(border, height / 12) + border;
 		int y = height - border - h;
 
@@ -442,6 +439,20 @@ public class TeamIntroPresentation extends AbstractICPCPresentation {
 		g.fillRect(0, y, width, h);
 		g.setComposite(AlphaComposite.SrcOver.derive(1f));
 		g.setColor(Color.WHITE);
-		text.drawFit(Math.max(border, width - text.getWidth()) / 2, y + (h - text.getHeight()) / 2, width - border * 2);
+		if ((text.getWidth() + border * 2) <= width) {
+			text.drawFit(Math.max(border, width - text.getWidth()) / 2, y + (h - text.getHeight()) / 2, width - border * 2);
+		} else {
+			TextHelper textImage = new TextHelper(g);
+			if (pos.smImage != null) {
+				textImage.addImage(pos.smImage);
+				textImage.addSpacer(border);
+			}
+
+			text = new TextHelper(g);
+			text.addString(pos.label);
+
+			textImage.draw(0, y + (h - textImage.getHeight()) / 2);
+			text.drawFit(pos.smImage.getWidth() + Math.max(border, width - text.getWidth()) / 2, y + (h - text.getHeight()) / 2, width - border * 2 - pos.smImage.getWidth());
+		}
 	}
 }


### PR DESCRIPTION
Closes #1171,

I'm not 100% if the logo is now placed in the same location or if the `x` should be calculated differently but on first glance this looks like a fix.

I've added 2 commits, for both possible solutions.

I like the 2nd for the consistency
The first has the benefit of giving more space for the name which might be worth it as the logo is already on screen at that moment.

<img width="1528" height="1122" alt="image" src="https://github.com/user-attachments/assets/b9a659f0-8680-4f90-b2f2-3e5dd055b071" />
<img width="1913" height="1117" alt="image" src="https://github.com/user-attachments/assets/4e74611f-2e00-4701-9d01-b445e9e933dc" />
