### PR TITLE
Remove disk scanning logging

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -926,7 +926,6 @@ public class DiskContestSource extends ContestSource {
 	 * trigger an event.
 	 */
 	protected void scanForResourceChanges() {
-		long time = System.currentTimeMillis();
 		try {
 			List<File> modifiedFiles = new ArrayList<>();
 			List<File> addedFiles = new ArrayList<>();
@@ -1043,8 +1042,6 @@ public class DiskContestSource extends ContestSource {
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Scanning failed", e);
 		}
-		Trace.trace(Trace.INFO,
-				"Scanned " + this.contestId + " for changes in " + (System.currentTimeMillis() - time) + "ms");
 	}
 
 	@Override


### PR DESCRIPTION
When I added periodic disk scanning for contests I added tracing so that I could confirm it was happening and see how long it was taking each time, especially on large contests. I've never seen more than 10-20ms in dev or prod and the constant tracing even when 'nothing is happening' is annoying and adds up if you leave the contest running, so I'm removing it.