### PR TITLE
Improve mime type handling, especially for video

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
+++ b/CDS/src/org/icpc/tools/cds/util/HttpHelper.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.util.Enumeration;
 
 import org.icpc.tools.contest.model.feed.JSONEncoder;
+import org.icpc.tools.contest.model.internal.MimeUtil;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.HttpServletRequest;
@@ -120,14 +121,7 @@ public class HttpHelper {
 	}
 
 	private static void setCommonHeaders(String name, HttpServletResponse response) {
-		if (name.endsWith(".jpg") || name.endsWith(".jpeg"))
-			response.setContentType("image/jpeg");
-		else if (name.endsWith(".txt") || name.endsWith(".tsv") || name.endsWith(".yaml") || name.endsWith(".xml"))
-			response.setContentType("text/plain");
-		else if (name.endsWith(".png"))
-			response.setContentType("image/png");
-		else if (name.endsWith(".svg"))
-			response.setContentType("image/svg+xml");
+		response.setContentType(MimeUtil.getMimeType(name));
 
 		response.setHeader("Cache-Control", "max-age=1800"); // 30 minutes
 		response.setHeader("Content-Disposition", "inline; filename=\"" + name + "\"");

--- a/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
+++ b/CDS/src/org/icpc/tools/cds/video/containers/MPEGTSHandler.java
@@ -20,12 +20,12 @@ public class MPEGTSHandler extends VideoStreamHandler {
 
 	@Override
 	protected String getFileExtension() {
-		return "m2ts";
+		return "ts";
 	}
 
 	@Override
 	protected String getMimeType() {
-		return "video/m2ts";
+		return "video/mp2t";
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -43,6 +43,7 @@ import org.icpc.tools.contest.model.internal.FileReferenceList;
 import org.icpc.tools.contest.model.internal.Group;
 import org.icpc.tools.contest.model.internal.IContestModifier;
 import org.icpc.tools.contest.model.internal.Info;
+import org.icpc.tools.contest.model.internal.MimeUtil;
 import org.icpc.tools.contest.model.internal.Organization;
 import org.icpc.tools.contest.model.internal.Person;
 import org.icpc.tools.contest.model.internal.Problem;
@@ -76,7 +77,7 @@ public class DiskContestSource extends ContestSource {
 
 	private static final String[] LOGO_EXTENSIONS = new String[] { "png", "svg", "jpg", "jpeg" };
 	private static final String[] PHOTO_EXTENSIONS = new String[] { "jpg", "jpeg", "png", "svg" };
-	private static final String[] VIDEO_EXTENSIONS = new String[] { "m2ts", "ogg", "flv", };
+	private static final String[] VIDEO_EXTENSIONS = new String[] { "ts", "m2ts", "ogg", "flv" };
 
 	protected File eventFeedFile;
 	private File root;
@@ -373,7 +374,7 @@ public class DiskContestSource extends ContestSource {
 				}
 			}
 			if (ext == null && fileRef.mime != null)
-				ext = getExtension(fileRef.mime);
+				ext = MimeUtil.getExtension(fileRef.mime);
 		}
 
 		// fallback to default filename and extension as necessary
@@ -457,7 +458,7 @@ public class DiskContestSource extends ContestSource {
 			ref.etag = etag;
 			ref.href = href;
 			ref.file = file;
-			ref.mime = getMimeType(ref.filename);
+			ref.mime = MimeUtil.getMimeType(ref.filename);
 			ref.lastModified = file.lastModified();
 			ref.updateTags();
 			readImageSize(ref);
@@ -697,68 +698,6 @@ public class DiskContestSource extends ContestSource {
 		return ref;
 	}
 
-	/**
-	 * Return mime-type based on filename.
-	 *
-	 * @param name
-	 * @return
-	 */
-	private static String getMimeType(String name) {
-		String name2 = name.toLowerCase();
-		if (name2.endsWith(".zip"))
-			return "application/zip";
-		else if (name2.endsWith(".png"))
-			return "image/png";
-		else if (name2.endsWith(".jpg") || name2.endsWith(".jpeg"))
-			return "image/jpeg";
-		else if (name2.endsWith(".svg"))
-			return "image/svg+xml";
-		else if (name2.endsWith(".m2ts"))
-			return "video/m2ts";
-		else if (name2.endsWith(".ogg"))
-			return "video/ogg";
-		else if (name2.endsWith(".flv"))
-			return "video/x-flv";
-		else if (name2.endsWith(".txt"))
-			return "text/plain";
-		else if (name2.endsWith(".log"))
-			return "text/plain";
-		else if (name2.endsWith(".pdf"))
-			return "application/pdf";
-		return null;
-	}
-
-	/**
-	 * Return filename based on mime-type.
-	 *
-	 * @param mimeType
-	 * @return
-	 */
-	private static String getExtension(String mimeType) {
-		if (mimeType == null)
-			return null;
-
-		if (mimeType.equals("application/zip"))
-			return "zip";
-		else if (mimeType.equals("image/png"))
-			return "png";
-		else if (mimeType.equals("image/jpeg"))
-			return "jpg";
-		else if (mimeType.equals("image/svg+xml"))
-			return "svg";
-		else if (mimeType.equals("video/MP2T") || mimeType.equals("video/m2ts"))
-			return "m2ts";
-		else if (mimeType.equals("video/ogg"))
-			return "ogg";
-		else if (mimeType.equals("video/x-flv"))
-			return "flv";
-		else if (mimeType.equals("text/plain"))
-			return "txt";
-		else if (mimeType.equals("application/pdf"))
-			return "pdf";
-		return null;
-	}
-
 	protected static void readImageSize(FileReference ref) {
 		File file = ref.file;
 		String name = file.getName().toLowerCase();
@@ -787,7 +726,7 @@ public class DiskContestSource extends ContestSource {
 	protected static FileReference readMetadata(File file) {
 		FileReference ref = new FileReference();
 		ref.filename = file.getName();
-		ref.mime = getMimeType(ref.filename);
+		ref.mime = MimeUtil.getMimeType(ref.filename);
 		ref.file = file;
 		ref.lastModified = file.lastModified();
 		ref.updateTags();

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/MimeUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/MimeUtil.java
@@ -1,0 +1,78 @@
+package org.icpc.tools.contest.model.internal;
+
+/**
+ * Helper class to deal with mime types and associated file extensions.
+ */
+public class MimeUtil {
+	/**
+	 * Return the mime-type based on filename.
+	 *
+	 * @param name
+	 * @return
+	 */
+	public static String getMimeType(String name) {
+		int ind = name.lastIndexOf(".");
+		if (ind < 0)
+			return null;
+
+		String ext = name.substring(ind + 1).toLowerCase();
+
+		if (ext.equals("zip"))
+			return "application/zip";
+		else if (ext.equals("png"))
+			return "image/png";
+		else if (ext.equals("jpg") || ext.equals("jpeg"))
+			return "image/jpeg";
+		else if (ext.equals("svg"))
+			return "image/svg+xml";
+		else if (ext.equals("ts"))
+			return "video/mp2t";
+		else if (ext.equals("m2ts"))
+			return "video/m2ts";
+		else if (ext.equals("ogg"))
+			return "video/ogg";
+		else if (ext.equals("flv"))
+			return "video/x-flv";
+		else if (ext.equals("txt") || ext.equals("log") || ext.equals("tsv") || ext.equals("yaml") || ext.equals("xml"))
+			return "text/plain";
+		else if (ext.equals("pdf"))
+			return "application/pdf";
+		return null;
+	}
+
+	/**
+	 * Return filename extensions based on mime-type.
+	 *
+	 * @param mimeType
+	 * @return
+	 */
+	public static String getExtension(String mimeType) {
+		if (mimeType == null)
+			return null;
+
+		switch (mimeType) {
+			case ("application/zip"):
+				return "zip";
+			case ("image/png"):
+				return "png";
+			case ("image/jpeg"):
+			case ("image/jpg"):
+				return "jpg";
+			case ("image/svg+xml"):
+				return "svg";
+			case ("video/mp2t"):
+				return "ts";
+			case ("video/m2ts"):
+				return "m2ts";
+			case ("video/ogg"):
+				return "ogg";
+			case ("video/x-flv"):
+				return "flv";
+			case ("text/plain"):
+				return "txt";
+			case ("application/pdf"):
+				return "pdf";
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
Fixes three things:

1. Move the existing utility functions out of DiskContestSource to create a reusable mime type utility class, to avoid some of the duplication and differences in behaviour.

2. The mime type wasn't being set when downloading reaction videos - but using the new util fixes this.

3. When we started supporting MPEG-TS there was conflicting information about the correct file extension and mime type, and based on google AI and video.js we got it wrong:

```
   MPEG Transport Stream (MPEG 2 transport stream) <-- this is what we actually support
   File extension: .ts
   Mime type: video/mp2t
   188-byte packets

   MPEG-2 Transport Stream <-- variant used by Blu-ray & AVCHD disks
   File extension: .m2ts
   Mime type: video/m2ts
   192-byte packets (4 bytes added to help file seeking)
```

   This switches us to use the file extension and mime type of the first.