### PR TITLE
Balloon script and SWT launcher

### DIFF
--- a/BalloonUtility/scripts/balloon.bat
+++ b/BalloonUtility/scripts/balloon.bat
@@ -22,7 +22,7 @@ robocopy "%ROOTDIR%\update" "%ROOTDIR%\" /e /move
 
 :restart
 
-java -jar "%LIBDIR%\swtLauncher.jar" org.icpc.tools.balloon.BalloonUtility %params%
+java -cp "%LIBDIR%\swtLauncher.jar" org.icpc.tools.contest.SWTLauncher org.icpc.tools.balloon.BalloonUtility %params%
 
 if errorlevel 255 goto :restart
 if errorlevel 254 goto :update

--- a/BalloonUtility/scripts/balloon.sh
+++ b/BalloonUtility/scripts/balloon.sh
@@ -18,7 +18,7 @@ LC_ALL=$LC_PAPER
 fi
 
 while true; do
-  java $vmoptions -jar lib/swtLauncher.jar org.icpc.tools.balloon.BalloonUtility "$@"
+  java $vmoptions -cp lib/swtLauncher.jar org.icpc.tools.contest.SWTLauncher org.icpc.tools.balloon.BalloonUtility "$@"
   result=$?
   if [ $result = 254 ]
   then

--- a/SWTLauncher/src/org/icpc/tools/contest/SWTLauncher.java
+++ b/SWTLauncher/src/org/icpc/tools/contest/SWTLauncher.java
@@ -53,12 +53,12 @@ public class SWTLauncher {
 			}
 
 			URLClassLoader cl = new URLClassLoader(urls.toArray(new URL[0]));
-			Class<?> c = cl.loadClass(args[1]);
+			Class<?> c = cl.loadClass(args[0]);
 			Method m = c.getMethod("main", String[].class);
 
 			int size = args.length;
-			String[] newAgs = new String[size - 2];
-			System.arraycopy(args, 2, newAgs, 0, size - 2);
+			String[] newAgs = new String[size - 1];
+			System.arraycopy(args, 1, newAgs, 0, size - 1);
 			m.invoke(null, (Object) newAgs);
 			cl.close();
 		} catch (Exception e) {


### PR DESCRIPTION
Missed balloon launcher scripts in previous PR, fix SWT launcher to use first arg as class name and pass all the remaining args (we've removed the first arg).