### PR TITLE
Ability to configure second contest source

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -64,6 +64,7 @@ public class ConfiguredContest {
 	private boolean recordReactions;
 	private boolean hidden;
 	private CCS ccs;
+	private CCS apiSource;
 	private List<Video> videos = new ArrayList<>(3);
 	private Test test;
 	private Boolean isTesting;
@@ -336,6 +337,11 @@ public class ConfiguredContest {
 		ee = CDSConfig.getChild(e, "view");
 		if (ee != null)
 			view = new View(ee);
+
+		ee = CDSConfig.getChild(e, "source");
+		if (ee != null) {
+			apiSource = new CCS(ee);
+		}
 	}
 
 	public static boolean isTeamOrSpare(IContest contest2, ITeam team) {
@@ -702,6 +708,21 @@ public class ConfiguredContest {
 					currentState[0] = state2;
 				}
 			});
+
+			if (apiSource != null && path != null) {
+				File folder = new File(path);
+				String name = System.getProperty("CDS-name");
+				try {
+					RESTContestSource contestSource2 = new RESTContestSource(folder, apiSource.getURL(), apiSource.getUser(),
+							apiSource.getPassword(), name != null ? name + "-source" : "source");
+					Contest contest3 = contestSource2.getContest();
+					contest3.addListenerFromStart((contest2, obj, d) -> {
+						pc.add(obj);
+					});
+				} catch (Exception e) {
+					Trace.trace(Trace.ERROR, "Could not configure second contest source", e);
+				}
+			}
 
 			// wait up to 2s to connect
 			if (contestSource instanceof RESTContestSource)


### PR DESCRIPTION
This feature - which will remain undocumented for now since there are limitations and things you need to understand to use it - adds the ability to add a second contest source to the config in addition to the ccs element, e.g.:

  <contest path="...">
    <ccs url="https://test.com/api/contests/a" .../>
    <source url="https://test.com/api/contests/b" .../>
  </contest>

The regular ccs source behaves as usual; the second source will connect independently and inject objects into the same contest.

Some things to mention:
 - There is no explicit handling of overlaps, so the same object can't exist in both sources unless it is identical. Most recent update wins.
 - The contest object cache is shared, so if you need to reset either source you should clear the full cache and restart the CDS.
 - The CCS source will only & always be used for fetching file attachments. e.g. if the second source contains a submission it'll try to download the file from the CCS.