### PR TITLE
Add timeout computing localhost and avoid when unnecessary

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/Trace.java
+++ b/ContestModel/src/org/icpc/tools/contest/Trace.java
@@ -1,7 +1,5 @@
 package org.icpc.tools.contest;
 
-import io.sentry.Sentry;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -21,7 +19,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 
-import org.icpc.tools.contest.model.internal.NetworkUtil;
+import io.sentry.Sentry;
 
 public class Trace {
 	public static final byte INFO = 0;
@@ -194,7 +192,6 @@ public class Trace {
 					+ System.getProperty("os.version") + ")");
 			writer.println("JRE: " + System.getProperty("java.vendor") + " (" + System.getProperty("java.version") + ")");
 			writer.println("Folder: " + System.getProperty("user.dir"));
-			writer.println("Host: " + NetworkUtil.getHostName() + " / " + NetworkUtil.getLocalAddress());
 			writer.println("Locale/TZ: " + Locale.getDefault().toString() + " / "
 					+ Calendar.getInstance().getTimeZone().getDisplayName());
 			if (args != null) {
@@ -208,7 +205,7 @@ public class Trace {
 			} catch (Exception e) {
 				// Sentry config might be empty.
 			}
-			writer.println("Sentry: " + (Sentry.isEnabled()? "Enabled" : "Disabled"));
+			writer.println("Sentry: " + (Sentry.isEnabled() ? "Enabled" : "Disabled"));
 			writer.println("Log started " + sdf.format(new Date()));
 			writer.println();
 			writer.flush();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/JSONEncoder.java
@@ -18,14 +18,7 @@ public class JSONEncoder {
 
 	private static final ThreadLocal<String> local = new ThreadLocal<>();
 	private static final ThreadLocal<String> local2 = new ThreadLocal<>();
-	private static String DEFAULT_HOST = "http://cds";
-	static {
-		try {
-			DEFAULT_HOST = NetworkUtil.getLocalAddress();
-		} catch (Exception e) {
-			// ignore
-		}
-	}
+	private static String DEFAULT_HOST = null;
 
 	private boolean first = true;
 	private PrintWriter pw;
@@ -221,8 +214,17 @@ public class JSONEncoder {
 
 	public String replace(String s) {
 		String host = local.get();
-		if (host == null)
+		if (host == null) {
+			if (DEFAULT_HOST == null) {
+				try {
+					DEFAULT_HOST = NetworkUtil.getLocalAddress();
+				} catch (Exception e) {
+					// ignore exception
+					DEFAULT_HOST = "https://cds";
+				}
+			}
 			host = DEFAULT_HOST;
+		}
 		String t = s.replace("<host>", host);
 
 		int ind = t.indexOf("\"href\":\"");

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/NetworkUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/NetworkUtil.java
@@ -34,7 +34,7 @@ public class NetworkUtil {
 		// Try to use a socket to connect to google and find the local IP address for the socket
 		// This is the best approach but only works when there is internet
 		try (Socket socket = new Socket()) {
-			socket.connect(new InetSocketAddress("google.com", 80));
+			socket.connect(new InetSocketAddress("google.com", 80), 2000);
 			localAddress = socket.getLocalAddress().getHostAddress();
 			return localAddress;
 		} catch (Exception e) {

--- a/PresCore/src/org/icpc/tools/presentation/core/internal/NoPresentation.java
+++ b/PresCore/src/org/icpc/tools/presentation/core/internal/NoPresentation.java
@@ -26,6 +26,7 @@ public class NoPresentation extends Presentation {
 	private BufferedImage tools;
 	private double scale;
 	private Point origin;
+	private String hostname;
 
 	@Override
 	public void init() {
@@ -43,6 +44,13 @@ public class NoPresentation extends Presentation {
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Error loading images", e);
 		}
+
+		execute(new Runnable() {
+			@Override
+			public void run() {
+				hostname = NetworkUtil.getLocalAddress();
+			}
+		});
 	}
 
 	@Override
@@ -129,8 +137,9 @@ public class NoPresentation extends Presentation {
 		g.drawString(s, (d.width - fm.stringWidth(s)) / 2, (d.height) * 7 / 8);
 
 		g.setColor(isLightMode() ? Color.LIGHT_GRAY : Color.DARK_GRAY);
-		s = NetworkUtil.getLocalAddress();
-		g.drawString(s, (d.width - fm.stringWidth(s)) / 2, d.height - fm.getHeight() - 20);
+		if (hostname != null) {
+			g.drawString(hostname, (d.width - fm.stringWidth(hostname)) / 2, d.height - fm.getHeight() - 20);
+		}
 
 		s = Trace.getVersion();
 		g.drawString(s, (d.width - fm.stringWidth(s)) / 2, d.height - 20);


### PR DESCRIPTION
As highlighted in #1129, if you're behind the GFW or simply on a machine with bad network configuration, pinging google.com in order to determine localhost can hang for 15s seconds (or potentially longer, depends on host or JDK configuration).

The first thing we can do is put a timeout on the ping. I went with 2s, because if you can't get to google.com in 2s, you're probably not going to and we should fallback to trying other options.

Next, we can avoid the call entirely when it's unnecessary. We could try every tool, but just starting with the resolver running a local feed I found the following:
 - Trace - this was put here for debugging purposes but we've only used it extremely rarely so I think we can just remove. (formatter also applied itself)
 - JSONEncoder - this is only needed on the CDS for file references. We can defer the call until it's actually required.
 - NoPresentation - this can be handy to debug clients, but no need to do it on the main thread, so I switch to a background call.