### PR TITLE
Default to 2026-01 Contest API

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -287,11 +287,11 @@ public class ContestRESTService extends HttpServlet {
 		je.encodePrimitive("logo", "[{\"href\":\"/cdsIcon.png\",\"filename\":\"logo.png\","
 				+ "\"mime\":\"image/png\",\"width\":512,\"height\":512}]");
 		if (isDraftSpec) {
-			je.encode("version", "2025-draft");
+			je.encode("version", "draft");
 			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
 		} else {
-			je.encode("version", "2023-06");
-			je.encode("version_url", "https://ccs-specs.icpc.io/2023-06/contest_api");
+			je.encode("version", "2026-01");
+			je.encode("version_url", "https://ccs-specs.icpc.io/2026-01/contest_api");
 		}
 		je.close();
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -10,8 +10,6 @@ import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.State;
 
 public class Scoreboard {
-	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
-
 	private static double round(double d) {
 		return Math.round(d * 100_000.0) / 100_000.0;
 	}
@@ -64,19 +62,11 @@ public class Scoreboard {
 			pw.write("\"score\":{");
 			if (ScoreboardType.PASS_FAIL.equals(scoreboardType)) {
 				pw.write("\"num_solved\":" + s.getNumSolved() + ",");
-				if (isDraftSpec) {
-					pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
-				} else {
-					pw.write("\"total_time\":" + ContestUtil.getTime(s.getTime()) + "},\n");
-				}
+				pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
 			} else if (ScoreboardType.SCORE.equals(scoreboardType)) {
 				pw.write("\"score\":" + round(s.getScore()));
 				if (s.getLastSolutionTime() >= 0) {
-					if (isDraftSpec) {
-						pw.write(",\"time\":\"" + RelativeTime.format(s.getLastSolutionTime()) + "\"},\n");
-					} else {
-						pw.write(",\"time\":" + ContestUtil.getTime(s.getLastSolutionTime()) + "},\n");
-					}
+					pw.write(",\"time\":\"" + RelativeTime.format(s.getLastSolutionTime()) + "\"},\n");
 				} else
 					pw.write("},\n");
 			}
@@ -101,11 +91,7 @@ public class Scoreboard {
 								pw.write(",\"first_to_solve\":true");
 						} else if (ScoreboardType.SCORE.equals(scoreboardType))
 							pw.write("\"score\":" + round(r.getScore()));
-						if (isDraftSpec) {
-							pw.write(",\"time\":\"" + RelativeTime.format(r.getContestTime()) + "\"");
-						} else {
-							pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
-						}
+						pw.write(",\"time\":\"" + RelativeTime.format(r.getContestTime()) + "\"");
 					} else
 						pw.write("\"solved\":false");
 					pw.write("}");

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -7,8 +7,6 @@ import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.feed.JSONParser;
 
 public class Clarification extends TimedEvent implements IClarification {
-	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
-
 	private static final String REPLY_TO_ID = "reply_to_id";
 	private static final String FROM_TEAM_ID = "from_team_id";
 	private static final String TO_TEAM_ID = "to_team_id";
@@ -115,14 +113,8 @@ public class Clarification extends TimedEvent implements IClarification {
 		props.addLiteralString(ID, id);
 		props.addLiteralString(REPLY_TO_ID, replyToId);
 		props.addLiteralString(FROM_TEAM_ID, fromTeamId);
-		if (!isDraftSpec) {
-			if (toTeamIds != null && toTeamIds.length > 0) {
-				props.addLiteralString(TO_TEAM_ID, toTeamIds[0]);
-			}
-		} else {
-			props.addArray(TO_TEAM_IDS, toTeamIds);
-			props.addArray(TO_GROUP_IDS, toGroupIds);
-		}
+		props.addArray(TO_TEAM_IDS, toTeamIds);
+		props.addArray(TO_GROUP_IDS, toGroupIds);
 		props.addLiteralString(PROBLEM_ID, problemId);
 		props.addString(TEXT, text);
 		super.getProperties(props);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -14,8 +14,6 @@ import org.icpc.tools.contest.model.feed.RelativeTime;
 import org.icpc.tools.contest.model.feed.Timestamp;
 
 public class Info extends ContestObject implements IInfo {
-	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
-
 	private static final String NAME = "name";
 	private static final String FORMAL_NAME = "formal_name";
 	private static final String START_TIME = "start_time";
@@ -341,10 +339,7 @@ public class Info extends ContestObject implements IInfo {
 			props.addLiteralString(SCOREBOARD_THAW_TIME, Timestamp.format(thawTime.longValue()));
 
 		if (penalty != null) {
-			if (isDraftSpec)
-				props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
-			else
-				props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
+			props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
 		}
 
 		if (!Double.isNaN(timeMultiplier))

--- a/README.md
+++ b/README.md
@@ -54,9 +54,10 @@ to use newer tools depending on your use.
 
 Version | Java Version | Contest API
 --- | --- | ---
-2.4 | Java 8 minimum | 2021_11
+2.4 | Java 8 minimum | 2021-11
 2.5 | Java 11 minimum | 2022-07
-2.6 | Java 17 minimum | 2023-06 (+ draft support for upcoming 2025 spec)
+2.6 | Java 17 minimum | 2023-06 (+ draft support for 2026-01)
+2.7 | Java 17 minimum | 2026-01
 
 ## Contributing
 


### PR DESCRIPTION
The 2.6 release supported the 2023-06 Contest API spec. As much of the (then draft) 2026-01 API was already supported as well - basically anything that wasn't a breaking change. If you wanted to try the breaking changes as well you could set the ICPC_CONTEST_API system property to 'draft'.

The 2.7 release will support 2026-01 by default and ICPC_CONTEST_API will be used to enable any future spec. This change integrates the breaking changes:
- contest penalty time and scoreboard times update to RELTIME
- clarifications allow multiple teams and groups
- update api info to correct version
- updates the readme to the correct spec versions