### PR TITLE
Allow null for location

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -338,9 +338,13 @@ public class Team extends ContestObject implements ITeam {
 			}
 			case LOCATION: {
 				JsonObject obj = JSONParser.getOrReadObject(value);
-				x = obj.getDouble(X);
-				y = obj.getDouble(Y);
-				rotation = obj.getDouble(ROTATION);
+				if (obj != null) {
+					x = obj.getDouble(X);
+					y = obj.getDouble(Y);
+					rotation = obj.getDouble(ROTATION);
+				}
+				// We return true when either location: null or set
+				// Otherwise we would wrongly list it as unknown property
 				return true;
 			}
 			case PHOTO: {


### PR DESCRIPTION
DOMjudge sends the location as `location: null` when it's not set.

This only handles the default case,