### PR TITLE
Submission file tokens

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Submission.java
@@ -147,7 +147,7 @@ public class Submission extends TimedEvent implements ISubmission {
 		props.addLiteralString(ACCOUNT_ID, accountId);
 		props.addLiteralString(LANGUAGE_ID, languageId);
 		props.addLiteralString(ENTRY_POINT, entryPoint);
-		props.addFileRef(FILES, files);
+		props.addFileRefSubs(FILES, files);
 		props.addFileRefSubs(REACTION, reaction);
 		super.getProperties(props);
 	}


### PR DESCRIPTION
If a web client requests the submission file over https but without auth it has the same issue as video and fails.

It's easier to fix on the client-side for this case since you're unlikely to be using a third-party module to download the zip file... but I'm lazy and trying to stage things. With this change the team-view can download source via token for the time being: https://github.com/icpctools/team-view/pull/125