### PR TITLE
Fix start of PresAdmin

### DIFF
--- a/PresAdmin/scripts/presAdmin.bat
+++ b/PresAdmin/scripts/presAdmin.bat
@@ -22,7 +22,7 @@ robocopy "%ROOTDIR%\update" "%ROOTDIR%\" /e /move
 
 :restart
 
-java -jar "%LIBDIR%\swtLauncher.jar" presentationAdmin.jar,tyrus-standalone-client-2.2.0.jar org.icpc.tools.presentation.admin.internal.Admin %params%
+java -jar "%LIBDIR%\swtLauncher.jar" presentationAdmin.jar,tyrus-standalone-client-2.2.0.jar,sentry-opentelemetry-agent-8.12.0.jar org.icpc.tools.presentation.admin.internal.Admin %params%
 
 if errorlevel 255 goto :restart
 if errorlevel 254 goto :update

--- a/PresAdmin/scripts/presAdmin.sh
+++ b/PresAdmin/scripts/presAdmin.sh
@@ -13,7 +13,7 @@ if [ "$UNAME" == "Darwin" ]; then
 fi
 
 while true; do
-  java $vmoptions -jar lib/swtLauncher.jar presentationAdmin.jar,tyrus-standalone-client-2.2.20.jar org.icpc.tools.presentation.admin.internal.Admin "$@"
+  java $vmoptions -jar lib/swtLauncher.jar presentationAdmin.jar,tyrus-standalone-client-2.2.20.jar,sentry-opentelemetry-agent-8.12.0.jar org.icpc.tools.presentation.admin.internal.Admin "$@"
   result=$?
   if [ $result = 254 ]
   then


### PR DESCRIPTION
The Sentry jar was not found and although it doesn't use it yet it needs to find it because of the ContestModel providing Sentry config.