### PR TITLE
Fix non-file video urls

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -366,9 +366,11 @@ public class ContestWebService extends HttpServlet {
 									je.encode("url", stream.getURL());
 								} else {
 									String file = stream.getFileName();
-									if (file != null)
-										file = "/" + file;
-									je.encode("url", "/stream/" + in + file);
+									if (file != null) {
+										je.encode("url", "/stream/" + in + "/" + file);
+									} else {
+										je.encode("url", "/stream/" + in);
+									}
 								}
 								je.encode("mode", stream.getMode().name().toLowerCase());
 								je.encode("status", stream.getStatus().name().toLowerCase());

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -241,9 +241,11 @@ public class PlaybackContest extends Contest {
 				ref.href = vs.getURL();
 			} else {
 				String file = vs.getFileName();
-				if (file != null)
-					file = "/" + file;
-				ref.href = "<host>/stream/" + i + file;
+				if (file != null) {
+					ref.href = "<host>/stream/" + i + "/" + file;
+				} else {
+					ref.href = "<host>/stream/" + i;
+				}
 			}
 			ref.mime = vs.getMimeType();
 			list.add(ref);

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -222,9 +222,11 @@ public class VideoServlet extends HttpServlet {
 				je.encode("url", vs.getURL());
 			} else {
 				String file = vs.getFileName();
-				if (file != null)
-					file = "/" + file;
-				je.encode("url", "/stream/" + c + file);
+				if (file != null) {
+					je.encode("url", "/stream/" + c + "/" + file);
+				} else {
+					je.encode("url", "/stream/" + c);
+				}
 			}
 			je.encode("status", vs.getStatus().name());
 			Stats s = vs.getStats();


### PR DESCRIPTION
Fix the video urls broken from a previous PR. When there's no file it should be "http://stream/6", not "http://stream/6/null". :)