### PR TITLE
Delay non-admin contest feeds until configuration is loaded

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -570,6 +570,10 @@ public class ConfiguredContest {
 				}
 				count++;
 			}
+			if (count == 20) {
+				Trace.trace(Trace.WARNING,
+						"Configuration was not loaded after 2s, allowing account access to " + account.getId());
+			}
 
 			IContestObject[] objs = contest.getObjects();
 			for (IContestObject co : objs)

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -561,6 +561,16 @@ public class ConfiguredContest {
 			ac = AccountHelper.createAccountContest(account);
 			ac.setHashCode(contest.hashCode());
 
+			int count = 0;
+			while (!contest.isConfigurationLoaded() && count < 20) {
+				try {
+					Thread.sleep(100);
+				} catch (Exception e) {
+					// ignore
+				}
+				count++;
+			}
+
 			IContestObject[] objs = contest.getObjects();
 			for (IContestObject co : objs)
 				ac.add(co);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -85,6 +85,7 @@ public class Contest implements IContest {
 	private long lastEventTime;
 	private IContestObject lastTimedEvent;
 	private int lastTimedEventIndex;
+	private boolean isConfigLoaded;
 
 	// map of known properties for each contest type
 	@SuppressWarnings("unchecked")
@@ -165,8 +166,12 @@ public class Contest implements IContest {
 		addKnownProperty(obj.getType(), obj.getProperties());
 	}
 
+	public boolean isConfigurationLoaded() {
+		return isConfigLoaded;
+	}
+
 	public void setConfigurationLoaded() {
-		// do nothing
+		isConfigLoaded = true;
 	}
 
 	public void addKnownProperty(IContestObject.ContestType type, Map<String, Object> props) {


### PR DESCRIPTION
Avoid serving data to non-admin clients until we've loaded all configuration files from disk, to avoid the situation where we load the tsvs, allow some clients to see them, and then load the jsons.