### PR TITLE
Allow video handlers to customize url (HLS filename)

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/video.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/video.jsp
@@ -168,13 +168,12 @@ function updateStreams(base, type) {
    		if (j > 0)
    			link += "&nbsp;";
    		var stream = streams[j];
-		var id = stream.id;
    		var cl = "text-info";
    		if (stream.status == "active")
    			cl = "text-success";
    		else if (stream.status == "failed")
    			cl = "text-danger";
-   		link += "<a href='/stream/" + id + "' class="+ cl+">" + id + "</a>";
+   		link += "<a href='" + stream.url + "' class="+ cl+">" + stream.id + "</a>";
    	}
   	d.innerHTML =link;
     

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -19,6 +19,7 @@ import org.icpc.tools.cds.RSSWriter;
 import org.icpc.tools.cds.presentations.PresentationFilesServlet;
 import org.icpc.tools.cds.util.HttpHelper;
 import org.icpc.tools.cds.video.VideoAggregator;
+import org.icpc.tools.cds.video.VideoAggregator.ConnectionMode;
 import org.icpc.tools.cds.video.VideoAggregator.Stats;
 import org.icpc.tools.cds.video.VideoStream;
 import org.icpc.tools.cds.video.VideoStream.StreamType;
@@ -361,6 +362,14 @@ public class ContestWebService extends HttpServlet {
 								je.open();
 								je.encode("id", in);
 								VideoStream stream = va.getStream(in);
+								if (ConnectionMode.DIRECT.equals(stream.getMode())) {
+									je.encode("url", stream.getURL());
+								} else {
+									String file = stream.getFileName();
+									if (file != null)
+										file = "/" + file;
+									je.encode("url", "/stream/" + in + file);
+								}
 								je.encode("mode", stream.getMode().name().toLowerCase());
 								je.encode("status", stream.getStatus().name().toLowerCase());
 								Stats stats = stream.getStats();

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -237,10 +237,14 @@ public class PlaybackContest extends Contest {
 		for (Integer i : in) {
 			FileReference ref = new FileReference();
 			VideoStream vs = VideoAggregator.getInstance().getStream(i);
-			if (ConnectionMode.DIRECT.equals(vs.getMode()))
+			if (ConnectionMode.DIRECT.equals(vs.getMode())) {
 				ref.href = vs.getURL();
-			else
-				ref.href = "<host>/stream/" + i;
+			} else {
+				String file = vs.getFileName();
+				if (file != null)
+					file = "/" + file;
+				ref.href = "<host>/stream/" + i + file;
+			}
 			ref.mime = vs.getMimeType();
 			list.add(ref);
 		}

--- a/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoHandler.java
@@ -18,6 +18,10 @@ public abstract class VideoHandler {
 
 	protected abstract String getFileExtension();
 
+	protected String getFileName() {
+		return null;
+	}
+
 	protected abstract String getMimeType();
 
 	/**

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -210,20 +210,30 @@ public class VideoServlet extends HttpServlet {
 		je.open();
 		je.openChildArray("streams");
 		int c = 0;
-		for (VideoStream vi : va.getVideoInfo()) {
+		for (VideoStream vs : va.getVideoInfo()) {
 			je.open();
-			je.encode("id", c++ + "");
-			je.encode("name", vi.getName());
-			je.encode("type", vi.getType().name());
-			je.encode("team_id", vi.getTeamId());
-			je.encode("mode", vi.getMode().name());
-			je.encode("status", vi.getStatus().name());
-			Stats s = vi.getStats();
+			je.encode("id", c + "");
+			je.encode("name", vs.getName());
+			je.encode("type", vs.getType().name());
+			je.encode("team_id", vs.getTeamId());
+			je.encode("mode", vs.getMode().name());
+
+			if (ConnectionMode.DIRECT.equals(vs.getMode())) {
+				je.encode("url", vs.getURL());
+			} else {
+				String file = vs.getFileName();
+				if (file != null)
+					file = "/" + file;
+				je.encode("url", "/stream/" + c + file);
+			}
+			je.encode("status", vs.getStatus().name());
+			Stats s = vs.getStats();
 			je.encode("current", s.currentListeners);
 			je.encode("max_current", s.maxConcurrentListeners);
 			je.encode("total_listeners", s.totalListeners);
 			je.encode("total_time", ContestUtil.formatTime(s.totalTime));
 			je.close();
+			c++;
 		}
 		je.closeArray();
 

--- a/CDS/src/org/icpc/tools/cds/video/VideoStream.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoStream.java
@@ -91,6 +91,10 @@ public class VideoStream implements IStore {
 		return handler.getFileExtension();
 	}
 
+	public String getFileName() {
+		return handler.getFileName();
+	}
+
 	public String getMimeType() {
 		return handler.getMimeType();
 	}

--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSHandler.java
@@ -59,6 +59,11 @@ public class HLSHandler extends VideoServingHandler {
 	}
 
 	@Override
+	protected String getFileName() {
+		return "index.m3u8";
+	}
+
+	@Override
 	protected String getMimeType() {
 		return "application/vnd.apple.mpegurl";
 	}
@@ -136,7 +141,7 @@ public class HLSHandler extends VideoServingHandler {
 					throw new IOException("Not authorized (HTTP response code 401)");
 			}
 
-			HLSParser parser = new HLSParser(uri, stream + "/");
+			HLSParser parser = new HLSParser(uri, "");// stream + "/");
 
 			in = conn.getInputStream();
 			parser.read(in);
@@ -213,7 +218,7 @@ public class HLSHandler extends VideoServingHandler {
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response, int stream, IStore store, String path)
 			throws IOException {
-		if (path == null) {
+		if (path == null || path.equals("index.m3u8")) {
 			handleIndex(request, response, stream, store);
 			return;
 		}


### PR DESCRIPTION
The CDS video urls are always 'folders' today, e.g. /stream/12. However, I found that some video players (e.g. video.js) expect HLS streams to be 'files' like 'blah.m3u8'. This PR allows video handlers to specify a filename that's appended to the file reference url like /stream/12/index.m3u8 in order to make the url look more typical, and uses it for HLS. CDS admin web pages are updated as well.

We could do this for streaming video formats as well, e.g. /stream/17/video.m2ts, but I haven't implemented that here.

The ability for the HLS parser to prefix the embedded files was left in for now, but could likely be removed later.