### PR TITLE
HLS and initial multi-client support

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/HLSFileCache.java
@@ -11,28 +11,37 @@ import java.net.URI;
 import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import org.icpc.tools.cds.service.ExecutorListener;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.feed.HTTPSSecurity;
 
-import jakarta.servlet.http.HttpServletResponse;
-
 public class HLSFileCache {
 	private static final long CACHE_TIME = 10 * 1000L; // 10s
+	private static final long MEMORY_TIME = 2 * 60 * 1000L; // 2 minutes
 
 	static class CachedFile {
 		public String name;
 		public byte[] b;
+		public int downloaded = -1;
 		public long storeTime;
 		public long lastAccessTime;
 		public int[] byterange;
+		public boolean keep;
+
+		@Override
+		public String toString() {
+			if (byterange != null) {
+				return name + " " + byterange[1] + "-" + (byterange[0] + byterange[1] - 1);
+			}
+			return name;
+		}
 	}
 
 	private HLSParser parser;
 
 	private List<CachedFile> list = new ArrayList<>();
-	private List<String> preload = new ArrayList<>();
-	// private List<String> lazyload = new ArrayList<>();
 
 	public HLSFileCache(HLSParser parser) {
 		this.parser = parser;
@@ -43,22 +52,36 @@ public class HLSFileCache {
 	}
 
 	public long cleanCache() {
+		Trace.trace(Trace.INFO, "Cleaning cache");
 		List<CachedFile> remove = new ArrayList<>(20);
 		long size = 0;
 
 		long now = System.currentTimeMillis();
 		synchronized (list) {
 			for (CachedFile cf : list) {
-				// remove anything older than the cache time
-				if (cf.storeTime < now - CACHE_TIME)
-					remove.add(cf);
-				else
+				if (!cf.keep && cf.lastAccessTime < now - CACHE_TIME) {
+					if (cf.storeTime < now - MEMORY_TIME) {
+						remove.add(cf);
+						Trace.trace(Trace.INFO, "Removing " + cf);
+					} else if (cf.b != null) {
+						// remove the local cached copy
+						cf.downloaded = 0;
+						cf.b = null;
+						// size += cf.b.length;
+						Trace.trace(Trace.INFO, "Removing data from " + cf);
+					} else {
+						size += cf.b.length;
+					}
+				} else {
 					size += cf.b.length;
+				}
 			}
 		}
 
-		for (CachedFile s : remove)
-			list.remove(s);
+		synchronized (list) {
+			for (CachedFile s : remove)
+				list.remove(s);
+		}
 
 		return size;
 	}
@@ -78,17 +101,7 @@ public class HLSFileCache {
 		return getFromCache(name, byterange) != null;
 	}
 
-	public void addPreload(String name) {
-		if (contains(name, null) || preload.contains(name))
-			return;
-		preload.add(name);
-	}
-
-	public boolean hasPreload(String name) {
-		return preload.contains(name);
-	}
-
-	private static byte[] cacheImpl(InputStream in, OutputStream out) throws IOException {
+	private static void cacheUnknownLength(CachedFile cf, InputStream in, OutputStream out) throws IOException {
 		ByteArrayOutputStream bout = new ByteArrayOutputStream();
 		BufferedInputStream bin = new BufferedInputStream(in);
 		byte[] b = new byte[1024 * 8];
@@ -108,128 +121,159 @@ public class HLSFileCache {
 		bin.close();
 		bout.close();
 
-		return bout.toByteArray();
+		cf.b = bout.toByteArray();
+		cf.downloaded = cf.b.length;
 	}
 
 	// Optimized caching when we know the size of the file in advance
-	private static byte[] cacheImpl(InputStream in, OutputStream out, int length) throws IOException {
-		byte[] cache = new byte[length];
+	private static void cache(CachedFile cf, InputStream in, OutputStream out) throws IOException {
+		int length = cf.b.length;
 		BufferedInputStream bin = new BufferedInputStream(in);
-		int n = bin.read(cache, 0, length);
+		int n = bin.read(cf.b, 0, length);
 		int i = 0;
 		while (n != -1) {
 			if (out != null) {
 				try {
-					out.write(cache, i, n);
+					out.write(cf.b, i, n);
 				} catch (Exception e) {
 					// ignore
 				}
 			}
 			i += n;
+			cf.downloaded = i;
 			if (i == length)
 				break;
 
-			n = bin.read(cache, i, length - i);
+			n = bin.read(cf.b, i, length - i);
 		}
 
 		bin.close();
-
-		return cache;
+		cf.downloaded = length;
 	}
 
-	public void stream(CachedFile cf, OutputStream out) {
+	private void stream(CachedFile cf, OutputStream out) {
+		int count = 0;
+		while (cf.downloaded != -1 && !(cf.b != null && cf.downloaded == cf.b.length) && count < 10) {
+			// another thread is downloading, wait a bit
+			try {
+				Thread.sleep(100);
+			} catch (Exception e) {
+				// ignore
+			}
+			count++;
+		}
+		if (cf.b == null || cf.downloaded != cf.b.length) {
+			// the other thread failed to download, let's try again
+			serveFile(cf, out);
+			return;
+		}
 		try {
+			byte[] b = cf.b;
 			cf.lastAccessTime = System.currentTimeMillis();
 
 			BufferedOutputStream bout = new BufferedOutputStream(out);
-			bout.write(cf.b, 0, cf.b.length);
+			bout.write(b, 0, b.length);
 			bout.close();
 		} catch (Exception e) {
-			Trace.trace(Trace.ERROR, "Error streaming HLS video from cache", e);
+			Trace.trace(Trace.ERROR, "Error streaming HLS video from cache " + cf, e);
 		}
 	}
 
-	public boolean addToCache(String name, int[] byterange) {
-		return streamAndCache(name, byterange, null);
-	}
-
-	public boolean streamAndCache(String name, int[] byterange, OutputStream out) {
+	public CachedFile addToCache(String name, int[] byterange, boolean downloadNow) {
 		CachedFile cf = getFromCache(name, byterange);
-		if (cf != null) {
-			// already cached, just send it
-			stream(cf, out);
-			return true;
+		if (cf == null) {
+			synchronized (list) {
+				cf = getFromCache(name, byterange);
+
+				if (cf == null) {
+					cf = new CachedFile();
+					cf.name = name;
+					cf.byterange = byterange;
+					list.add(cf);
+				}
+			}
 		}
+		cf.storeTime = System.currentTimeMillis();
+		Trace.trace(Trace.INFO, "Added to cache list: " + cf + " " + downloadNow);
 
-		synchronized (this) {
-			cf = getFromCache(name, byterange);
-			if (cf != null) {
-				stream(cf, out);
-				return true;
+		if (downloadNow) {
+			final CachedFile cf2 = cf;
+			ExecutorListener.getExecutor().schedule(() -> {
+				boolean download = false;
+				synchronized (cf2) {
+					if (cf2.downloaded == -1) {
+						download = true;
+						cf2.downloaded = 0;
+					}
+				}
+				if (download) {
+					streamAndCache(cf2, null);
+				}
+			}, 0, TimeUnit.SECONDS);
+		}
+		return cf;
+	}
+
+	public void serveFile(CachedFile cf, OutputStream out) {
+		// only the first thread should attempt to download the file
+		boolean download = false;
+		synchronized (cf) {
+			if (cf.downloaded == -1) {
+				download = true;
+				cf.downloaded = 0;
+			}
+		}
+		if (download) {
+			streamAndCache(cf, out);
+		} else {
+			stream(cf, out);
+		}
+	}
+
+	private void streamAndCache(CachedFile cf, OutputStream out) {
+		long time = System.currentTimeMillis();
+		String range = "";
+		try {
+			URI uri = parser.getURI().resolve(cf.name);
+			URLConnection conn = HTTPSSecurity.createURLConnection(uri.toURL(), null, null);
+			conn.setConnectTimeout(15000);
+			conn.setReadTimeout(10000);
+			conn.setRequestProperty("Content-Type", "video/mp4");
+
+			if (cf.byterange != null) {
+				// convert from HLS to HTTP byte range
+				range = cf.byterange[1] + "-" + (cf.byterange[0] + cf.byterange[1] - 1);
+				conn.setRequestProperty("Range", "bytes=" + range);
 			}
 
-			long time = System.currentTimeMillis();
-			String range = "";
-			try {
-				URI uri = parser.getURI().resolve(name);
-				URLConnection conn = HTTPSSecurity.createURLConnection(uri.toURL(), null, null);
-				conn.setConnectTimeout(15000);
-				conn.setReadTimeout(10000);
-				conn.setRequestProperty("Content-Type", "video/mp4");
-
-				if (byterange != null) {
-					// convert from HLS to HTTP byte range
-					range = byterange[1] + "-" + (byterange[0] + byterange[1] - 1);
-					conn.setRequestProperty("Range", "bytes=" + range);
-				}
-
-				if (conn instanceof HttpURLConnection) {
-					HttpURLConnection httpConn = (HttpURLConnection) conn;
-					int httpStatus = httpConn.getResponseCode();
-					if (httpStatus == HttpURLConnection.HTTP_NOT_FOUND)
-						throw new IOException("404 Not found (" + name + ")");
-					else if (httpStatus == HttpURLConnection.HTTP_UNAUTHORIZED)
-						throw new IOException("Not authorized (HTTP response code 401)");
-				}
-
-				int length = conn.getContentLength();
-
-				cf = new CachedFile();
-				cf.name = name;
-				if (length > 0 || byterange != null) {
-					cf.b = cacheImpl(conn.getInputStream(), out, length > 0 ? length : byterange[0]);
-				} else {
-					cf.b = cacheImpl(conn.getInputStream(), out);
-				}
-				cf.storeTime = System.currentTimeMillis();
-				cf.byterange = byterange;
-				list.add(cf);
-
-				Trace.trace(Trace.INFO,
-						"  Cache success: " + name + " " + range + " (" + (System.currentTimeMillis() - time) + "ms)");
-				return true;
-			} catch (Exception e) {
-				Trace.trace(Trace.ERROR,
-						"  Cache fail: " + name + " " + range + " (" + (System.currentTimeMillis() - time) + "ms)");
-				return false;
+			if (conn instanceof HttpURLConnection) {
+				HttpURLConnection httpConn = (HttpURLConnection) conn;
+				int httpStatus = httpConn.getResponseCode();
+				if (httpStatus == HttpURLConnection.HTTP_NOT_FOUND)
+					throw new IOException("404 Not found (" + cf.name + ")");
+				else if (httpStatus == HttpURLConnection.HTTP_UNAUTHORIZED)
+					throw new IOException("Not authorized (HTTP response code 401)");
 			}
+
+			int length = conn.getContentLength();
+			if (length > 0 || cf.byterange != null) {
+				cf.b = new byte[length > 0 ? length : cf.byterange[0]];
+				cache(cf, conn.getInputStream(), out);
+			} else {
+				cacheUnknownLength(cf, conn.getInputStream(), out);
+			}
+			cf.lastAccessTime = System.currentTimeMillis();
+
+			Trace.trace(Trace.INFO,
+					"  Cache success: " + cf.name + " " + range + " (" + (System.currentTimeMillis() - time) + "ms)");
+		} catch (Exception e) {
+			Trace.trace(Trace.ERROR,
+					"  Cache fail: " + cf.name + " " + range + " (" + (System.currentTimeMillis() - time) + "ms)");
+			cf.downloaded = -1;
 		}
 	}
 
 	public HLSParser getParser() {
 		return parser;
-	}
-
-	// treat preloads like lazy loads
-	protected void preloadIt(String name, HttpServletResponse response) throws IOException {
-		System.out.println("  Preload: " + name);
-		if (!addToCache(name, null)) {
-			response.sendError(HttpServletResponse.SC_NOT_FOUND);
-			return;
-		}
-
-		CachedFile cf = getFromCache(name, null);
-		if (cf != null)
-			stream(cf, response.getOutputStream());
 	}
 }


### PR DESCRIPTION
Prior to this, cached file = a file that we had already downloaded. If the client requested a new file, we'd try to validate it against the current parsed index and then download it. Multiple clients could easily download the same file; HLS preload and map files were special cases.

After this change, the cached file list is built up as we parse any index to contain all known downloadable files. We have full control over which we download immediately (just the map for now). Each new request looks in the cache, and waits if there's another thread already downloading the file. Map and preload don't need to be special cases anymore. The cache can now forget really old files (2min for now) and has better control over clearing in-memory files (10s for now).

Net: better cache control and less special cases. Future ability to stream to multiple clients at once while still downloading.