### PR TITLE
Fix contest util scripts

### DIFF
--- a/ContestUtil/scripts/contestUtil.bat
+++ b/ContestUtil/scripts/contestUtil.bat
@@ -2,4 +2,4 @@
 
 set LIBDIR=%~dp0\lib
 
-java -cp "%LIBDIR%\contestUtil.jar" org.icpc.tools.contest.SWTLauncher org.icpc.tools.contest.util.Launcher %1 %2 %3 %4 %5
+java -cp "%LIBDIR%\*" org.icpc.tools.contest.util.Launcher %1 %2 %3 %4 %5

--- a/ContestUtil/scripts/contestUtil.sh
+++ b/ContestUtil/scripts/contestUtil.sh
@@ -2,5 +2,5 @@
 
 libdir=`dirname "$0"`/lib
 
-java -cp "$libdir/contestUtil.jar" org.icpc.tools.contest.SWTLauncher org.icpc.tools.contest.util.Launcher "$@"
+java -cp "$libdir/*" org.icpc.tools.contest.util.Launcher "$@"
 exit 0

--- a/ContestUtil/scripts/eventFeed.bat
+++ b/ContestUtil/scripts/eventFeed.bat
@@ -2,5 +2,5 @@
 
 set LIBDIR=%~dp0\lib
 
-java -cp "%LIBDIR%\contestUtil.jar" org.icpc.tools.contest.util.EventFeedUtil %1 %2 %3 %4
+java -cp "%LIBDIR%\*" org.icpc.tools.contest.util.EventFeedUtil %1 %2 %3 %4
 

--- a/ContestUtil/scripts/eventFeed.sh
+++ b/ContestUtil/scripts/eventFeed.sh
@@ -2,5 +2,5 @@
 
 libdir=`dirname "$0"`/lib
 
-java -cp "$libdir/contestUtil.jar" org.icpc.tools.contest.util.EventFeedUtil "$@"
+java -cp "$libdir/*" org.icpc.tools.contest.util.EventFeedUtil "$@"
 exit 0

--- a/ContestUtil/scripts/eventFeedSplitter.bat
+++ b/ContestUtil/scripts/eventFeedSplitter.bat
@@ -2,5 +2,5 @@
 
 set LIBDIR=%~dp0\lib
 
-java -cp "%LIBDIR%\contestUtil.jar" org.icpc.tools.contest.util.EventFeedSplitter %1 %2 %3 %4
+java -cp "%LIBDIR%\*" org.icpc.tools.contest.util.EventFeedSplitter %1 %2 %3 %4
 

--- a/ContestUtil/scripts/eventFeedSplitter.sh
+++ b/ContestUtil/scripts/eventFeedSplitter.sh
@@ -2,5 +2,5 @@
 
 libdir=`dirname "$0"`/lib
 
-java -cp "$libdir/contestUtil.jar" org.icpc.tools.contest.util.EventFeedSplitter "$@"
+java -cp "$libdir/*" org.icpc.tools.contest.util.EventFeedSplitter "$@"
 exit 0

--- a/ContestUtil/scripts/scoreboardUtil.bat
+++ b/ContestUtil/scripts/scoreboardUtil.bat
@@ -2,4 +2,4 @@
 
 set LIBDIR=%~dp0\lib
 
-java -cp "%LIBDIR%\contestUtil.jar" org.icpc.tools.contest.util.ScoreboardUtil %1 %2 %3 %4
+java -cp "%LIBDIR%\*" org.icpc.tools.contest.util.ScoreboardUtil %1 %2 %3 %4

--- a/ContestUtil/scripts/scoreboardUtil.sh
+++ b/ContestUtil/scripts/scoreboardUtil.sh
@@ -2,5 +2,5 @@
 
 libdir=`dirname "$0"`/lib
 
-java -cp "$libdir/contestUtil.jar" org.icpc.tools.contest.util.ScoreboardUtil "$@"
+java -cp "$libdir/*" org.icpc.tools.contest.util.ScoreboardUtil "$@"
 exit 0


### PR DESCRIPTION
Some time ago we simplified the jar manifest classpaths so that they were no longer chained: instead of specifically picking one or two top-level jars that would pull in the others as necessary, launching scripts (including the SWTLauncher) just add 'lib/*'. We missed updating the contest util scripts though, so they fail (as reported over email by Samanway). This just changes to use * like the other tools.

Also, none of the contestUtil classes appear to need the SWTLauncher (must be there for historical reasons) so I removed it to simplify and match the other scripts.