### PR TITLE
HLS live streaming

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSParser.java
@@ -210,7 +210,7 @@ public class HLSParser {
 			// so prefilling the entire cache is unnecessary and causes a huge
 			// delay. For now, only cache up to 10 files at a time: works fine
 			// for streaming, only loads ~60s for samples
-			if (fileCache.getSize() > 10)
+			if (fileCache.getSize() > 2)
 				return;
 		}
 
@@ -219,6 +219,41 @@ public class HLSParser {
 				fileCache.addToCache(ss, null);
 			}
 		}
+	}
+
+	protected static boolean byterangeMatches(int[] a, int[] b) {
+		return ((a == null && b == null) || (a != null && b != null && a[0] == b[0] && a[1] == b[1]));
+	}
+
+	public boolean isValidFile(String name, int[] byterange) {
+		if (name == null)
+			return false;
+
+		if (map != null && map.file.equals(name) && byterangeMatches(map.byterange, byterange)) {
+			return true;
+		}
+
+		for (HLSSegment s : playlist) {
+			if (s.gap)
+				continue;
+
+			if (s.file.equals(name) && byterangeMatches(s.byterange, byterange)) {
+				return true;
+			}
+
+			for (String ss : s.parts) {
+				if (name.equals(ss))
+					return true;
+			}
+		}
+
+		if (footerParts != null && footerParts.length > 0) {
+			for (String ss : footerParts) {
+				if (name.equals(ss))
+					return true;
+			}
+		}
+		return false;
 	}
 
 	public List<String> getPreload() {


### PR DESCRIPTION
Typical HLS indexes for streaming contain a rolling set of video files.

The HLS support prior to this was focussed on 'cached streaming': the CDS would connect to an endpoint and cache both the HLS index and all files contained in it before responding with the index to the client. This was simple and ensured a full cache when dealing with multiple clients, but there's a long initial delay / latency, it gave us little control over how the cache is used, and didn't work for samples (where the index contains the full video, potentially Gbs of cache).

This change drops the pre-caching down to only the first file, and adds support for caching while streaming, i.e. if there's a file requested that we don't have in the cache, we can stream it directly to the client while filling the cache for the following client.

Now that we have the byterange support, I also optimized caching for cases where we know the size of the file in advance or the server tells us the content length.

Net effect:
- latency for the first client drops from waiting for ~5 files (depending on the HLS source) to 1.
- samples are fully supported, since we fill the cache as we go.
- caching is slightly faster (avoids 1+ large array copies).
- now that the code handles all cases we have more options for how we manage the cache in the future.
- clients accessing the same file concurrently is almost certainly still broken, but again this is a better codebase to fix that with.