### PR TITLE
Fix alternating audio in team display presentation

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -1153,7 +1154,8 @@ public class DiskContestSource extends ContestSource {
 			boolean found = false;
 			for (FileReference ref2 : localList) {
 				if (ref.height == ref2.height && ref.width == ref2.width
-						&& (ref.mime == null || ref.mime.equals(ref2.mime))) {
+						&& (ref.mime == null || ref.mime.equals(ref2.mime))
+						&& (ref.tags == null || Arrays.equals(ref.tags, ref2.tags))) {
 					found = true;
 					continue;
 				}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/FileReference.java
@@ -38,6 +38,12 @@ public class FileReference {
 		height = obj.getInt("height");
 		width = obj.getInt("width");
 		filename = obj.getString("filename");
+		Object[] tagsArray = obj.getArray("tags");
+		if (tagsArray != null) {
+			tags = new String[tagsArray.length];
+			for (int i = 0; i < tagsArray.length; i++)
+				tags[i] = (String) tagsArray[i];
+		}
 	}
 
 	public void updateTags() {
@@ -48,7 +54,7 @@ public class FileReference {
 
 		List<String> list = new ArrayList<>(KNOWN_TAGS.length);
 		for (String t : KNOWN_TAGS) {
-			if (filename.contains(t))
+			if (filename.contains("." + t + "."))
 				list.add(t);
 		}
 


### PR DESCRIPTION
I found two issues:

* The disk contest source didn't compare tags of files during merging, which would result in both files being merged into one
* The file reference constructor from JSON didn't set the tags

After fixing both I can successfully alternate audio genders.

Fixes #1275