### PR TITLE
URL account tokens for reaction videos

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -13,6 +13,7 @@ import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
 import org.icpc.tools.cds.service.ExecutorListener;
+import org.icpc.tools.cds.util.HttpHelper;
 import org.icpc.tools.cds.util.PlaybackContest;
 import org.icpc.tools.cds.video.VideoAggregator;
 import org.icpc.tools.cds.video.VideoAggregator.ConnectionMode;
@@ -526,17 +527,9 @@ public class ConfiguredContest {
 		if (contest == null)
 			loadContest();
 
-		IAccount account = PUBLIC_ACCOUNT;
-		String user = request.getRemoteUser();
-		if (user != null) {
-			List<IAccount> accounts = CDSConfig.getInstance().getAccounts();
-			for (IAccount acc : accounts) {
-				if (user.equals(acc.getUsername())) {
-					account = acc;
-				}
-			}
-		}
-
+		IAccount account = HttpHelper.getAccountFromRequest(request);
+		if (account == null)
+			account = PUBLIC_ACCOUNT;
 		return getContestForAccount(account);
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
@@ -17,6 +17,7 @@ public class JSONEncoder {
 	}
 
 	private static final ThreadLocal<String> local = new ThreadLocal<>();
+	private static final ThreadLocal<String> local2 = new ThreadLocal<>();
 	private static String DEFAULT_HOST = "http://cds";
 	static {
 		try {
@@ -214,11 +215,25 @@ public class JSONEncoder {
 		local.set(host);
 	}
 
+	public static void setAccountToken(String token) {
+		local2.set(token);
+	}
+
 	public String replace(String s) {
 		String host = local.get();
 		if (host == null)
 			host = DEFAULT_HOST;
-		return s.replace("<host>", host);
+		String t = s.replace("<host>", host);
+
+		int ind = t.indexOf("\"href\":\"");
+		if (ind > 0) {
+			int ind2 = t.indexOf("\"", ind + 10);
+			if (ind2 > 0 && local2.get() != null) {
+				t = t.substring(0, ind2) + "?token=" + local2.get() + t.substring(ind2);
+			}
+		}
+
+		return t;
 	}
 
 	public void encodeValue(int value) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -148,7 +148,7 @@ public class Submission extends TimedEvent implements ISubmission {
 		props.addLiteralString(LANGUAGE_ID, languageId);
 		props.addLiteralString(ENTRY_POINT, entryPoint);
 		props.addFileRef(FILES, files);
-		props.addFileRef(REACTION, reaction);
+		props.addFileRefSubs(REACTION, reaction);
 		super.getProperties(props);
 	}
 


### PR DESCRIPTION
Adds account-specific token parameters to reaction video downloads. Any client using the url as-is (without basic auth) can download the file as the given user. This allows (e.g.) web-based clients to pass the url to players like video.js that support https but not basic auth.

The token is a one-way hash based on the account user and password. It is only implemented for reaction videos for now to get some use and feedback, but could be used for other 'file downloads' as well. Since all traffic is via https it could probably use a simpler algorithm, but this can easily be changed later.

I moved the existing static method used to determine which account is making any request to HttpHelper since it is not contest-specific, and added the new token helpers there.

Example of reaction video in /submissions or event-feed after this change: {"href":"contests/baku-live/submissions/1/reaction.webcam?token=DSjPuOj7OL9HLxEtMe0a5Mrl1vGCz2N2cO1bidDA=","filename":"reaction.webcam.m2ts","mime":"video/m2ts","tags":["webcam"]}],"contest_time":"0:07:47.704","time":"2025-05-26T09:55:53.702-04:00"}