### PR TITLE
Change to json objects for team PDF and detail presentation

### DIFF
--- a/CDS/src/org/icpc/tools/cds/web/TeamPDFService.java
+++ b/CDS/src/org/icpc/tools/cds/web/TeamPDFService.java
@@ -5,6 +5,8 @@ import java.awt.Graphics2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -17,6 +19,7 @@ import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.JSONEncoder;
 import org.icpc.tools.contest.model.internal.FileReference;
 import org.icpc.tools.contest.model.util.QRCode;
 
@@ -196,7 +199,14 @@ public class TeamPDFService {
 		BufferedImage image = new BufferedImage(500, 500, BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g = (Graphics2D) image.getGraphics();
 		g.setColor(Color.BLACK);
-		QRCode.drawQRCode(g, team.getLabel(), 0, 0, 500);
+
+		StringWriter sw = new StringWriter();
+		JSONEncoder je = new JSONEncoder(new PrintWriter(sw));
+		je.open();
+		je.encode("team_id", team.getId());
+		je.close();
+
+		QRCode.drawQRCode(g, sw.toString(), 0, 0, 500);
 		g.dispose();
 		Image qrImg = Image.getInstance(image, null);
 		float scale = (float) (72f * r.getHeight() / 2f / qrImg.getWidth() * 0.7f);

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
@@ -15,8 +15,12 @@ import javax.sound.sampled.Clip;
 import javax.sound.sampled.LineEvent;
 
 import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IOrganization;
+import org.icpc.tools.contest.model.IPerson;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.JSONParser;
+import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.FileReference;
 import org.icpc.tools.presentation.contest.internal.AbstractICPCPresentation;
 import org.icpc.tools.presentation.contest.internal.ICPCFont;
@@ -105,7 +109,7 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 	/**
 	 * Play a wav file using Java audio.
 	 */
-	private void playWAV(File file) {
+	private static void playWAV(File file) {
 		try {
 			AudioInputStream audioIn = AudioSystem.getAudioInputStream(file);
 			Clip clip = AudioSystem.getClip();
@@ -215,12 +219,48 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 			setTeam(null);
 			return;
 		}
-		ITeam newTeam = getContest().getTeamById(val);
+
+		// try json object containing ids
+		IContest contest = getContest();
+		try {
+			// replace fancy quotes with standard ones
+			val = val.replaceAll("[\\u201c\\u201d]", "\"");
+			JsonObject obj = JSONParser.getOrReadObject(val);
+			String teamId = obj.getString("team_id");
+
+			ITeam newTeam = null;
+			if (teamId != null) {
+				newTeam = contest.getTeamById(teamId);
+			} else {
+				String personId = obj.getString("person_id");
+				if (personId != null) {
+					IPerson p = contest.getPersonById(personId);
+					if (p != null) {
+						// person could be on more than one team, just check in order for now
+						for (String teamId2 : p.getTeamIds()) {
+							newTeam = contest.getTeamById(teamId2);
+							if (newTeam != null) {
+								break;
+							}
+						}
+					}
+				}
+			}
+			if (newTeam != null) {
+				setTeam(newTeam);
+				return;
+			}
+		} catch (Exception e) {
+			// ignore
+		}
+
+		// try by raw team id or label
+		ITeam newTeam = contest.getTeamById(val);
 		if (newTeam != null) {
 			setTeam(newTeam);
 			return;
 		}
-		ITeam[] teams = getContest().getTeams();
+		ITeam[] teams = contest.getTeams();
 		for (ITeam t : teams) {
 			if (t.getLabel().equals(val)) {
 				setTeam(t);


### PR DESCRIPTION
This switches the team PDF printouts to use QR codes with a JSON object containing a team_id (e.g. `{"team_id":"10"}`) instead of a simple string. Updates the team detail presentation to support objects with the team id or a person id.

Fixes #1297.