### PR TITLE
Remove {width} as its not in spec

### DIFF
--- a/BalloonUtility/README.md
+++ b/BalloonUtility/README.md
@@ -1,6 +1,6 @@
 # The ICPC Balloon Utility 
 
-![](docs/balloonIcon.png){width=50}
+![](docs/balloonIcon.png)
 
 An ICPC Tool
 

--- a/CDS/README.md
+++ b/CDS/README.md
@@ -1,6 +1,6 @@
 # The ICPC Contest Data Server (CDS)
 
-![](docs/cdsIcon.png){width=50}
+![](docs/cdsIcon.png)
 
 An ICPC Tool
 

--- a/CoachView/README.md
+++ b/CoachView/README.md
@@ -1,6 +1,6 @@
 # The ICPC Coach View
 
-![](docs/coachViewIcon.png){width=50}
+![](docs/coachViewIcon.png)
 
 An ICPC Tool
 

--- a/ContestUtil/README.md
+++ b/ContestUtil/README.md
@@ -1,6 +1,6 @@
 # Contest Utilities
 
-![](docs/contestUtilsIcon.png){width=50}
+![](docs/contestUtilsIcon.png)
 
 An ICPC Tool
 

--- a/Resolver/README.md
+++ b/Resolver/README.md
@@ -1,6 +1,6 @@
 # The ICPC Resolver 
 
-![](docs/resolverIcon.png){width=50}
+![](docs/resolverIcon.png)
 
 An ICPC Tool
 


### PR DESCRIPTION
It seems its not part of the spec according to: https://www.markdownguide.org/hacks/#image-size

I checked with the GitHub page itself and it seems it also ignores the width:
<img width="663" height="1106" alt="Screenshot from 2025-08-21 22-03-30" src="https://github.com/user-attachments/assets/f8d13b6e-44d6-4cea-9ff6-c8b360693343" />
and in the PDF (generated on linux):
<img width="1464" height="1585" alt="Screenshot from 2025-08-21 22-05-49" src="https://github.com/user-attachments/assets/c58974b1-310f-4821-83b9-6b052f40c085" />

So I think we can close: https://github.com/icpctools/icpctools/issues/775 as the width probably worked in the past but doesn't anymore (or I just don't see what it should do).

Closes: #775