### PR TITLE
Include spares when reseting contest floor origin

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/FloorMap.java
@@ -1015,6 +1015,12 @@ public class FloorMap {
 			((Printer) printer).setLocation(printer.getX() - ox, printer.getY() - oy);
 		}
 
+		if (mapInfo != null && mapInfo.getSpareTeams() != null) {
+			for (ITeam t : mapInfo.getSpareTeams()) {
+				((Team) t).setLocation(t.getX() - ox, t.getY() - oy, t.getRotation());
+			}
+		}
+
 		computeAisleIntersections();
 	}
 }


### PR DESCRIPTION
When a floor map is saved to disk it automatically moves the origin to top left, just to pretty-print values and have 0,0 at the top left. Unfortunately it was missing spares (empty desks) when doing this, so they were always 'off the map'.