### PR TITLE
Handle null values for toTeamIds

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -74,7 +74,10 @@ public class Clarification extends TimedEvent implements IClarification {
 			fromTeamId = (String) value;
 			return true;
 		} else if (TO_TEAM_ID.equals(name)) {
-			toTeamIds = new String[] { (String) value };
+			if (value == null || "null".equals(value))
+				toTeamIds = null;
+			else
+				toTeamIds = new String[] { (String) value };
 			return true;
 		} else if (TO_TEAM_IDS.equals(name)) {
 			if (value == null || "null".equals(value))


### PR DESCRIPTION
When sending a broadcast (2023_06 spec), `to_team_id` is null, and the code creates `[null]` (an array with a `null` object) for `to_team_ids`, causing verification failure with:

`Clarification to unknown team null` or `Clarification between teams`

This is introduced from 39ac2647772a52aee5e3cce886a45b66bd7fa977

So far, I've only observed that the resolver will be notified of invalid feeds, but this doesn't affect usage. However, there may be other potential impacts since the code uses the array length as some logic

<details>

```
Invalid clarifications (16): Clarification to unknown team null
Invalid clarifications (17): Clarification to unknown team null
Invalid clarifications (17): Clarification between teams
Invalid clarifications (19): Clarification to unknown team null
Invalid clarifications (19): Clarification between teams
Invalid clarifications (21): Clarification to unknown team null
Invalid clarifications (21): Clarification between teams
Invalid clarifications (23): Clarification to unknown team null
Invalid clarifications (23): Clarification between teams
Invalid clarifications (24): Clarification to unknown team null
Invalid clarifications (24): Clarification between teams
Invalid clarifications (26): Clarification to unknown team null
Invalid clarifications (26): Clarification between teams
Invalid clarifications (28): Clarification to unknown team null
Invalid clarifications (28): Clarification between teams
Invalid clarifications (29): Clarification to unknown team null
Invalid clarifications (29): Clarification between teams
Invalid clarifications (31): Clarification to unknown team null
Invalid clarifications (31): Clarification between teams
Invalid clarifications (33): Clarification to unknown team null
Invalid clarifications (33): Clarification between teams
Invalid clarifications (35): Clarification to unknown team null
Invalid clarifications (35): Clarification between teams
Invalid clarifications (37): Clarification to unknown team null
Invalid clarifications (37): Clarification between teams
Invalid clarifications (38): Clarification to unknown team null
Invalid clarifications (38): Clarification between teams
Invalid clarifications (40): Clarification to unknown team null
Invalid clarifications (40): Clarification between teams
```

</details>