### PR TITLE
Add compatibility section to main readme

### DIFF
--- a/CDS/README.md
+++ b/CDS/README.md
@@ -37,7 +37,7 @@ regarding CDS services can be found on the [CLI Contest Data Package specificati
 
 Note: many of the data access functions provided by the CDS require the use of a compatible
 _Contest Control System_ (CCS) for running the contest. See the _Competitive Learning Institute_'s
-[Contest Control System specification](https://ccs-specs.icpc.io/ccs_system_requirements)
+[Contest Control System specification](https://ccs-specs.icpc.io)
 for details. See the documentation for the CCS being used by your contest to determine whether it meets the CLI CCS specification.
 
 ## Using the CDS
@@ -51,7 +51,7 @@ the entire CDS can be run using the embedded Liberty server without any other to
 
 Alternatively, the CDS can be deployed on other Application Servers
 such as [Apache Tomcat](http://tomcat.apache.org/), 
-[JBoss](http://jbossas.jboss.org/) (now [WildFly](http://wildfly.org/), or
+[WildFly](http://wildfly.org/), or
 [Jetty](http://www.eclipse.org/jetty/). However, the mechanisms and requirements for deploying web applications 
 to application servers differ between servers.
 This guide does not attempt to provide tutorial details for such alternative deployments; see the Appendices and

--- a/README.md
+++ b/README.md
@@ -43,6 +43,21 @@ The most popular CCSs that have been tested and successfully used at multiple co
 * [Kattis](https://www.kattis.com)
 * [PC^2](https://pc2ccs.github.io)
 
+## Java and Contest API Version Compatibility
+
+The table below shows the minimum Java version supported by each release of the tools. Java is backward compatible so
+we'd generally recommend running on the latest LTS version.
+
+The Contest API is not 100% backward compatible, so you should match the Contest API supported by your CCS.
+However, the breakage is usually small and the tools attempt to read from older sources, so you may be able
+to use newer tools depending on your use.
+
+Version | Java Version | Contest API
+--- | --- | ---
+2.4 | Java 8 minimum | 2021_11
+2.5 | Java 11 minimum | 2022-07
+2.6 | Java 17 minimum | 2023-06 (+ draft support for upcoming 2025 spec)
+
 ## Contributing
 
 The ICPC Tools are developed, tested, and maintained by a group of ICPC volunteers. Bug reports, feature requests,


### PR DESCRIPTION
Adds a new section to the main readme showing Java/spec version compatibility to be a bit more explicit and clear.

Also fix two old/broken links in the CDS readme.