### PR TITLE
HLS byterange support

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,46 +20,45 @@ import org.icpc.tools.contest.Trace;
  */
 public class HLSParser {
 	private static final String EXT = "#EXT";
+	private static final String VERSION = "#EXT-X-VERSION:";
 	private static final String X_GAP = "#EXT-X-GAP";
 	private static final String X_MAP = "#EXT-X-MAP:";
 	private static final String X_STREAM_INF = "#EXT-X-STREAM-INF:";
+	private static final String X_BYTE_RANGE = "#EXT-X-BYTERANGE:";
 
 	private static final String INF = "#EXTINF:";
 	private static final String X_PART = "#EXT-X-PART:";
 
 	private static final String PRELOAD_HINT = "#EXT-X-PRELOAD-HINT:";
 
-	// #EXT-X-MAP:URI="60aab25693f9_init.mp4"
+	// #EXT-X-MAP:URI="60aab25693f9_init.mp4",BYTERANGE="720@0"
 	// 60aab25693f9_seg7.mp4
 	// #EXT-X-PART:DURATION=0.20000,URI="60aab25693f9_part23.mp4"
 	// #EXT-X-PRELOAD-HINT:TYPE=PART,URI="b6d064eaa487_part10.mp4"
+	// #EXT-X-BYTERANGE:2258821@2268117
 
 	private static final String[] EMPTY = new String[0];
 
+	protected URI uri;
+	protected String version;
 	protected String[] header;
 	protected String[] footer;
 	protected String[] footerParts;
-	protected String init;
+	protected HLSSegment map;
 	protected List<String> preload = new ArrayList<>();
 	protected long readTime;
 
 	protected String urlPrefix;
 
-	class Segment {
-		String[] comments;
-		String[] parts;
-		String file;
-		boolean gap;
+	protected HLSSegment[] playlist;
+
+	public HLSParser(URI uri, String prefix) {
+		this.uri = uri;
+		urlPrefix = prefix;
 	}
 
-	protected Segment[] playlist;
-
-	public HLSParser() {
-		// todo
-	}
-
-	public void setURLPrefix(String s) {
-		urlPrefix = s;
+	public URI getURI() {
+		return uri;
 	}
 
 	private String[] getURI(String s) {
@@ -69,9 +69,54 @@ public class HLSParser {
 		if (j < 0)
 			return null;
 
-		String uri = s.substring(i + 5, j);
+		String uri2 = s.substring(i + 5, j);
 		String edit = s.substring(0, i + 5) + urlPrefix + s.substring(i + 5);
-		return new String[] { uri, edit };
+		return new String[] { uri2, edit };
+	}
+
+	/**
+	 * Returns the value of the quoted property from with the string. For instance, given the input
+	 * string '...,x="y",...' and key 'x', it will return 'y'.
+	 *
+	 * @param s a string
+	 * @param key a property key
+	 * @return the value of the property, or null if it was not in the string
+	 */
+	private static String getValue(String s, String key) {
+		int i = s.indexOf(key + "=");
+		if (i < 0)
+			return null;
+		int j = s.indexOf("\"", i + key.length() + 2);
+		if (j < 0)
+			return null;
+
+		return s.substring(i + key.length() + 2, j);
+	}
+
+	/**
+	 * Parses a byterange string from the spec form "<length>[@<start>]" into an int array with
+	 * [length, start]. e.g. input "1024@512" -> output [1024, 512]
+	 *
+	 * @param a byterange string
+	 * @return an integer array containing the length and start
+	 */
+	private static int[] parseByteRange(String s) {
+		if (s == null || s.length() == 0)
+			return null;
+
+		int[] br = new int[2];
+		try {
+			int ind = s.indexOf("@");
+			if (ind < 0) {
+				br[0] = Integer.parseInt(s);
+			} else {
+				br[0] = Integer.parseInt(s.substring(0, ind));
+				br[1] = Integer.parseInt(s.substring(ind + 1, s.length()));
+			}
+		} catch (Exception e) {
+			Trace.trace(Trace.ERROR, "Could not parse byterange " + s, e);
+		}
+		return br;
 	}
 
 	public void read(InputStream in) {
@@ -83,20 +128,25 @@ public class HLSParser {
 			String s = br.readLine();
 			List<String> buf = new ArrayList<String>();
 			List<String> filebuf = new ArrayList<String>();
-			List<Segment> segments = new ArrayList<Segment>();
+			List<HLSSegment> segments = new ArrayList<HLSSegment>();
 			boolean gap = false;
+			int[] byterange = null;
 			while (s != null) {
 				if (s.startsWith(X_STREAM_INF) || s.startsWith(INF)) {
 					if (header == null) {
 						header = buf.toArray(EMPTY);
 						buf.clear();
 					}
+					byterange = null;
 
 					buf.add(s);
 				} else if (s.startsWith(EXT)) {
 					if (s.startsWith(X_MAP)) {
 						String[] ss = getURI(s);
-						init = ss[0];
+						HLSSegment seg = new HLSSegment();
+						seg.file = ss[0];
+						seg.byterange = parseByteRange(getValue(s, "BYTERANGE"));
+						map = seg;
 						buf.add(ss[1]);
 					} else if (s.startsWith(X_PART)) {
 						String[] ss = getURI(s);
@@ -109,14 +159,21 @@ public class HLSParser {
 					} else if (s.equals(X_GAP)) {
 						gap = true;
 						buf.add(s);
+					} else if (s.startsWith(X_BYTE_RANGE)) {
+						byterange = parseByteRange(s.substring(X_BYTE_RANGE.length()));
+						buf.add(s);
+					} else if (s.equals(VERSION)) {
+						version = s.substring(VERSION.length());
+						buf.add(s);
 					} else
 						buf.add(s);
 				} else { // file
-					Segment seg = new Segment();
+					HLSSegment seg = new HLSSegment();
 					seg.comments = buf.toArray(EMPTY);
 					seg.parts = filebuf.toArray(EMPTY);
 					seg.file = s;
 					seg.gap = gap;
+					seg.byterange = byterange;
 					segments.add(seg);
 					buf.clear();
 					filebuf.clear();
@@ -128,7 +185,7 @@ public class HLSParser {
 			br.close();
 			footer = buf.toArray(EMPTY);
 			footerParts = filebuf.toArray(EMPTY);
-			playlist = segments.toArray(new Segment[0]);
+			playlist = segments.toArray(new HLSSegment[0]);
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Error parsing HLS index", e);
 		}
@@ -136,29 +193,32 @@ public class HLSParser {
 		readTime = System.currentTimeMillis();
 	}
 
-	public List<String> filesToDownload() {
-		List<String> list = new ArrayList<String>();
+	public void prefillCache(HLSFileCache fileCache) {
+		if (map != null)
+			fileCache.addToCache(map.file, map.byterange);
 
-		if (init != null)
-			list.add(init);
-
-		for (Segment s : playlist) {
+		for (HLSSegment s : playlist) {
 			if (s.gap)
 				continue;
 
-			list.add(s.file);
+			fileCache.addToCache(s.file, s.byterange);
 			for (String ss : s.parts) {
-				list.add(ss);
+				fileCache.addToCache(ss, null);
 			}
+
+			// TODO: samples tend to have the entire video in the index to start,
+			// so prefilling the entire cache is unnecessary and causes a huge
+			// delay. For now, only cache up to 10 files at a time: works fine
+			// for streaming, only loads ~60s for samples
+			if (fileCache.getSize() > 10)
+				return;
 		}
 
 		if (footerParts != null && footerParts.length > 0) {
 			for (String ss : footerParts) {
-				list.add(ss);
+				fileCache.addToCache(ss, null);
 			}
 		}
-
-		return list;
 	}
 
 	public List<String> getPreload() {
@@ -178,7 +238,7 @@ public class HLSParser {
 			}
 
 			if (playlist != null) {
-				for (Segment seg : playlist) {
+				for (HLSSegment seg : playlist) {
 					for (String s : seg.comments) {
 						bw.write(s);
 						bw.newLine();
@@ -213,7 +273,7 @@ public class HLSParser {
 	}
 
 	public static void main(String[] args) {
-		HLSParser parser = new HLSParser();
+		HLSParser parser = new HLSParser(URI.create("/"), null);
 		InputStream in = parser.getClass().getResourceAsStream("HLSexample2.m3u8");
 		System.out.println("Reading");
 		parser.read(in);

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSSegment.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSSegment.java
@@ -1,0 +1,14 @@
+package org.icpc.tools.cds.video.containers;
+
+/**
+ * An HLS media segment.
+ */
+public class HLSSegment {
+	protected String[] comments;
+	protected String[] parts;
+	protected String file;
+	protected boolean gap;
+
+	// HLS byte range: [ length, start ]
+	protected int[] byterange;
+}


### PR DESCRIPTION
Our support for the HLS spec is incomplete: it's based on which parts of the spec I saw >1 year ago when connected to a mediamtx endpoint. For instance, we do not support multi-index playlists yet, just single index / single playlist streams.

Another part of the spec we didn't support was BYTERANGEs - i.e. instead of each segment being different files, they can be byte ranges in a single file. Or different ranges in multiple files, or whatever.

I'm not sure if a mediamtx endpoint will ever use this, but it's possible and maybe even likely if they use a memory cache instead of a disk cache. However, it is used by most of the HLS samples I've been trying to test with, so supporting it is both future-proofing and making it easier to test.

The amount of change is large, but boils down to these things:
- move HLS segment class to its own file.
- parser updates to handle byte ranges in segments and maps.
- cache changes to request segments that are byte ranges.
- cache changes to save ranges as separate files so they don't conflict.
- change list of files to download to directly load the cache via segments.
- several fixes to child url handling to load the samples.

Full disclosure: this _still_ doesn't totally work for samples because our cache tries to pre-load all segments, and samples tend to list all of them - potentially hours of video. For now I've put a TODO and some code in the parser that only loads at most 10 segments per index. We should never hit this in streaming, and for large samples it just means there's a temporary delay and only ~1 minute of video before it crashes. In the future we should preload a couple, then do the rest in the background or on demand.