### PR TITLE
Prevent resolver from happily running with partially parsed data.

### DIFF
--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -485,8 +485,10 @@ public class Resolver {
 				Trace.trace(Trace.INFO, "Test mode active");
 			} else {
 				// not test mode
-				if (!contestSources[con].waitForContest(30000))
+				if (!contestSources[con].waitForContest(60000)) {
 					Trace.trace(Trace.ERROR, "Could not load complete contest");
+					System.exit(1);
+				}
 			}
 
 			// check for unjudged runs. if we're in test mode warn the user and delete them.


### PR DESCRIPTION
Nowadays, event feeds including a million runs can be very large, and parsing takes some time, especially on very old hardware.

This change
- doubles the timeout, as we ran into the same error now multiple times
- and if it still not successful, bails out instead of "silently" continueing