### PR TITLE
Remove contest location docs (moved to spec)

### DIFF
--- a/doc/spec-extensions.md
+++ b/doc/spec-extensions.md
@@ -69,9 +69,6 @@ Additional JSON attributes of contest objects:
 | Name                 | Type          | Description
 | :------------------- | :------------ | :----------
 | time\_multiplier     | number        | The amount time is sped up, e.g. `2.5` for a contest replaying at 2.5x original speed.
-| location             | object        | JSON object as specified in the rows below.
-| location.latitude    | number        | Latitude in degrees. Required iff location is present.
-| location.longitude   | number        | Longitude in degrees. Required iff location is present.
 
 #### Examples
 


### PR DESCRIPTION
Contest location was moved into the spec, we no longer need to document it.