### PR TITLE
Avoid exception due to invalid bronze medal

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
@@ -156,7 +156,7 @@ public class Ranking {
 				} else
 					standingI.setRank((n + 1) + "");
 
-				if (scoring != Scoring.LIVE && i > lastBronze - 1
+				if (scoring != Scoring.LIVE && i > lastBronze - 1 && lastBronze > 0
 						&& standingI.getNumSolved() < standings[order[lastBronze - 1]].getNumSolved())
 					standingI.setPenalty(-1);
 			}

--- a/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/AwardUtil.java
@@ -513,11 +513,16 @@ public class AwardUtil {
 		if (awards != null) {
 			for (IAward a : awards)
 				if (a.getAwardType() == IAward.MEDAL && a.getId().contains("bronze")) {
-					lastBronze = 0;
+					lastBronze = 1;
 					String[] teamIds = a.getTeamIds();
 					if (teamIds != null) {
 						for (String tId : teamIds) {
-							lastBronze = Math.max(lastBronze, contest.getOrderOf(contest.getTeamById(tId)) + 1);
+							ITeam team = contest.getTeamById(tId);
+							if (team == null) {
+								Trace.trace(Trace.ERROR, "Error: Bronze medal given to team not in the contest: " + tId);
+							} else {
+								lastBronze = Math.max(lastBronze, contest.getOrderOf(team) + 1);
+							}
 						}
 					}
 				}


### PR DESCRIPTION
The fix is the '= 1' in AwardUtil - if there is a bronze medal but we can't find any of the teams in the contest, default last bronze to the first team.

Also added a clear error when this happens, and an extra check in the Ranking where it failed.

Fixes #1249.