### PR TITLE
Alternate between male and female voice in team detail pres

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IOrganization.java
@@ -49,7 +49,7 @@ public interface IOrganization extends IContestObject {
 	 *
 	 * @return an audio file
 	 */
-	File getAudio(boolean force);
+	File getAudio(String tag, boolean force);
 
 	/**
 	 * The country of the organization.

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
@@ -12,7 +12,10 @@ public class FileReference {
 	public static final String TAG_DARK = "dark";
 	public static final String TAG_WEBCAM = "webcam";
 	public static final String TAG_DESKTOP = "desktop";
-	public static final String[] KNOWN_TAGS = new String[] { TAG_LIGHT, TAG_DARK, TAG_WEBCAM, TAG_DESKTOP };
+	public static final String TAG_MALE = "male";
+	public static final String TAG_FEMALE = "female";
+	public static final String[] KNOWN_TAGS = new String[] { TAG_LIGHT, TAG_DARK, TAG_WEBCAM, TAG_DESKTOP, TAG_MALE,
+			TAG_FEMALE };
 
 	public String mime;
 	public String href = null;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Organization.java
@@ -132,8 +132,8 @@ public class Organization extends ContestObject implements IOrganization {
 	}
 
 	@Override
-	public File getAudio(boolean force) {
-		return getFile(audio.first(), AUDIO, force);
+	public File getAudio(String tag, boolean force) {
+		return getFile(AUDIO, audio, 0, 0, tag, force);
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
@@ -16,6 +16,7 @@ import javax.sound.sampled.Clip;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.internal.FileReference;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
 import org.icpc.tools.presentation.contest.internal.TextHelper;
@@ -39,6 +40,7 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 	private BufferedImage contestImage;
 	private ITeam team;
 	private TeamInfo info;
+	private boolean voice;
 
 	@Override
 	public void setSize(Dimension d) {
@@ -87,7 +89,8 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 
 		// if there is an audio recording for this university, play it
 		if (org != null && org.getAudio() != null && !org.getAudio().isEmpty()) {
-			File f = org.getAudio(true);
+			File f = org.getAudio(voice ? FileReference.TAG_MALE : FileReference.TAG_FEMALE, true);
+			voice = !voice;
 			if (f != null) {
 				Trace.trace(Trace.INFO, "Playing audio for org " + org.getId() + " " + f.getName());
 				if (f.getName().endsWith(".wav"))


### PR DESCRIPTION
As per title:
- Update organization audio to support multiple file refs and allow a tag.
- Add male/female tags.
- Update team detail to alternate between the two tags.