### PR TITLE
Fix loading synchronization issue

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -575,9 +575,9 @@ public class ConfiguredContest {
 						"Configuration was not loaded after 2s, allowing account access to " + account.getId());
 			}
 
-			IContestObject[] objs = contest.getObjects();
-			for (IContestObject co : objs)
-				ac.add(co);
+			contest.addListenerFromStart((contest2, obj, d) -> {
+				contest.add(obj);
+			});
 
 			accountContests.put(key, ac);
 		}
@@ -684,12 +684,6 @@ public class ConfiguredContest {
 			State[] currentState = new State[1];
 			currentState[0] = new State();
 			contest.addListenerFromStart((contest2, obj, d) -> {
-				synchronized (accountContests) {
-					for (Contest ac : accountContests.values()) {
-						ac.add(obj);
-					}
-				}
-
 				if (obj instanceof ITeam) {
 					ITeam team = (ITeam) obj;
 					if (videos != null && streamMap.get(team.getId()) == null && isTeamOrSpare(contest, team)) {

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -562,7 +562,7 @@ public class ConfiguredContest {
 			ac.setHashCode(contest.hashCode());
 
 			int count = 0;
-			while (!contest.isConfigurationLoaded() && count < 20) {
+			while (!contest.isConfigurationLoaded() && count < 40) {
 				try {
 					Thread.sleep(100);
 				} catch (Exception e) {
@@ -572,7 +572,7 @@ public class ConfiguredContest {
 			}
 			if (count == 20) {
 				Trace.trace(Trace.WARNING,
-						"Configuration was not loaded after 2s, allowing account access to " + account.getId());
+						"Configuration was not loaded after 4s, allowing account access to " + account.getId());
 			}
 
 			contest.addListenerFromStart((contest2, obj, d) -> {

--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -62,7 +62,6 @@ public class PlaybackContest extends Contest {
 	protected double timeMultiplier = Double.NaN;
 	protected Long startTime;
 	private Contest defaultConfig = new Contest(false);
-	protected boolean configurationLoaded;
 
 	public PlaybackContest(ConfiguredContest cc) {
 		contestId = cc.getId();
@@ -427,7 +426,7 @@ public class PlaybackContest extends Contest {
 				|| type == ContestType.PERSON || type == ContestType.ORGANIZATION) {
 			applyDefaults(obj);
 
-			if (!configurationLoaded) {
+			if (!isConfigurationLoaded()) {
 				defaultConfig.add(obj);
 			}
 		}
@@ -516,11 +515,6 @@ public class PlaybackContest extends Contest {
 		}
 
 		super.add(obj);
-	}
-
-	@Override
-	public void setConfigurationLoaded() {
-		configurationLoaded = true;
 	}
 
 	private void applyDefaults(IContestObject obj) {


### PR DESCRIPTION
Fixes two problems:
- PlaybackContest had its own configurationLoaded property, which never gets set: all non-admin clients would wait for 2s regardless of config being loaded. It now uses the property from the parent contest object.
- Synchronized accountContests means that the playback contest is blocked from adding objects while we're waiting for account to load... which blindly waits for 2s as per above. i.e. we weren't letting the main contest load config at all. It now spreads the objects to each account directly (multiple listeners) instead of from the main listener.