### PR TITLE
Avoid websocket reconnect on normal disconnect

### DIFF
--- a/CDS/src/org/icpc/tools/cds/presentations/Client.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/Client.java
@@ -538,9 +538,10 @@ public class Client {
 
 	protected void disconnect() {
 		try {
-			if (session.isOpen())
-				// TODO - this appears to be hanging, and not absolutely necessary
-				session.close(new CloseReason(CloseCodes.NORMAL_CLOSURE, "Good-bye!"));
+			if (session.isOpen()) {
+				// disconnection due to communication error, make sure session is closed
+				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION, "Good-bye!"));
+			}
 		} catch (Exception e) {
 			// ignore
 		}

--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationWebSocket.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationWebSocket.java
@@ -35,7 +35,7 @@ public class PresentationWebSocket {
 		if (name == null) {
 			try {
 				Trace.trace(Trace.INFO, "Disconnecting client with no name");
-				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION, "Client is missing required name"));
+				session.close(new CloseReason(CloseCodes.CANNOT_ACCEPT, "Client is missing required name"));
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error disconnecting websocket with no name");
 			}
@@ -53,7 +53,7 @@ public class PresentationWebSocket {
 		if (uid == 0) {
 			try {
 				Trace.trace(Trace.INFO, "Disconnecting client with no uid");
-				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION, "Client is missing uid parameter"));
+				session.close(new CloseReason(CloseCodes.CANNOT_ACCEPT, "Client is missing uid parameter"));
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error disconnecting websocket with invalid uid");
 			}
@@ -64,7 +64,7 @@ public class PresentationWebSocket {
 			try {
 				Trace.trace(Trace.INFO,
 						"Disconnecting, client with uid " + Integer.toHexString(uid) + " already logged in.");
-				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION, "Client is already logged in"));
+				session.close(new CloseReason(CloseCodes.CANNOT_ACCEPT, "Client is already logged in"));
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error disconnecting websocket with existing uid");
 			}
@@ -77,7 +77,7 @@ public class PresentationWebSocket {
 			try {
 				Trace.trace(Trace.INFO,
 						"Disconnecting client " + Integer.toHexString(uid) + " with invalid version: " + version);
-				session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION,
+				session.close(new CloseReason(CloseCodes.CANNOT_ACCEPT,
 						"CDS: Client version " + version + " is incompatible with CDS"));
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error disconnecting websocket with invalid version");
@@ -99,7 +99,7 @@ public class PresentationWebSocket {
 			if (isAdmin) {
 				try {
 					Trace.trace(Trace.INFO, "Disconnecting user " + user + " with incorrect admin role");
-					session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION,
+					session.close(new CloseReason(CloseCodes.CANNOT_ACCEPT,
 							"CDS: User cannot be an admin - try staff, analyst, or public user"));
 				} catch (Exception e) {
 					Trace.trace(Trace.ERROR, "Error disconnecting websocket with invalid role");
@@ -112,8 +112,8 @@ public class PresentationWebSocket {
 					|| (IAccount.STAFF.equals(role) && !(isAdmin || isBlue))) {
 				try {
 					Trace.trace(Trace.INFO, "Disconnecting user " + user + " with insufficient role: " + role);
-					session.close(new CloseReason(CloseCodes.UNEXPECTED_CONDITION,
-							"CDS: User does not have required role: " + role));
+					session.close(
+							new CloseReason(CloseCodes.CANNOT_ACCEPT, "CDS: User does not have required role: " + role));
 				} catch (Exception e) {
 					Trace.trace(Trace.ERROR, "Error disconnecting websocket with invalid role");
 				}

--- a/PresCore/src/org/icpc/tools/client/core/BasicClient.java
+++ b/PresCore/src/org/icpc/tools/client/core/BasicClient.java
@@ -114,8 +114,11 @@ public class BasicClient {
 			Trace.trace(Trace.USER, name + " disconnected");
 			fireConnectionStateEvent(false);
 			session = null;
-			if (closeReason != null && closeReason.getCloseCode() != CloseCodes.NORMAL_CLOSURE) {
-				if (closeReason.getCloseCode() == CloseCodes.UNEXPECTED_CONDITION
+			if (closeReason != null) {
+				if (closeReason.getCloseCode() == CloseCodes.NORMAL_CLOSURE)
+					return;
+
+				if (closeReason.getCloseCode() == CloseCodes.CANNOT_ACCEPT
 						&& closeReason.getReasonPhrase().startsWith("CDS: ")) {
 					Trace.trace(Trace.ERROR, closeReason.getReasonPhrase().substring(4));
 					return;
@@ -125,6 +128,7 @@ public class BasicClient {
 			}
 
 			// reconnect
+			Trace.trace(Trace.INFO, name + " reconnecting");
 			connect();
 		}
 	}


### PR DESCRIPTION
When the resolver pings the CDS to confirm if it is an admin or regular client, the default logic automatically reconnects. Depending on conditions this can cause a race condition on the CDS and a lot of useless logging that the client is already connected.

This avoids client reconnection on a normal/expected disconnection. I've also updated the disconnection due to invalid login from UNEXPECTED_CONDITION to CANNOT_ACCEPT and made sure that the disconnection cleanup due to connection failure correctly returns uses UNEXPECTED_CONDITION (although in practice the client never sees this).

Fixes #1132.