### PR TITLE
Default presentation for presentation client

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/standalone/StandaloneLauncher.java
@@ -253,7 +253,7 @@ public class StandaloneLauncher {
 		}
 	}
 
-	protected static PresentationInfo findPresentation(List<PresentationInfo> presentations, String s) {
+	public static PresentationInfo findPresentation(List<PresentationInfo> presentations, String s) {
 		try {
 			int num = Integer.parseInt(s);
 			List<PresentationInfo> list = PresentationHelper.getPresentations();


### PR DESCRIPTION
Adds an option to set a default presentation for connected presentation clients. This presentation is set before trying to connect to the CDS. If the CDS doesn't set any presentation then this one is shown; otherwise whatever the CDS says takes over.

This avoids the standard ICPC Tools splash page, and allows you to have a default w/o waiting for clients to connect and then setting it in the pres admin.

Fixes #955.