### PR TITLE
Fix scoring contest scoreboard

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/ContestUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ContestUtil.java
@@ -84,6 +84,10 @@ public class ContestUtil {
 		return timeMs / 60000L;
 	}
 
+	public static long roundTimeToMin(long timeMs) {
+		return timeMs / 60000L * 60000L;
+	}
+
 	/**
 	 * Format contest time as a string.
 	 *

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.icpc.tools.contest.Trace;
-import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IClarification;
@@ -1046,8 +1045,8 @@ public class Contest implements IContest {
 				for (int j = 0; j < numProblems; j++) {
 					penalty += tempResults[i][j].getPenaltyTime();
 					if (tempResults[i][j].getStatus() == Status.SOLVED) {
-						long time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime());
-						penalty += time * (60 * 1000L);
+						long time = tempResults[i][j].getContestTime();
+						penalty += time;
 						numSolved++;
 						score += tempResults[i][j].getScore();
 						if (time > lastSolution)
@@ -1058,7 +1057,7 @@ public class Contest implements IContest {
 						double scoreForThisProblem = tempResults[i][j].getScore();
 						if (scoreForThisProblem > 0) {
 							score += scoreForThisProblem;
-							long time = ContestUtil.getTimeInMin(tempResults[i][j].getContestTime()) * 60 * 1000L;
+							long time = tempResults[i][j].getContestTime();
 							if (time > lastSolution)
 								lastSolution = time;
 						}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Ranking.java
@@ -79,9 +79,10 @@ public class Ranking {
 					if (si.getScore() < sj.getScore())
 						swap = true;
 					else if (si.getScore() == sj.getScore()) {
-						if (si.getLastSolutionTime() > sj.getLastSolutionTime())
+						if ((sj.getLastSolutionTime() >= 0 && si.getLastSolutionTime() < 0)
+								|| (sj.getLastSolutionTime() >= 0 && si.getLastSolutionTime() > sj.getLastSolutionTime())) {
 							swap = true;
-						else if (si.getLastSolutionTime() == sj.getLastSolutionTime()) {
+						} else if (si.getLastSolutionTime() == sj.getLastSolutionTime()) {
 							String tin = teams[order[i]].getActualDisplayName();
 							String tjn = teams[order[j]].getActualDisplayName();
 							if (tin != null && tjn != null && collator.compare(tin, tjn) > 0)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Result.java
@@ -1,8 +1,9 @@
 package org.icpc.tools.contest.model.internal;
 
+import org.icpc.tools.contest.model.ContestUtil;
+import org.icpc.tools.contest.model.IContest.ScoreboardType;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IJudgementType;
-import org.icpc.tools.contest.model.IContest.ScoreboardType;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IResult;
 import org.icpc.tools.contest.model.ISubmission;
@@ -76,7 +77,7 @@ public class Result implements IResult {
 					if (j.getScore() > score) {
 						score = j.getScore();
 						numJudged++;
-						time = s.getContestTime();
+						time = ContestUtil.roundTimeToMin(s.getContestTime());
 					}
 				}
 			}
@@ -104,7 +105,7 @@ public class Result implements IResult {
 			} // else compile or judgement error that doesn't count as an attempt or penalty
 		}
 
-		time = s.getContestTime();
+		time = ContestUtil.roundTimeToMin(s.getContestTime());
 
 	}
 


### PR DESCRIPTION
Fixes two problems:
- Teams are sorted correctly when they have a solved problem, even if they didn't score any points (i.e. last solution time used as timebreaker).
- Conversion to RELTIMEs for 2026-01 was broken: scoreboard row wasn't converted back from ms to min and problem data wasn't rounded. Fixed in Result so that penalty & time are always rounded to minutes for both pass/fail and scoring contests.

Fixes #1294.