### PR TITLE
Remove unnecessary output

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/details-admin/contest.html
+++ b/CDS/WebContent/WEB-INF/jsps/details-admin/contest.html
@@ -46,7 +46,6 @@ $(document).ready(function () {
             $("#info-freeze").html(formatTime(parseTime(info.scoreboard_freeze_duration)));
         
         var logo = bestSquareLogo(info.logo, 50);
-        console.log(info.name + " - " + info.logo + " -> " + logo);
         if (logo != null) {
             var elem = document.createElement("img");
             elem.setAttribute("src", "/api/" + logo.href);
@@ -54,7 +53,6 @@ $(document).ready(function () {
             document.getElementById("logo").appendChild(elem);
         }
         var banner = bestLogo(info.banner, 100, 50);
-        console.log(info.name + " - " + info.banner + " -> " + banner);
         if (banner != null) {
             var elem = document.createElement("img");
             elem.setAttribute("src", "/api/" + banner.href);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1328,6 +1328,9 @@ public class Contest implements IContest {
 		if (s == null)
 			return false;
 
+		if (info.getFreezeDuration() == null)
+			return true;
+
 		return s.getContestTime() < (info.getDuration() - info.getFreezeDuration());
 	}
 


### PR DESCRIPTION
Found while testing with Pavel's contest API:
- unnecessary console output in CDS web
- contest without a freeze causes NPE in the resolver