### PR TITLE
Improve load time for on-disk contests

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -184,7 +184,8 @@ public abstract class ContestSource {
 					return;
 				}
 				notifyListeners(ConnectionState.INITIALZED);
-				boolean reconnect = (ContestSource.this instanceof RESTContestSource);
+				boolean reconnect = (ContestSource.this instanceof RESTContestSource)
+						&& ((RESTContestSource) ContestSource.this).getURL() != null;
 
 				final IContestListener readListener = new IContestListener() {
 					@Override
@@ -293,7 +294,7 @@ public abstract class ContestSource {
 		int last = -1;
 		int count = 0;
 		int n = getContest().getNumObjects();
-		while (count < 3 && !contest.isDoneUpdating()) {
+		while (count < 3 && !contest.isDoneUpdating() && lastState != ConnectionState.COMPLETE) {
 			if (System.currentTimeMillis() > endTime)
 				return false;
 


### PR DESCRIPTION
This makes two minor changes that improve contest loading time, especially for the resolver:

Reconnection logic: if you lose connection to a remote/REST contest we can try to reconnect; if you're reading from disk you can only read files once. We changed the local disk contests to use the RESTContestSource a couple years ago to allow loading remote file resources but didn't catch that this causes it to pointlessly try to reload. The fix is to also check if there's a URL on the contest source.

Contest Updating Logic: when waiting for all contest data to be loaded it was looking for 2 things: contest is correctly finalized, or 2s without any new events. Most of the time we run the resolver _before_ finalizing though, so we wait an extra 2s for no reason. Added a check if we're done reading the files, if so we don't need the wait.

The _first_ load of any contest is going to be especially slow because we have to load all file references and cache the information. After that, _subsequent_ loads of a large contest (144 teams, 15,000 lines, 4.4Mb event feed) was taking ~4s on my M4. After these changes it takes ~900ms.

Part of #1129.