### PR TITLE
Initial file reference tag support - group logos

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IGroup.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IGroup.java
@@ -54,12 +54,12 @@ public interface IGroup extends IContestObject {
 	 *
 	 * @return the logo
 	 */
-	File getLogo(int width, int height, boolean force);
+	File getLogo(int width, int height, String tag, boolean force);
 
 	/**
 	 * The logo of the group.
 	 *
 	 * @return the logo
 	 */
-	BufferedImage getLogoImage(int width, int height, boolean forceLoad, boolean resizeToFit);
+	BufferedImage getLogoImage(int width, int height, String tag, boolean forceLoad, boolean resizeToFit);
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ISubmission.java
@@ -79,13 +79,6 @@ public interface ISubmission extends IContestObject {
 	String getReactionURL();
 
 	/**
-	 * Return the URLs to the reaction videos
-	 *
-	 * @return
-	 */
-	String[] getReactionURLs();
-
-	/**
 	 * Returns the contest time relative to the start of the contest, in ms.
 	 *
 	 * @return the contest time

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -117,7 +117,8 @@ public abstract class ContestSource {
 	 * @return
 	 * @throws IOException
 	 */
-	public File getFile(IContestObject obj, FileReference ref, String property) throws Exception {
+	public File getFile(IContestObject.ContestType type, String id, FileReference ref, String property)
+			throws Exception {
 		return null;
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -310,15 +310,15 @@ public class DiskContestSource extends ContestSource {
 	}
 
 	@Override
-	public File getFile(IContestObject obj, FileReference ref, String property) throws Exception {
-		if (obj == null)
+	public File getFile(ContestType type, String id, FileReference ref, String property) throws Exception {
+		if (type == null || id == null)
 			return null;
 
 		if (ref.file != null)
 			return ref.file;
 
 		// use the pattern to find the right folder
-		FilePattern pattern = getLocalPattern(obj.getType(), obj.getId(), property);
+		FilePattern pattern = getLocalPattern(type, id, property);
 
 		File folder = root;
 		if (pattern.folder != null)
@@ -336,7 +336,7 @@ public class DiskContestSource extends ContestSource {
 		}
 
 		// otherwise, assume the default file name or try a new one if that is taken
-		return getNewFile(obj.getType(), obj.getId(), property, ref);
+		return getNewFile(type, id, property, ref);
 	}
 
 	/**
@@ -514,8 +514,18 @@ public class DiskContestSource extends ContestSource {
 				FileReference ref = new FileReference();
 				String name = st[0];
 				ref.filename = name;
-				if (name != null && name.length() > 0)
+				if (name != null && name.length() > 0) {
 					ref.file = new File(folder, name);
+
+					List<String> tags = new ArrayList<>(FileReference.KNOWN_TAGS.length);
+					for (String t : FileReference.KNOWN_TAGS) {
+						if (name.contains(t))
+							tags.add(t);
+					}
+
+					if (!list.isEmpty())
+						ref.tags = tags.toArray(new String[0]);
+				}
 				if (st[1] != null && !st[1].isEmpty())
 					ref.href = st[1];
 				ref.mime = st[2];

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -259,8 +259,8 @@ public class RESTContestSource extends DiskContestSource {
 	}
 
 	@Override
-	public File getFile(IContestObject obj, FileReference ref, String property) throws Exception {
-		File file = super.getFile(obj, ref, property);
+	public File getFile(ContestType type, String id, FileReference ref, String property) throws Exception {
+		File file = super.getFile(type, id, ref, property);
 
 		return downloadIfNecessary(ref, file);
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
@@ -2,10 +2,16 @@ package org.icpc.tools.contest.model.internal;
 
 import java.io.File;
 import java.lang.ref.SoftReference;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 
 public class FileReference {
+	public static final String TAG_LIGHT = "light";
+	public static final String TAG_DARK = "dark";
+	public static final String[] KNOWN_TAGS = new String[] { TAG_LIGHT, TAG_DARK };
+
 	public String mime;
 	public String href = null;
 	public File file;
@@ -14,6 +20,7 @@ public class FileReference {
 	public String etag;
 	public int width = -1;
 	public int height = -1;
+	public String[] tags;
 	public SoftReference<Object> data;
 
 	public FileReference() {
@@ -26,6 +33,17 @@ public class FileReference {
 		height = obj.getInt("height");
 		width = obj.getInt("width");
 		filename = obj.getString("filename");
+
+		if (filename != null) {
+			List<String> list = new ArrayList<>(KNOWN_TAGS.length);
+			for (String t : KNOWN_TAGS) {
+				if (filename.contains(t))
+					list.add(t);
+			}
+
+			if (!list.isEmpty())
+				tags = list.toArray(new String[0]);
+		}
 	}
 
 	public String getURL() {
@@ -40,6 +58,10 @@ public class FileReference {
 		return height;
 	}
 
+	public String[] getTags() {
+		return tags;
+	}
+
 	protected String getJSON() {
 		// if (file == null)
 		// return "{\"href\":\"" + href + "\"}";
@@ -52,6 +74,18 @@ public class FileReference {
 			sb.append(",\"width\":" + width);
 		if (height > 0)
 			sb.append(",\"height\":" + height);
+		if (tags != null && tags.length > 0) {
+			StringBuilder sb2 = new StringBuilder();
+			boolean first = true;
+			for (String s : tags) {
+				if (!first)
+					sb2.append(",");
+				sb2.append("\"" + s + "\"");
+				first = false;
+
+			}
+			sb.append(",\"tags\":[" + sb2.toString() + "]");
+		}
 		sb.append("}");
 		return sb.toString();
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Group.java
@@ -63,13 +63,13 @@ public class Group extends ContestObject implements IGroup {
 	}
 
 	@Override
-	public File getLogo(int width, int height, boolean force) {
-		return getFile(getBestFileReference(logo, new ImageSizeFit(width, height)), LOGO, force);
+	public File getLogo(int width, int height, String tag, boolean force) {
+		return getFile(LOGO, logo, width, height, tag, force);
 	}
 
 	@Override
-	public BufferedImage getLogoImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(LOGO, logo, width, height, forceLoad, resizeToFit);
+	public BufferedImage getLogoImage(int width, int height, String variant, boolean forceLoad, boolean resizeToFit) {
+		return getRefImage(LOGO, logo, width, height, variant, forceLoad, resizeToFit);
 	}
 
 	public FileReferenceList getLogo() {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -196,11 +196,13 @@ public class Info extends ContestObject implements IInfo {
 	}
 
 	public File getLogo(int width, int height, boolean force) {
-		return getFile(getBestFileReference(logo, new ImageSizeFit(width, height)), LOGO, force);
+		String tag = null;
+		return getFile(LOGO, logo, width, height, tag, force);
 	}
 
 	public BufferedImage getLogoImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(LOGO, logo, width, height, forceLoad, resizeToFit);
+		String tag = null;
+		return getRefImage(LOGO, logo, width, height, tag, forceLoad, resizeToFit);
 	}
 
 	public void setBanner(FileReferenceList list) {
@@ -212,11 +214,13 @@ public class Info extends ContestObject implements IInfo {
 	}
 
 	public File getBanner(int width, int height, boolean force) {
-		return getFile(getBestFileReference(banner, new ImageSizeFit(width, height)), BANNER, force);
+		String tag = null;
+		return getFile(BANNER, banner, width, height, tag, force);
 	}
 
 	public BufferedImage getBannerImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(BANNER, banner, width, height, forceLoad, resizeToFit);
+		String tag = null;
+		return getRefImage(BANNER, banner, width, height, tag, forceLoad, resizeToFit);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -103,12 +103,14 @@ public class Organization extends ContestObject implements IOrganization {
 
 	@Override
 	public File getLogo(int width, int height, boolean force) {
-		return getFile(getBestFileReference(logo, new ImageSizeFit(width, height)), LOGO, force);
+		String tag = null;
+		return getFile(LOGO, logo, width, height, tag, force);
 	}
 
 	@Override
 	public BufferedImage getLogoImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(LOGO, logo, width, height, forceLoad, resizeToFit);
+		String tag = null;
+		return getRefImage(LOGO, logo, width, height, tag, forceLoad, resizeToFit);
 	}
 
 	@Override
@@ -122,12 +124,12 @@ public class Organization extends ContestObject implements IOrganization {
 
 	@Override
 	public File getCountryFlag(int width, int height, boolean force) {
-		return getFile(getBestFileReference(countryFlag, new ImageSizeFit(width, height)), COUNTRY_FLAG, force);
+		return getFile(COUNTRY_FLAG, countryFlag, width, height, null, force);
 	}
 
 	@Override
 	public BufferedImage getCountryFlagImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(COUNTRY_FLAG, countryFlag, width, height, forceLoad, resizeToFit);
+		return getRefImage(COUNTRY_FLAG, countryFlag, width, height, null, forceLoad, resizeToFit);
 	}
 
 	@Override
@@ -141,13 +143,12 @@ public class Organization extends ContestObject implements IOrganization {
 
 	@Override
 	public File getCountrySubdivisionFlag(int width, int height, boolean force) {
-		return getFile(getBestFileReference(countrySubdivisionFlag, new ImageSizeFit(width, height)),
-				COUNTRY_SUBDIVISION_FLAG, force);
+		return getFile(COUNTRY_SUBDIVISION_FLAG, countrySubdivisionFlag, width, height, null, force);
 	}
 
 	@Override
 	public BufferedImage getCountrySubdivisionFlagImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(COUNTRY_SUBDIVISION_FLAG, countrySubdivisionFlag, width, height, forceLoad, resizeToFit);
+		return getRefImage(COUNTRY_SUBDIVISION_FLAG, countrySubdivisionFlag, width, height, null, forceLoad, resizeToFit);
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Person.java
@@ -109,12 +109,12 @@ public class Person extends ContestObject implements IPerson {
 
 	@Override
 	public File getPhoto(int width, int height, boolean force) {
-		return getFile(getBestFileReference(photo, new ImageSizeFit(width, height)), PHOTO, force);
+		return getFile(PHOTO, photo, width, height, null, force);
 	}
 
 	@Override
 	public BufferedImage getPhotoImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(PHOTO, photo, width, height, forceLoad, resizeToFit);
+		return getRefImage(PHOTO, photo, width, height, null, forceLoad, resizeToFit);
 	}
 
 	public void setPhoto(FileReferenceList list) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -84,14 +84,6 @@ public class Submission extends TimedEvent implements ISubmission {
 	}
 
 	@Override
-	public String[] getReactionURLs() {
-		if (reaction == null || reaction.isEmpty())
-			return null;
-
-		return reaction.getHrefs();
-	}
-
-	@Override
 	public File resolveFileReference(String url) {
 		return FileReferenceList.resolve(url, files, reaction);
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Team.java
@@ -125,7 +125,7 @@ public class Team extends ContestObject implements ITeam {
 
 	@Override
 	public File getPhoto(int width, int height, boolean force) {
-		return getFile(getBestFileReference(photo, new ImageSizeFit(width, height)), PHOTO, force);
+		return getFile(PHOTO, photo, width, height, null, force);
 	}
 
 	public void setPhoto(FileReferenceList list) {
@@ -134,7 +134,7 @@ public class Team extends ContestObject implements ITeam {
 
 	@Override
 	public BufferedImage getPhotoImage(int width, int height, boolean forceLoad, boolean resizeToFit) {
-		return getRefImage(PHOTO, photo, width, height, forceLoad, resizeToFit);
+		return getRefImage(PHOTO, photo, width, height, null, forceLoad, resizeToFit);
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/resolver/TeamAwardPresentation.java
@@ -30,6 +30,7 @@ import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IStanding;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.internal.Award;
+import org.icpc.tools.contest.model.internal.FileReference;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.AwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
 import org.icpc.tools.contest.model.util.Messages;
@@ -251,7 +252,8 @@ public class TeamAwardPresentation extends AbstractICPCPresentation {
 			if (hasGroupAward && groupIds != null && groupIds.length == 1) {
 				IGroup g = contest.getGroupById(groupIds[0]);
 				if (g != null) {
-					c.groupLogo = g.getLogoImage(height / 5, height / 5, true, true);
+					c.groupLogo = g.getLogoImage(height / 5, height / 5,
+							isLightMode() ? FileReference.TAG_LIGHT : FileReference.TAG_DARK, true, true);
 				}
 			}
 		}


### PR DESCRIPTION
Initial implementation of the file reference tag support as per the draft spec: file references can have one or more string tags, and clients can use this to filter to known tags.

Notes:
- The spec may still separate tags in the filename by '_' or '.', we can easily fix that later.
- I simplified ContestSource.getFile() here because of code overlap although it's not directly related - source just needs to know the type and id, not the entire object.
- I got rid of ContestObject.ReferenceMatcher/ImageSizeFit and made getBestFileReference() private. My original thought years ago was that we could expose multiple ways of picking the 'best' file, but we never used/needed it.
- I updated ContestObject.getFile() to match getRefImage(), and added an optional tag.
- Team, person photo just pass null for the tag - I don't think we'll ever need light/dark for photos.
- I updated group logo and the one use in TeamAwardPresentation to show the API and client change for tags. I expect to do the same thing for logos and banner in info (contest) and organization, but this PR is already big enough so that will come next.

First part of #1228.