### PR TITLE
Reaction video tagging

### DIFF
--- a/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
+++ b/CDS/src/org/icpc/tools/cds/video/ReactionVideoRecorder.java
@@ -157,9 +157,9 @@ public class ReactionVideoRecorder {
 				info.stream[count] = streamsWebcam.get(i);
 				String extension = va.getStream(info.stream[count]).getFileExtension();
 				if (numWebcam > 1)
-					info.file[count] = new File(submissionDir, "reaction-" + WEBCAM + (i + 1) + "." + extension);
+					info.file[count] = new File(submissionDir, "reaction." + WEBCAM + (i + 1) + "." + extension);
 				else
-					info.file[count] = new File(submissionDir, "reaction-" + WEBCAM + "." + extension);
+					info.file[count] = new File(submissionDir, "reaction." + WEBCAM + "." + extension);
 				count++;
 			}
 		}
@@ -170,9 +170,9 @@ public class ReactionVideoRecorder {
 				info.stream[count] = streamsDesktop.get(i);
 				String extension = va.getStream(info.stream[count]).getFileExtension();
 				if (numDesktop > 1)
-					info.file[count] = new File(submissionDir, "reaction-" + DESKTOP + (i + 1) + "." + extension);
+					info.file[count] = new File(submissionDir, "reaction." + DESKTOP + (i + 1) + "." + extension);
 				else
-					info.file[count] = new File(submissionDir, "reaction-" + DESKTOP + "." + extension);
+					info.file[count] = new File(submissionDir, "reaction." + DESKTOP + "." + extension);
 				count++;
 			}
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
@@ -10,7 +10,9 @@ import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 public class FileReference {
 	public static final String TAG_LIGHT = "light";
 	public static final String TAG_DARK = "dark";
-	public static final String[] KNOWN_TAGS = new String[] { TAG_LIGHT, TAG_DARK };
+	public static final String TAG_WEBCAM = "webcam";
+	public static final String TAG_DESKTOP = "desktop";
+	public static final String[] KNOWN_TAGS = new String[] { TAG_LIGHT, TAG_DARK, TAG_WEBCAM, TAG_DESKTOP };
 
 	public String mime;
 	public String href = null;


### PR DESCRIPTION
We record webcam and desktop for reactions videos, but there is only one reaction property, so we've been serving desktop as one file and webcam as another, i.e.:

{"id":"2",... "reaction":[{"href":"contests/baku-live/submissions/2/reaction-webcam","filename":"reaction-webcam.m2ts","mime":"video/m2ts"},{"href":"contests/baku-live/submissions/2/reaction-desktop","filename":"reaction-desktop.m2ts","mime":"video/m2ts"}]}

The only way you could tell these part was based on the filename or url - but now the spec has tags, which are a much better way to differentiate them.

This PR makes two changes: renaming the files to use '.' instead of '-' to match the variant format in the draft spec, and adding support for these tags. The new output looks like:

{"id":"2",... "reaction":[{"href":"contests/baku-live/submissions/2/reaction.webcam","filename":"reaction.webcam.ts","mime":"video/mp2t","tags":["webcam"]},{"href":"contests/baku-live/submissions/2/reaction.desktop","filename":"reaction.desktop.ts","mime":"video/mp2t","tags":["desktop"]}]}

(file extension and mimetype already changed via PR #1236)