### PR TITLE
Play the organization's name in the team detail presentation

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
@@ -38,6 +38,20 @@ public interface IOrganization extends IContestObject {
 	String getActualFormalName();
 
 	/**
+	 * An audio recording of the university name.
+	 *
+	 * @return a file reference list
+	 */
+	FileReferenceList getAudio();
+
+	/**
+	 * The audio recording of the university name.
+	 *
+	 * @return an audio file
+	 */
+	File getAudio(boolean force);
+
+	/**
 	 * The country of the organization.
 	 *
 	 * @return the country

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -74,10 +74,12 @@ public class DiskContestSource extends ContestSource {
 	private static final String COUNTRY_SUBDIVISON_FLAG = "country_subdivision_flag";
 	private static final String PACKAGE = "package";
 	private static final String STATEMENT = "statement";
+	private static final String AUDIO = "audio";
 
 	private static final String[] LOGO_EXTENSIONS = new String[] { "png", "svg", "jpg", "jpeg" };
 	private static final String[] PHOTO_EXTENSIONS = new String[] { "jpg", "jpeg", "png", "svg" };
 	private static final String[] VIDEO_EXTENSIONS = new String[] { "ts", "m2ts", "ogg", "flv" };
+	private static final String[] AUDIO_EXTENSIONS = new String[] { "mp4", "m4a", "wav" };
 
 	protected File eventFeedFile;
 	private File root;
@@ -1104,6 +1106,8 @@ public class DiskContestSource extends ContestSource {
 		} else if (type == ContestType.ORGANIZATION) {
 			if (LOGO.equals(property))
 				return new FilePattern(type, id, property, LOGO_EXTENSIONS);
+			if (AUDIO.equals(property))
+				return new FilePattern(type, id, property, AUDIO_EXTENSIONS);
 			if (COUNTRY_FLAG.equals(property))
 				return new FilePattern(type, id, property, LOGO_EXTENSIONS);
 			if (COUNTRY_SUBDIVISON_FLAG.equals(property))
@@ -1196,6 +1200,7 @@ public class DiskContestSource extends ContestSource {
 		} else if (obj instanceof Organization) {
 			Organization org = (Organization) obj;
 			org.setLogo(mergeRefs(org.getLogo(), getFilesWithPattern(obj, LOGO)));
+			org.setAudio(mergeRefs(org.getAudio(), getFilesWithPattern(obj, AUDIO)));
 			org.setCountryFlag(mergeRefs(org.getCountryFlag(), getFilesWithPattern(obj, COUNTRY_FLAG)));
 			org.setCountrySubdivisionFlag(
 					mergeRefs(org.getCountrySubdivisionFlag(), getFilesWithPattern(obj, COUNTRY_SUBDIVISON_FLAG)));

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/MimeUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/MimeUtil.java
@@ -37,6 +37,10 @@ public class MimeUtil {
 			return "text/plain";
 		else if (ext.equals("pdf"))
 			return "application/pdf";
+		else if (ext.equals("m4a") || ext.equals("mp4"))
+			return "audio/mp4";
+		else if (ext.equals("wav"))
+			return "audio/wav";
 		return null;
 	}
 
@@ -72,6 +76,10 @@ public class MimeUtil {
 				return "txt";
 			case ("application/pdf"):
 				return "pdf";
+			case ("audio/mp4"):
+				return "mp4";
+			case ("audio/wav"):
+				return "wav";
 		}
 		return null;
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -21,6 +21,7 @@ public class Organization extends ContestObject implements IOrganization {
 	private static final String COUNTRY_FLAG = "country_flag";
 	private static final String COUNTRY_SUBDIVISION = "country_subdivison";
 	private static final String COUNTRY_SUBDIVISION_FLAG = "country_subdivision_flag";
+	private static final String AUDIO = "audio";
 
 	private String icpcId;
 	private String name;
@@ -30,6 +31,7 @@ public class Organization extends ContestObject implements IOrganization {
 	private String account;
 	private Location location;
 	private FileReferenceList logo;
+	private FileReferenceList audio;
 	private String country;
 	private FileReferenceList countryFlag;
 	private String countrySubdivision;
@@ -121,6 +123,20 @@ public class Organization extends ContestObject implements IOrganization {
 	}
 
 	@Override
+	public FileReferenceList getAudio() {
+		return audio;
+	}
+
+	public void setAudio(FileReferenceList list) {
+		audio = list;
+	}
+
+	@Override
+	public File getAudio(boolean force) {
+		return getFile(audio.first(), AUDIO, force);
+	}
+
+	@Override
 	public File getCountryFlag(int width, int height, boolean force) {
 		return getFile(COUNTRY_FLAG, countryFlag, width, height, null, force);
 	}
@@ -160,7 +176,7 @@ public class Organization extends ContestObject implements IOrganization {
 
 	@Override
 	public File resolveFileReference(String url2) {
-		return FileReferenceList.resolve(url2, logo, countryFlag);
+		return FileReferenceList.resolve(url2, logo, audio, countryFlag, countrySubdivisionFlag);
 	}
 
 	@Override
@@ -206,6 +222,10 @@ public class Organization extends ContestObject implements IOrganization {
 				logo = parseFileReference(value);
 				return true;
 			}
+			case AUDIO: {
+				audio = parseFileReference(value);
+				return true;
+			}
 			case COUNTRY_FLAG: {
 				countryFlag = parseFileReference(value);
 				return true;
@@ -235,6 +255,7 @@ public class Organization extends ContestObject implements IOrganization {
 		o.hashtag = hashtag;
 		o.account = account;
 		o.location = location;
+		o.audio = audio;
 		return o;
 	}
 
@@ -254,6 +275,7 @@ public class Organization extends ContestObject implements IOrganization {
 		if (location != null)
 			props.add(LOCATION, location.getJSON());
 		props.addFileRef(LOGO, logo);
+		props.addFileRef(AUDIO, audio);
 	}
 
 	@Override

--- a/doc/spec-extensions.md
+++ b/doc/spec-extensions.md
@@ -133,6 +133,27 @@ Returned data:
 [{"id":"12346","logo":[{"href":"http://example.com/api/contests/wf14/groups/12346/logo/56px","width":56,"height":56}]}]
 ```
 
+### Organizations
+
+Organizations can include an audio recording of their name, used for (e.g.) announcing the team entering
+the contest floor or receiving an award.
+
+Additional JSON attributes of organization objects:
+
+| Name           | Type            | Description
+| :------------- | :-------------- | :----------
+| audio          | array of FILE ? | An audio file recording of the organization name.
+
+Request:
+
+`GET https://example.com/api/contests/wf14/organizations`
+
+Returned data:
+
+```json
+[{"id":"12346","audio":[{"href":"http://example.com/api/contests/wf14/organizations/1236/audio","mime-type":"wav"}]}]
+```
+
 ### Award
 
 Awards have one additional attribute, used to decide how to display the award in


### PR DESCRIPTION
- MimeUtil: adds support for mp4, m4a, and wav mime types/file mapping.
- Organization: adds an 'audio' property, a recording of the university name.
- DiskContestSource: add support for loading audio files from the local contest folder.
- TeamDetailPresentation: when an audio file exists, play it when the team is selected. Regular Java audio is used for wav files, VLCj for other formats.