### PR TITLE
SWT launcher only needs one arg

### DIFF
--- a/SWTLauncher/src/org/icpc/tools/contest/SWTLauncher.java
+++ b/SWTLauncher/src/org/icpc/tools/contest/SWTLauncher.java
@@ -30,7 +30,7 @@ public class SWTLauncher {
 	}
 
 	public static void main(String[] args) {
-		if (args == null || args.length < 2) {
+		if (args == null || args.length < 1) {
 			System.err.println("Error: Missing SWT launcher arguments");
 			return;
 		}


### PR DESCRIPTION
The SWT launcher only needs 1 arg, shouldn't error when there are only 2.