### PR TITLE
Update broken links and other content errors in various READMEs

### DIFF
--- a/BalloonUtility/README.md
+++ b/BalloonUtility/README.md
@@ -1,6 +1,6 @@
 # The ICPC Balloon Utility 
 
-![](docs/balloonIcon.png)
+<img src="docs/balloonIcon.png" width="50">
 
 An ICPC Tool
 
@@ -55,11 +55,11 @@ screen will be unpopulated as shown above.)
 In order to use the BU once it is started, it must 
 be connected to the output of a _Contest Control System (CCS)_.
 The Balloon Utility will work with any CCS or the CDS which is 
-compliant with the [Contest API Specification](https://ccs-specs.icpc.io/contest_api).
+compliant with the [Contest API Specification](https://ccs-specs.icpc.io/2026-01/contest_api).
 Tools known to produce compliant event feeds include
 [Contest Data Server](https://tools.icpc.global/cds/), 
 [DOMjudge](https://www.domjudge.org),
-[PC-Squared](http://pc2.ecs.csus.edu/pc2), and 
+[PC-Squared](https://pc2ccs.github.io/), and 
 [Kattis](https://www.kattis.com);
 other Contest Control Systems may also produce compatible event feeds and
 hence work with the Balloon Utility.

--- a/CDS/README.md
+++ b/CDS/README.md
@@ -1,6 +1,6 @@
 # The ICPC Contest Data Server (CDS)
 
-![](docs/cdsIcon.png)
+<img src="docs/cdsIcon.png" width="50">
 
 An ICPC Tool
 
@@ -153,7 +153,7 @@ The attributes associated with this element are as follows:
 segment of the path (e.g. 'test' in 'C:\\icpc\\test').
 
 * path: specifies the full path to a Contest Package defining the organization of the contest
-(config files, logos, etc.). See the [Contest Package](https://ccs-specs.icpc.io/2022-07/contest_package) specification for details on how
+(config files, logos, etc.). See the [Contest Package](https://ccs-specs.icpc.io/2026-01/contest_package) specification for details on how
 to organize a Contest Package. Note that _the path attribute is required_; the CDS will not 
 operate if it does not have a folder to store contest related data, even when it is empty and getting all data from the CCS.
 

--- a/CoachView/README.md
+++ b/CoachView/README.md
@@ -1,6 +1,6 @@
 # The ICPC Coach View
 
-![](docs/coachViewIcon.png)
+<img stc="docs/coachViewIcon.png" width="50">
 
 An ICPC Tool
 
@@ -10,7 +10,7 @@ The Coach View is a software component designed to provide the ability for spect
 (coaches as well as other interested people) to view either or both of a selected team's desktop (machine screen)
 or web camera during a contest. It requires that the Contest Administrator configure desktop
 and/or webcam streaming from team machines during the contest, and also requires a
-[Contest API](https://ccs-specs.icpc.io/contest_api) source that implements video streaming, for
+[Contest API](https://ccs-specs.icpc.io/2026-01/contest_api) source that implements video streaming, for
 example the ICPC Tools [Contest Data Server](https://tools.icpc.global/cds/).
 
 The Coach View provides the ability for a coach to select a specific team by name or team number and to view

--- a/ContestUtil/README.md
+++ b/ContestUtil/README.md
@@ -1,6 +1,6 @@
 # Contest Utilities
 
-![](docs/contestUtilsIcon.png)
+<img src="docs/contestUtilsIcon.png" width="50">
 
 An ICPC Tool
 

--- a/PresAdmin/README.md
+++ b/PresAdmin/README.md
@@ -1,6 +1,6 @@
 # The ICPC Presentation Admin
 
-![](docs/adminIcon.png){width=50}
+<img src="docs/adminIcon.png" width="50">
 
 An ICPC Tool
 
@@ -20,7 +20,7 @@ Other presentations show data such as the languages being used,
 the current number of solutions to each contest problem,
 notifications that a particular team has just solved a particular problem,
 and so forth, all updating in real time based on input from a 
-[Contest Control System (CCS)](https://ccs-specs.icpc.io/ccs_system_requirements).
+[Contest Control System (CCS)](https://ccs-specs.icpc.io/2026-01/ccs_system_requirements).
 There are also pre-defined presentations for showing a variety of user-selected
 data such as team photographs, contest logos and related images,
 local sites of interest, fireworks for the end 
@@ -28,9 +28,9 @@ of the contest, and so forth.
 
 The ICPC Presentation System will work with any 
 CCS that produces an event feed which is 
-compliant with the [Contest API](https://ccs-specs.icpc.io/contest_api).
+compliant with the [Contest API](https://ccs-specs.icpc.io/2026-01/contest_api).
 Systems known to produce compliant event feeds include 
-[PC-Squared](http://pc2.ecs.csus.edu) and 
+[PC-Squared](https://pc2ccs.github.io/) and 
 [Kattis](https://www.kattis.com); 
 other Contest Control Systems may also produce compatible event feeds and 
 hence work with the Presentation System.

--- a/PresContest/README.md
+++ b/PresContest/README.md
@@ -42,8 +42,8 @@ When a Presentation Client is started it must be told, in addition to what prese
 where to obtain its input data (images, contest events, etc.).
 This is referred to as specifying a _contest source_.
 Presentation Clients can obtain their input data from two different types of contest sources:
-a compliant [_Contest API_](https://ccs-specs.icpc.io/contest_api), or a
-a [_Contest Package_](https://ccs-specs.icpc.io/2022-07/contest_package) folder.
+a compliant [_Contest API_](https://ccs-specs.icpc.io/2026-01/contest_api), or a
+a [_Contest Package_](https://ccs-specs.icpc.io/2026-01/contest_package) folder.
 
 When connecting to a live contest via the Contest API, the Presentation Client works
 by reading the _event feed_.
@@ -52,7 +52,7 @@ compliant with the Contest API specification.
 Tools known to produce compliant event feeds include
 [Contest Data Server](https://tools.icpc.global/cds/), 
 [DOMjudge](https://www.domjudge.org),
-[PC-Squared](http://pc2.ecs.csus.edu/pc2), and 
+[PC-Squared](https://pc2ccs.github.io/), and 
 [Kattis](https://www.kattis.com); 
 other Contest Control Systems may also produce compatible event feeds and 
 hence work with the Presentation System.

--- a/ProblemSet/README.md
+++ b/ProblemSet/README.md
@@ -1,6 +1,6 @@
 # The ICPC Problem Set Editor 
 
-![](docs/problemSetIcon.png){width=50}
+<img src="docs/problemSetIcon.png" width="50">
 
 An ICPC Tool
 
@@ -8,10 +8,10 @@ An ICPC Tool
 
 The ICPC Problem Set Editor is a tool for creating and editing _problemset.yaml_ files, 
 which define the list of contest problems
-and their colors for a [CLICS-compliant](https://ccs-specs.icpc.io/ccs_system_requirements)
+and their colors for a [CLICS-compliant](https://ccs-specs.icpc.io/2026-01/ccs_system_requirements)
 Contest Control System (CCS).
 
-The following shows a screen shot of the editor in action:
+The following shows a screenshot of the editor in action:
 
 ![Problem Set editor](docs/ProblemSetScreenShot.png)
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Welcome to the ICPC Tools!
 The ICPC Tools are a set of tools to support running programming contests. For the latest downloads, please go to the [ICPC Tools website](https://tools.icpc.global).
 
 Each of the ICPC tools can be used individually, or together in any combination. They are all designed to support
-the REST-based [Contest API](https://ccs-specs.icpc.io/2021-11/contest_api) as defined by the Competitive Learning Initiative (CLI).
+the REST-based [Contest API](https://ccs-specs.icpc.io/2026-01/contest_api) as defined by the Competitive Learning Initiative (CLI).
 Some features require extensions to the specification, and those are described [here](doc/spec-extensions.md).
 
 These tools were built to support the
@@ -30,7 +30,7 @@ Contest Utilities | A variety of useful contest-related utilities: event feed va
 
 ## Contest Control System Compatibility
 
-The ICPC Tools are built to work with any Contest Control System (CCS) that supports the REST-based [Contest API](https://ccs-specs.icpc.io/2021-11/contest_api).
+The ICPC Tools are built to work with any Contest Control System (CCS) that supports the REST-based [Contest API](https://ccs-specs.icpc.io/2026-01/contest_api).
 
 To be more specific, the only part of the Contest API that is strictly required is the event feed and any file
 references that the feed refers to. If your CCS correctly supports the event feed, then all of the ICPC Tools will
@@ -87,10 +87,10 @@ A [Docker image](https://ghcr.io/icpctools/cds) is provided to run the CDS witho
 The basic way to run it, is to run
 
 ```bash
-docker run --name cds --rm -it  -p 8080:8080 -p 8443:8443 -e CCS_URL=https://www.domjudge.org/demoweb/api/contests/nwerc18 -e CCS_USER=admin -e CCS_PASSWORD=admin ghcr.io/icpctools/cds:2.2.407
+docker run --name cds --rm -it  -p 8080:8080 -p 8443:8443 -e CCS_URL=https://www.domjudge.org/demoweb/api/contests/nwerc18 -e CCS_USER=admin -e CCS_PASSWORD=admin ghcr.io/icpctools/cds:2.7.1359
 ```
 
-Replace `https://www.domjudge.org/demoweb/api/contests/nwerc18` with your CCS contest API URL, `CCS_USER` with a user with admin privileges to the CCS URL, `CCS_PASSWORD` with the password for the given user and `2.2.407` with the version of the CDS you want to run.
+Replace `https://www.domjudge.org/demoweb/api/contests/nwerc18` with your CCS contest API URL, `CCS_USER` with a user with admin privileges to the CCS URL, `CCS_PASSWORD` with the password for the given user and `2.7.1359` with the version of the CDS you want to run.
 
 Now you can access the CDS at https://localhost:8443/.
 

--- a/Resolver/README.md
+++ b/Resolver/README.md
@@ -1,6 +1,6 @@
 # The ICPC Resolver 
 
-![](docs/resolverIcon.png)
+<img src="docs/resolverIcon.png" width="50">
 
 An ICPC Tool
 
@@ -98,11 +98,11 @@ credentials are only given to trusted contest staff or not distributed until the
 ### Input Data Sources
 
 The Resolver works with any CCS or the CDS that produces an event feed which is
-compliant with the [Contest API Specification](https://ccs-specs.icpc.io/contest_api).
+compliant with the [Contest API Specification](https://ccs-specs.icpc.io/2026-01/contest_api).
 Tools known to produce compliant event feeds include
 [Contest Data Server](https://tools.icpc.global/cds/), 
 [DOMjudge](https://www.domjudge.org),
-[PC-Squared](http://pc2.ecs.csus.edu/pc2), and 
+[PC-Squared](https://pc2ccs.github.io/), and 
 [Kattis](https://www.kattis.com);
 other Contest Control Systems may also produce compatible event feeds and
 hence work with the Resolver.
@@ -112,7 +112,7 @@ three different sources: a _Contest Package_ folder, a _Contest API_ source, or 
 
 If the Resolver is started with the first argument being a path (relative or absolute)
 to a folder, it will expect the folder to contain contest data as per the
-[Contest Package](https://ccs-specs.icpc.io/2022-07/contest_package) specification.
+[Contest Package](https://ccs-specs.icpc.io/2026-01/contest_package) specification.
 If the Resolver is started with the first argument pointing to a file, it will expect
 the file to be an event feed JSON file.
 
@@ -421,7 +421,7 @@ The specification of what groups exist in a contest comes from the event feed
 The CCS used in the World Finals is configured to define six "regions" (groups):
 North America, Latin American (comprising Central and South America),
 Europe, Asia, Africa and the Middle East, and the South Pacific.  
-(See the interactive [ICPC Regional Finder map](https://icpc.baylor.edu/regionals/finder) for definitions of the
+(See the interactive [ICPC Regional Finder map](https://icpc.global/regionals/finder) for definitions of the
 precise boundaries of ICPC Regions.)
 The highest placing team at the World Finals from each of the six ICPC regions
 receives an award acknowledging their accomplishment as "Regional Champion".

--- a/website/content/coach-view.md
+++ b/website/content/coach-view.md
@@ -11,7 +11,7 @@ The Coach View is a software component designed to provide the ability for spect
 (coaches as well as other interested people) to view either or both of a selected team's desktop (machine screen)
 or web camera during a contest.  It requires that the Contest Administrator configure desktop
 and/or webcam streaming from team machines during the contest, and also requires a
-[Contest API](https://ccs-specs.icpc.io/contest_api) source that implements video streaming, for
+[Contest API](https://ccs-specs.icpc.io/2026-01/contest_api) source that implements video streaming, for
 example the ICPC Tools [Contest Data Server](/cds).
 
 The Coach View provides the ability for a coach to select a specific team by name or team number and to view

--- a/website/content/pres-admin.md
+++ b/website/content/pres-admin.md
@@ -29,9 +29,9 @@ of the contest, and so forth.
 
 The ICPC Presentation System will work with any
 CCS that produces an event feed which is
-compliant with the [_CLI Contest API_](https://ccs-specs.icpc.io/contest_api).
+compliant with the [_CLI Contest API_](https://ccs-specs.icpc.io/2026-01/contest_api).
 Systems known to produce compliant event feeds include
-[PC-Squared](http://pc2.ecs.csus.edu),
+[PC-Squared](https://pc2ccs.github.io),
 [Kattis](https://www.kattis.com/) and [DOMjudge](https://www.domjudge.org);
 other Contest Control Systems may also produce compatible event feeds and
 hence work with the Presentation System.

--- a/website/content/problem-set-editor.md
+++ b/website/content/problem-set-editor.md
@@ -9,6 +9,6 @@ icon: fas fa-file-alt
 
 The ICPC Problem Set Editor is a tool for creating and editing `problemset.yaml` files,
 which define the list of contest problems
-and their colors for a Contest Control System (CCS) that supports the [CCS Specification](https://ccs-specs.icpc.io/ccs_system_requirements).
+and their colors for a Contest Control System (CCS) that supports the [CCS Specification](https://ccs-specs.icpc.io/2026-01/ccs_system_requirements).
 
 {{< tooldownload name="Problem Set Editor" toolname=problemset doc=ProblemSet >}}


### PR DESCRIPTION
I noticed that multiple links have become outdated, so I went through all `.md` files I could find to try to fix this.

Most of the changes are one of the following:
  - Add a version number to ccs-specs.icpc.io links. I elected to go with `2026-01`. Let me know if you think it would make more sense to still use `2023-06`.
  - Replace http://pc2.ecs.csus.edu/pc2 with https://pc2ccs.github.io
  - Set a width to the various icon images in READMEs, as the layout of them is currently quite broken.
  
Moreover, I found this email listed in `CDS/README.md`: `cpctools-dev@ecs.csus.edu`. As a lot of links (including `pc2.ecs.csus.edu`) have become outdated, I thought I'd double-check if this email is still monitored? If not, it should probably be removed/replaced.