### PR TITLE
Implement doOptions, allow origin for download

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -427,6 +427,7 @@ public class ContestRESTService extends HttpServlet {
 		}
 
 		cc.incrementDownload();
+		response.setHeader("Access-Control-Allow-Origin", "*");
 		if (obj instanceof ISubmission && url != null && url.contains("reaction")) {
 			HttpHelper.streamFile(request, response, f);
 		} else {
@@ -448,6 +449,18 @@ public class ContestRESTService extends HttpServlet {
 			doPatch(request, response);
 		else
 			super.service(request, response);
+	}
+
+	@Override
+	protected void doOptions(HttpServletRequest request, HttpServletResponse response)
+			throws ServletException, IOException {
+		response.setHeader("Access-Control-Allow-Origin", "*");
+		response.setHeader("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS");
+		response.setHeader("Access-Control-Allow-Headers", "Content-Type, Authorization");
+		response.setHeader("Access-Control-Allow-Credentials", "true");
+		response.setHeader("Allow", "GET, POST, PUT, DELETE, OPTIONS");
+
+		response.setStatus(HttpServletResponse.SC_OK);
 	}
 
 	// {"id":"finals","start_time":null}


### PR DESCRIPTION
While testing team-view downloading submissions with authorization I found two things:
- When using the browser fetch command, browsers will sometimes do an HTTP OPTIONS request before trying the actual download URL, and if the OPTIONS fails or doesn't include all required access-control headers it will fail early without actually trying the URL you requested (and which would have succeeded). Implementing doOptions on the CDS avoids this failure, and might help with other browser-side or other 'overly correct' clients.
- Download responses didn't include the allow-origin header that we set on all other responses.