### PR TITLE
Fix balloon printer and update SWT launcher

### DIFF
--- a/BalloonUtility/scripts/balloon.bat
+++ b/BalloonUtility/scripts/balloon.bat
@@ -22,7 +22,7 @@ robocopy "%ROOTDIR%\update" "%ROOTDIR%\" /e /move
 
 :restart
 
-java -cp "%LIBDIR%\*" org.icpc.tools.balloon.BalloonUtility %params%
+java -jar "%LIBDIR%\swtLauncher.jar" org.icpc.tools.balloon.BalloonUtility %params%
 
 if errorlevel 255 goto :restart
 if errorlevel 254 goto :update

--- a/BalloonUtility/scripts/balloon.sh
+++ b/BalloonUtility/scripts/balloon.sh
@@ -18,7 +18,7 @@ LC_ALL=$LC_PAPER
 fi
 
 while true; do
-  java $vmoptions -cp "lib/*" org.icpc.tools.balloon.BalloonUtility "$@"
+  java $vmoptions -jar lib/swtLauncher.jar org.icpc.tools.balloon.BalloonUtility "$@"
   result=$?
   if [ $result = 254 ]
   then

--- a/BalloonUtility/src/META-INF/MANIFEST.MF
+++ b/BalloonUtility/src/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: org.icpc.tools.balloon.BalloonUtility
-Class-Path: contestModel.jar presentCore.jar

--- a/PresAdmin/scripts/presAdmin.bat
+++ b/PresAdmin/scripts/presAdmin.bat
@@ -22,7 +22,7 @@ robocopy "%ROOTDIR%\update" "%ROOTDIR%\" /e /move
 
 :restart
 
-java -jar "%LIBDIR%\swtLauncher.jar" presentationAdmin.jar,tyrus-standalone-client-2.2.0.jar,sentry-opentelemetry-agent-8.12.0.jar org.icpc.tools.presentation.admin.internal.Admin %params%
+java -jar "%LIBDIR%\swtLauncher.jar" org.icpc.tools.presentation.admin.internal.Admin %params%
 
 if errorlevel 255 goto :restart
 if errorlevel 254 goto :update

--- a/PresAdmin/scripts/presAdmin.sh
+++ b/PresAdmin/scripts/presAdmin.sh
@@ -13,7 +13,7 @@ if [ "$UNAME" == "Darwin" ]; then
 fi
 
 while true; do
-  java $vmoptions -jar lib/swtLauncher.jar presentationAdmin.jar,tyrus-standalone-client-2.2.20.jar,sentry-opentelemetry-agent-8.12.0.jar org.icpc.tools.presentation.admin.internal.Admin "$@"
+  java $vmoptions -jar lib/swtLauncher.jar org.icpc.tools.presentation.admin.internal.Admin "$@"
   result=$?
   if [ $result = 254 ]
   then

--- a/PresAdmin/src/META-INF/MANIFEST.MF
+++ b/PresAdmin/src/META-INF/MANIFEST.MF
@@ -1,2 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: contestModel.jar presentCore.jar

--- a/ProblemSet/scripts/problemSet.bat
+++ b/ProblemSet/scripts/problemSet.bat
@@ -15,4 +15,4 @@ goto :loop
 
 :continue
 
-java -cp "%LIBDIR%\*" org.icpc.tools.contest.util.problemset.ProblemSetEditor %params% 
+java -jar "%LIBDIR%\swtLauncher.jar" org.icpc.tools.contest.util.problemset.ProblemSetEditor %params% 

--- a/ProblemSet/scripts/problemSet.sh
+++ b/ProblemSet/scripts/problemSet.sh
@@ -12,4 +12,4 @@ if [ "$UNAME" == "Darwin" ]; then
    vmoptions=-XstartOnFirstThread
 fi
 
-java $vmoptions -cp "$LIBDIR/*" org.icpc.tools.contest.util.problemset.ProblemSetEditor "$@"
+java $vmoptions -jar lib/swtLauncher.jar org.icpc.tools.contest.util.problemset.ProblemSetEditor "$@"

--- a/ProblemSet/src/META-INF/MANIFEST.MF
+++ b/ProblemSet/src/META-INF/MANIFEST.MF
@@ -1,1 +1,0 @@
-Manifest-Version: 1.0

--- a/Resolver/scripts/awards.bat
+++ b/Resolver/scripts/awards.bat
@@ -15,4 +15,4 @@ goto :loop
 
 :continue
 
-java -cp "%LIBDIR%\*" org.icpc.tools.resolver.awards.Awards %params%
+java -jar "%LIBDIR%\swtLauncher.jar" org.icpc.tools.resolver.awards.Awards %params%

--- a/Resolver/scripts/awards.sh
+++ b/Resolver/scripts/awards.sh
@@ -12,4 +12,4 @@ if [ "$UNAME" == "Darwin" ]; then
    vmoptions=-XstartOnFirstThread
 fi
 
-java $vmoptions -cp "$LIBDIR/*" org.icpc.tools.resolver.awards.Awards "$@"
+java $vmoptions -jar $LIBDIR/swtLauncher.jar org.icpc.tools.resolver.awards.Awards "$@"

--- a/Resolver/src/META-INF/MANIFEST.MF
+++ b/Resolver/src/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: org.icpc.tools.resolver.Resolver
-Class-Path: contestModel.jar presentations.jar

--- a/SWTLauncher/src/org/icpc/tools/contest/SWTLauncher.java
+++ b/SWTLauncher/src/org/icpc/tools/contest/SWTLauncher.java
@@ -1,6 +1,7 @@
 package org.icpc.tools.contest;
 
 import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
@@ -40,10 +41,15 @@ public class SWTLauncher {
 			URL swtURL = findSWTJar();
 			urls.add(swtURL);
 
-			String jarArg = args[0];
-			String[] jars = jarArg.split(",");
-			for (String jar : jars) {
-				urls.add(new File("lib" + File.separator + jar).toURI().toURL());
+			File libFolder = new File("lib");
+			File[] libs = libFolder.listFiles(new FileFilter() {
+				@Override
+				public boolean accept(File ff) {
+					return !ff.getName().startsWith("swt-") && ff.getName().endsWith(".jar");
+				}
+			});
+			for (File lib : libs) {
+				urls.add(lib.toURI().toURL());
 			}
 
 			URLClassLoader cl = new URLClassLoader(urls.toArray(new URL[0]));


### PR DESCRIPTION
Adding the sentry dependency broke a few of the tool scripts a couple months ago. Instead of the direct fix of adding sentry to all the scripts, I tried to simplify and allow all of them to run against all jars in the lib folder (June 20 / build 1215), but I had forgotten how the SWT launcher works.

This may be going further down the rabbit hole, but it simplifies how the SWT launcher works as well, removes unused (and potentially confusing) manifest files, and fixes the scripts to match.