### PR TITLE
Always prefer SVGs

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -426,6 +426,13 @@ public abstract class ContestObject implements IContestObject {
 		if (list.size() == 1)
 			return list.first();
 
+		// look for svgs first
+		for (FileReference ref : list) {
+			if ("image/svg+xml".equals(ref.mime))
+				return ref;
+		}
+
+		// otherwise find best size
 		if (fit != null)
 			return fit.getBestMatch(list);
 


### PR DESCRIPTION
There's a very small chance that an SVG just contains a low res image, but in all other cases SVGs are better: the file download time is less, loading is less, and generating an image of any exact size should be comparable to png scaling. This change always picks an SVG as 'best' if one exists in a file reference list, regardless of requested image size.