### PR TITLE
Taskbar guard

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
@@ -1085,11 +1085,13 @@ public class BalloonUtility {
 		});
 
 		Display.setAppName("Balloon Utility");
-		try {
-			BufferedImage image = ImageIO.read(BalloonUtility.class.getResourceAsStream("/images/balloonIcon.png"));
-			Taskbar.getTaskbar().setIconImage(image);
-		} catch (Exception e) {
-			Trace.trace(Trace.INFO, "Couldn't set taskbar icon", e);
+		if (Taskbar.isTaskbarSupported()) {
+			try {
+				BufferedImage image = ImageIO.read(BalloonUtility.class.getResourceAsStream("/images/balloonIcon.png"));
+				Taskbar.getTaskbar().setIconImage(image);
+			} catch (Exception e) {
+				Trace.trace(Trace.INFO, "Couldn't set taskbar icon", e);
+			}
 		}
 
 		Display display = new Display();

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -84,7 +84,6 @@ public class CoachView extends Panel {
 
 	private static boolean lightMode = false;
 
-
 	static {
 		String[] countries = Locale.getISOCountries();
 		localeMap = new HashMap<String, Locale>(countries.length);
@@ -940,7 +939,7 @@ public class CoachView extends Panel {
 		Trace.init("ICPC Coach View", "coachView", args);
 
 		String[] displayStr2 = new String[1];
-		//boolean[] lightMode = new boolean[1];
+		// boolean[] lightMode = new boolean[1];
 		ContestSource contestSource = ArgumentParser.parse(args, new OptionParser() {
 			@Override
 			public boolean setOption(String option, List<Object> options) throws IllegalArgumentException {
@@ -949,7 +948,7 @@ public class CoachView extends Panel {
 					displayStr2[0] = (String) options.get(0);
 					return true;
 				} else if ("--light".equals(option)) {
-					//lightMode[0] = true;
+					// lightMode[0] = true;
 					lightMode = true;
 					return true;
 				}
@@ -977,7 +976,8 @@ public class CoachView extends Panel {
 		try {
 			BufferedImage image = ImageIO.read(CoachView.class.getClassLoader().getResource("images/coachViewIcon.png"));
 			frame.setIconImage(image);
-			Taskbar.getTaskbar().setIconImage(image);
+			if (Taskbar.isTaskbarSupported())
+				Taskbar.getTaskbar().setIconImage(image);
 		} catch (Exception e) {
 			// could not set icon
 		}

--- a/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
+++ b/PresAdmin/src/org/icpc/tools/presentation/admin/internal/Admin.java
@@ -82,11 +82,13 @@ public class Admin {
 		View v = new View(url, source.user, source.password);
 
 		Display.setAppName("Presentation Admin");
-		try {
-			BufferedImage image = ImageIO.read(Admin.class.getResourceAsStream("/images/adminIcon.png"));
-			Taskbar.getTaskbar().setIconImage(image);
-		} catch (Exception e) {
-			Trace.trace(Trace.INFO, "Couldn't set taskbar icon", e);
+		if (Taskbar.isTaskbarSupported()) {
+			try {
+				BufferedImage image = ImageIO.read(Admin.class.getResourceAsStream("/images/adminIcon.png"));
+				Taskbar.getTaskbar().setIconImage(image);
+			} catch (Exception e) {
+				Trace.trace(Trace.INFO, "Couldn't set taskbar icon", e);
+			}
 		}
 
 		final Display display = new Display();

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -288,7 +288,8 @@ public class PresentationWindowImpl extends PresentationWindow {
 		this.title = title;
 
 		setIconImage(iconImage);
-		Taskbar.getTaskbar().setIconImage(iconImage);
+		if (Taskbar.isTaskbarSupported())
+			Taskbar.getTaskbar().setIconImage(iconImage);
 
 		setBounds(r);
 		setBackground(Color.black);

--- a/ProblemSet/src/org/icpc/tools/contest/util/problemset/ProblemSetEditor.java
+++ b/ProblemSet/src/org/icpc/tools/contest/util/problemset/ProblemSetEditor.java
@@ -537,11 +537,14 @@ public class ProblemSetEditor {
 		}
 
 		Display.setAppName("Problem Set Editor");
-		try {
-			BufferedImage image = ImageIO.read(ProblemSetEditor.class.getResourceAsStream("/images/problemSetIcon.png"));
-			Taskbar.getTaskbar().setIconImage(image);
-		} catch (Exception e) {
-			// could not set icon
+		if (Taskbar.isTaskbarSupported()) {
+			try {
+				BufferedImage image = ImageIO
+						.read(ProblemSetEditor.class.getResourceAsStream("/images/problemSetIcon.png"));
+				Taskbar.getTaskbar().setIconImage(image);
+			} catch (Exception e) {
+				// could not set icon
+			}
 		}
 
 		Display display = new Display();

--- a/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/awards/AwardUI.java
@@ -733,11 +733,13 @@ public class AwardUI {
 		}
 
 		Display.setAppName("Award Utility");
-		try {
-			BufferedImage image = ImageIO.read(AwardUI.class.getResourceAsStream("/images/resolverIcon.png"));
-			Taskbar.getTaskbar().setIconImage(image);
-		} catch (Exception e) {
-			Trace.trace(Trace.ERROR, "Couldn't set taskbar icon");
+		if (Taskbar.isTaskbarSupported()) {
+			try {
+				BufferedImage image = ImageIO.read(AwardUI.class.getResourceAsStream("/images/resolverIcon.png"));
+				Taskbar.getTaskbar().setIconImage(image);
+			} catch (Exception e) {
+				Trace.trace(Trace.ERROR, "Couldn't set taskbar icon");
+			}
 		}
 
 		Display display = new Display();


### PR DESCRIPTION
Avoid calling Taskbar.setIconImage() on platforms that don't support it.

Fixes #1183.