### PR TITLE
Consistently use display size

### DIFF
--- a/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/PresentationWindowImpl.java
@@ -844,7 +844,7 @@ public class PresentationWindowImpl extends PresentationWindow {
 	}
 
 	private Presentation doFinalSetup(Presentation p) {
-		Dimension d = getSize();
+		Dimension d = getDisplaySize();
 		if (!p.getSize().equals(d))
 			p.setSize(d);
 		p.aboutToShow();


### PR DESCRIPTION
The display size allows you to configure a portion of the screen for display, e.g. for cropping an overwash edges for projectors. It was getting reset when new presentations are setup, this fixes that.