### PR TITLE
Improve default config

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -20,13 +20,10 @@ import org.icpc.tools.cds.video.VideoStream.StreamType;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IAccount;
-import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IJudgement;
-import org.icpc.tools.contest.model.IPerson;
-import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.ContestSource;
@@ -645,8 +642,6 @@ public class ConfiguredContest {
 			source.addListener(new ContestSourceListener() {
 				@Override
 				public void stateChanged(ConnectionState state2) {
-					if (ContestSource.ConnectionState.CONNECTED.equals(state2))
-						pc.setConfigurationLoaded();
 					if (ContestSource.ConnectionState.CONNECTING.equals(state2))
 						Trace.trace(Trace.USER, "Reading contest: " + id);
 					else if (ContestSource.ConnectionState.COMPLETE.equals(state2))
@@ -724,58 +719,6 @@ public class ConfiguredContest {
 
 		ITeam team = contest.getTeamById(sub.getTeamId());
 		return contest.isTeamHidden(team);
-	}
-
-	protected IContestObject filterHidden(IContestObject obj) {
-		if (obj instanceof IGroup) {
-			IGroup group = (IGroup) obj;
-			if (group.isHidden())
-				return null;
-		} else if (obj instanceof ITeam) {
-			ITeam team = (ITeam) obj;
-			if (contest.isTeamHidden(team))
-				return null;
-		} else if (obj instanceof IPerson) {
-			IPerson person = (IPerson) obj;
-			ITeam team = contest.getTeamById(person.getTeamId());
-			if (contest.isTeamHidden(team))
-				return null;
-		} else if (obj instanceof ISubmission) {
-			ISubmission sub = (ISubmission) obj;
-			ITeam team = contest.getTeamById(sub.getTeamId());
-			if (contest.isTeamHidden(team))
-				return null;
-		} else if (obj instanceof IRun) {
-			IRun run = (IRun) obj;
-			IJudgement j = contest.getJudgementById(run.getJudgementId());
-			if (isJudgementHidden(j))
-				return null;
-		} else if (obj instanceof IJudgement) {
-			IJudgement j = (IJudgement) obj;
-			if (isJudgementHidden(j))
-				return null;
-		} else if (obj instanceof IClarification) {
-			IClarification clar = (IClarification) obj;
-			ITeam team = contest.getTeamById(clar.getFromTeamId());
-			if (contest.isTeamHidden(team))
-				return null;
-			if (clar.getToTeamIds() != null) {
-				for (String teamId : clar.getToTeamIds()) {
-					team = contest.getTeamById(teamId);
-					if (contest.isTeamHidden(team))
-						return null;
-				}
-			}
-			if (clar.getToGroupIds() != null) {
-				for (String groupId : clar.getToGroupIds()) {
-					IGroup group = contest.getGroupById(groupId);
-					if (group != null && group.isHidden())
-						return null;
-				}
-			}
-		}
-
-		return obj;
 	}
 
 	public void incrementRest() {

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -422,19 +422,12 @@ public class PlaybackContest extends Contest {
 		}
 
 		ContestType type = obj.getType();
-		boolean configType = true;
 		if (type == ContestType.CONTEST || type == ContestType.PROBLEM || type == ContestType.GROUP
 				|| type == ContestType.LANGUAGE || type == ContestType.JUDGEMENT_TYPE || type == ContestType.TEAM
 				|| type == ContestType.PERSON || type == ContestType.ORGANIZATION) {
 			applyDefaults(obj);
-			configType = true;
-		}
 
-		if (!configurationLoaded) {
-			if (!configType)
-				configurationLoaded = true;
-			else {
-				applyDefaults(obj);
+			if (!configurationLoaded) {
 				defaultConfig.add(obj);
 			}
 		}
@@ -525,6 +518,7 @@ public class PlaybackContest extends Contest {
 		super.add(obj);
 	}
 
+	@Override
 	public void setConfigurationLoaded() {
 		configurationLoaded = true;
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -805,6 +805,7 @@ public class DiskContestSource extends ContestSource {
 		contest.addModifier(mod);
 
 		loadConfigFiles();
+		contest.setConfigurationLoaded();
 
 		// load event feed
 		File feedFile = eventFeedFile;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -165,6 +165,10 @@ public class Contest implements IContest {
 		addKnownProperty(obj.getType(), obj.getProperties());
 	}
 
+	public void setConfigurationLoaded() {
+		// do nothing
+	}
+
 	public void addKnownProperty(IContestObject.ContestType type, Map<String, Object> props) {
 		if (type == null || props == null)
 			return;


### PR DESCRIPTION
The CDS stores a set of 'default' objects as it reads config from disk, and then when it gets objects from the CCS that match it adds any missing properties. When the contest data was requested by multiple accounts before the default configuration was loaded, the configurationLoaded flag can get triggered early.

Remove unused configType = false code path and only store config objects in the default config.

Make the 'end of configuration' more direct: just call the contest.setConfigurationLoaded() method directly from the disk source instead of triggering off an event.

Remove unused filterHidden() method to reduce confusion.