### PR TITLE
Remove getFiles() pattern

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
@@ -72,13 +72,6 @@ public interface ISubmission extends IContestObject {
 	File getReaction(boolean force);
 
 	/**
-	 * Returns the reaction video.
-	 *
-	 * @return the reaction video
-	 */
-	File[] getReactions(boolean force);
-
-	/**
 	 * Return the URL to the reaction video
 	 *
 	 * @return

--- a/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ITeam.java
@@ -81,13 +81,6 @@ public interface ITeam extends IContestObject, IPosition {
 	File getPhoto(int width, int height, boolean force);
 
 	/**
-	 * The registration photos.
-	 *
-	 * @return the photo files
-	 */
-	File[] getPhotos(boolean force);
-
-	/**
 	 * The registration photo.
 	 *
 	 * @return the photo
@@ -109,13 +102,6 @@ public interface ITeam extends IContestObject, IPosition {
 	File getVideo(boolean force);
 
 	/**
-	 * The registration video.
-	 *
-	 * @return the video file
-	 */
-	File[] getVideos(boolean force);
-
-	/**
 	 * The disk backup.
 	 *
 	 * @return the backup files
@@ -128,13 +114,6 @@ public interface ITeam extends IContestObject, IPosition {
 	 * @return the backup file
 	 */
 	File getBackup(boolean force);
-
-	/**
-	 * The disk backup.
-	 *
-	 * @return the backup files
-	 */
-	File[] getBackups(boolean force);
 
 	/**
 	 * The key log
@@ -151,13 +130,6 @@ public interface ITeam extends IContestObject, IPosition {
 	File getKeyLog(boolean force);
 
 	/**
-	 * The key log.
-	 *
-	 * @return the key log files
-	 */
-	File[] getKeylogs(boolean force);
-
-	/**
 	 * The tool usage data.
 	 *
 	 * @return the tool usage data files
@@ -170,13 +142,6 @@ public interface ITeam extends IContestObject, IPosition {
 	 * @return the tool usage data file
 	 */
 	File getToolData(boolean force);
-
-	/**
-	 * The tool usage data.
-	 *
-	 * @return the tool usage data files
-	 */
-	File[] getToolDatas(boolean force);
 
 	/**
 	 * The desktop stream.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -362,15 +362,6 @@ public abstract class ContestObject implements IContestObject {
 		}
 	}
 
-	protected File[] getFiles(FileReferenceList list, String property, boolean force) {
-		int size = list.size();
-		File[] files = new File[size];
-		for (int i = 0; i < size; i++) {
-			files[i] = getFile(list.get(i), property, force);
-		}
-		return files;
-	}
-
 	public interface ReferenceMatcher {
 		public FileReference getBestMatch(FileReferenceList list);
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -76,11 +76,6 @@ public class Submission extends TimedEvent implements ISubmission {
 	}
 
 	@Override
-	public File[] getReactions(boolean force) {
-		return getFiles(reaction, REACTION, force);
-	}
-
-	@Override
 	public String getReactionURL() {
 		if (reaction == null || reaction.isEmpty())
 			return null;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -128,11 +128,6 @@ public class Team extends ContestObject implements ITeam {
 		return getFile(getBestFileReference(photo, new ImageSizeFit(width, height)), PHOTO, force);
 	}
 
-	@Override
-	public File[] getPhotos(boolean force) {
-		return getFiles(photo, PHOTO, force);
-	}
-
 	public void setPhoto(FileReferenceList list) {
 		photo = list;
 	}
@@ -153,11 +148,6 @@ public class Team extends ContestObject implements ITeam {
 	}
 
 	@Override
-	public File[] getVideos(boolean force) {
-		return getFiles(video, VIDEO, force);
-	}
-
-	@Override
 	public FileReferenceList getBackup() {
 		return backup;
 	}
@@ -165,11 +155,6 @@ public class Team extends ContestObject implements ITeam {
 	@Override
 	public File getBackup(boolean force) {
 		return getFile(backup.first(), BACKUP, force);
-	}
-
-	@Override
-	public File[] getBackups(boolean force) {
-		return getFiles(backup, BACKUP, force);
 	}
 
 	public void setBackup(FileReferenceList list) {
@@ -186,11 +171,6 @@ public class Team extends ContestObject implements ITeam {
 		return getFile(keylog.first(), KEY_LOG, force);
 	}
 
-	@Override
-	public File[] getKeylogs(boolean force) {
-		return getFiles(keylog, KEY_LOG, force);
-	}
-
 	public void setKeyLog(FileReferenceList list) {
 		keylog = list;
 	}
@@ -203,11 +183,6 @@ public class Team extends ContestObject implements ITeam {
 	@Override
 	public File getToolData(boolean force) {
 		return getFile(tooldata.first(), TOOL_DATA, force);
-	}
-
-	@Override
-	public File[] getToolDatas(boolean force) {
-		return getFiles(tooldata, TOOL_DATA, force);
 	}
 
 	public void setToolData(FileReferenceList list) {


### PR DESCRIPTION
I'm not sure when this pattern was added (when file references were added and could include multiple files?), but ContestObject.getFiles() is used by a bunch of file reference properties, none of which are then used.

I don't think it's a good pattern to force all file references of a property to be downloaded at once. (the playback contest does this, but with targeted comparisons) It is not consistent or done with any other file references and just complicates the API, so removing this.