### PR TITLE
Optimize contest loading solely from event feed file

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -154,8 +154,7 @@ public class DiskContestSource extends ContestSource {
 	 * that it is consistent across restarts). A hash can also be provided to distinguish between
 	 * two feeds that use the same CAF but have a different hash, for example a different CCS URL
 	 *
-	 * @param eventFeedFile - a JSON or XML event feed file
-	 * @param folder - a contest archive folder
+	 * @param file - a JSON or XML event feed file, or a contest archive folder
 	 * @param hash - any uid or hash that's consistent across restarts
 	 */
 	protected DiskContestSource(File file, String hash) {
@@ -317,6 +316,11 @@ public class DiskContestSource extends ContestSource {
 
 		if (ref.file != null)
 			return ref.file;
+
+		if (eventFeedFile != null) {
+			// only loading from a local event feed, no resources on disk
+			return null;
+		}
 
 		// use the pattern to find the right folder
 		FilePattern pattern = getLocalPattern(type, id, property);
@@ -1044,6 +1048,10 @@ public class DiskContestSource extends ContestSource {
 			folder = new File(root, pattern.folder);
 
 		FileReferenceList refList = new FileReferenceList();
+		if (!folder.exists()) {
+			return refList;
+		}
+
 		List<String> hrefs = new ArrayList<>();
 		for (String ext : pattern.extensions) {
 			File[] files = folder.listFiles(
@@ -1176,6 +1184,10 @@ public class DiskContestSource extends ContestSource {
 	}
 
 	public void attachLocalResources(IContestObject obj) {
+		if (eventFeedFile != null) {
+			// source is only reading from an event feed, no local resources
+			return;
+		}
 		updateCache(obj.getType(), obj.getId());
 		if (obj instanceof Info) {
 			Info info = (Info) obj;


### PR DESCRIPTION
When a disk contest source is pointing directly at an event feed file (e.g. running the resolver pointing at only an ndjson file, no contest archive), there is no point looking for local file references or caching the set of file references we've found on disk, because they don't exist.

Putting in these three checks saves ~600ms loading a reasonably large contest on my M4, but likely saves several seconds on older hardware, and way more on a non-SSD.

Part of #1129.