### PR TITLE
No need to drop untrusted listeners if we're not listening

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/PlaybackContest.java
@@ -416,7 +416,7 @@ public class PlaybackContest extends Contest {
 
 		if (obj instanceof State) {
 			State state = (State) obj;
-			if (state.isFrozen() && state.isRunning())
+			if (state.isFrozen() && state.isRunning() && VideoAggregator.isRunning())
 				VideoAggregator.getInstance().dropUntrustedListeners();
 		}
 


### PR DESCRIPTION
Found a case where the video aggregator is getting loaded even if video is not configured on any contest. This just avoids calling getInstance() and triggering the load.