### PR TITLE
Serve different specs on separate endpoints

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSConfig.java
+++ b/CDS/src/org/icpc/tools/cds/CDSConfig.java
@@ -152,11 +152,6 @@ public class CDSConfig {
 		try {
 			Element e = readElement(file);
 
-			if (e.hasAttribute("contest-api")) {
-				String spec = getString(e, "contest-api");
-				System.setProperty("ICPC_CONTEST_API", spec);
-			}
-
 			loadContests(e);
 			loadOtherConfig(e);
 

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -29,6 +29,7 @@ import org.icpc.tools.contest.model.IInfo;
 import org.icpc.tools.contest.model.ILanguage;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.Scoreboard;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.DiskContestSource;
 import org.icpc.tools.contest.model.feed.JSONArrayWriter;
@@ -53,7 +54,6 @@ import jakarta.servlet.http.HttpServletResponse;
 
 @WebServlet(urlPatterns = { "/api", "/api/", "/api/*" }, asyncSupported = true)
 public class ContestRESTService extends HttpServlet {
-	private static final boolean isDraftSpec = "draft".equals(System.getProperty("ICPC_CONTEST_API"));
 	private static final long serialVersionUID = 1L;
 
 	static class EndpointInfo {
@@ -80,21 +80,32 @@ public class ContestRESTService extends HttpServlet {
 		response.setHeader("X-Frame-Options", "sameorigin");
 
 		String path = request.getPathInfo();
+		if (path != null && path.equals("/metrics")) {
+			MetricsService.write(request, response);
+			return;
+		}
+
+		if (path != null && path.startsWith("/2026-01")) {
+			ContestAPIHelper.set2026_01();
+			path = path.substring(8);
+		} else if (path != null && path.startsWith("/2023-06")) {
+			ContestAPIHelper.set2023_06();
+			path = path.substring(8);
+		} else {
+			ContestAPIHelper.set2026_01();
+		}
 		if (path == null || path.equals("") || path.equals("/")) {
 			sendAPIInfo(response);
 			return;
 		}
-		if (path.equals("/metrics")) {
-			MetricsService.write(request, response);
-			return;
-		}
+
 		if (!path.startsWith("/contests")) {
 			request.getRequestDispatcher("/WEB-INF/jsps/contestAPI.jsp").forward(request, response);
 			return;
 		}
 		path = path.substring(9);
 
-		if (path == null || path.equals("") || path.equals("/")) {
+		if (path.equals("") || path.equals("/")) {
 			// list contests
 			PrintWriter pw = response.getWriter();
 			JSONArrayWriter writer = new JSONArrayWriter(pw);
@@ -286,12 +297,15 @@ public class ContestRESTService extends HttpServlet {
 		je.encode("name", "Contest Data Server");
 		je.encodePrimitive("logo", "[{\"href\":\"/cdsIcon.png\",\"filename\":\"logo.png\","
 				+ "\"mime\":\"image/png\",\"width\":512,\"height\":512}]");
-		if (isDraftSpec) {
-			je.encode("version", "draft");
-			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
-		} else {
+		if (ContestAPIHelper.is2026_01()) {
 			je.encode("version", "2026-01");
 			je.encode("version_url", "https://ccs-specs.icpc.io/2026-01/contest_api");
+		} else if (ContestAPIHelper.is2023_06()) {
+			je.encode("version", "2023-06");
+			je.encode("version_url", "https://ccs-specs.icpc.io/2023-06/contest_api");
+		} else {
+			je.encode("version", "draft");
+			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
 		}
 		je.close();
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/Scoreboard.java
@@ -3,6 +3,7 @@ package org.icpc.tools.contest.model;
 import java.io.PrintWriter;
 
 import org.icpc.tools.contest.model.IContest.ScoreboardType;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper;
 import org.icpc.tools.contest.model.feed.JSONEncoder;
 import org.icpc.tools.contest.model.feed.RelativeTime;
 import org.icpc.tools.contest.model.feed.Timestamp;
@@ -62,11 +63,19 @@ public class Scoreboard {
 			pw.write("\"score\":{");
 			if (ScoreboardType.PASS_FAIL.equals(scoreboardType)) {
 				pw.write("\"num_solved\":" + s.getNumSolved() + ",");
-				pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
+				if (ContestAPIHelper.is2023_06()) {
+					pw.write("\"total_time\":" + ContestUtil.getTime(s.getTime()) + "},\n");
+				} else {
+					pw.write("\"total_time\":\"" + RelativeTime.format(s.getTime()) + "\"},\n");
+				}
 			} else if (ScoreboardType.SCORE.equals(scoreboardType)) {
 				pw.write("\"score\":" + round(s.getScore()));
 				if (s.getLastSolutionTime() >= 0) {
-					pw.write(",\"time\":\"" + RelativeTime.format(s.getLastSolutionTime()) + "\"},\n");
+					if (ContestAPIHelper.is2023_06()) {
+						pw.write(",\"time\":" + ContestUtil.getTime(s.getLastSolutionTime()) + "},\n");
+					} else {
+						pw.write(",\"time\":\"" + RelativeTime.format(s.getLastSolutionTime()) + "\"},\n");
+					}
 				} else
 					pw.write("},\n");
 			}
@@ -91,7 +100,11 @@ public class Scoreboard {
 								pw.write(",\"first_to_solve\":true");
 						} else if (ScoreboardType.SCORE.equals(scoreboardType))
 							pw.write("\"score\":" + round(r.getScore()));
-						pw.write(",\"time\":\"" + RelativeTime.format(r.getContestTime()) + "\"");
+						if (ContestAPIHelper.is2023_06()) {
+							pw.write(",\"time\":" + ContestUtil.getTime(r.getContestTime()));
+						} else {
+							pw.write(",\"time\":\"" + RelativeTime.format(r.getContestTime()) + "\"");
+						}
 					} else
 						pw.write("\"solved\":false");
 					pw.write("}");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -16,6 +16,28 @@ import org.icpc.tools.contest.model.internal.Info;
 public class ContestAPIHelper {
 	protected static boolean isCDS;
 
+	private enum Version {
+		v2023_06, v2026_01
+	}
+
+	private static final ThreadLocal<Version> local = new ThreadLocal<>();
+
+	public static void set2026_01() {
+		local.set(Version.v2026_01);
+	}
+
+	public static void set2023_06() {
+		local.set(Version.v2023_06);
+	}
+
+	public static boolean is2026_01() {
+		return local.get() == Version.v2026_01;
+	}
+
+	public static boolean is2023_06() {
+		return local.get() == Version.v2023_06;
+	}
+
 	static class Result {
 		String content;
 		URL url;

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper;
 import org.icpc.tools.contest.model.feed.JSONParser;
 
 public class Clarification extends TimedEvent implements IClarification {
@@ -113,8 +114,16 @@ public class Clarification extends TimedEvent implements IClarification {
 		props.addLiteralString(ID, id);
 		props.addLiteralString(REPLY_TO_ID, replyToId);
 		props.addLiteralString(FROM_TEAM_ID, fromTeamId);
-		props.addArray(TO_TEAM_IDS, toTeamIds);
-		props.addArray(TO_GROUP_IDS, toGroupIds);
+
+		if (ContestAPIHelper.is2023_06()) {
+			if (toTeamIds != null && toTeamIds.length > 0) {
+				props.addLiteralString(TO_TEAM_ID, toTeamIds[0]);
+			}
+		} else {
+			props.addArray(TO_TEAM_IDS, toTeamIds);
+			props.addArray(TO_GROUP_IDS, toGroupIds);
+		}
+
 		props.addLiteralString(PROBLEM_ID, problemId);
 		props.addString(TEXT, text);
 		super.getProperties(props);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -10,6 +10,7 @@ import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContest.ScoreboardType;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IInfo;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper;
 import org.icpc.tools.contest.model.feed.RelativeTime;
 import org.icpc.tools.contest.model.feed.Timestamp;
 
@@ -339,7 +340,11 @@ public class Info extends ContestObject implements IInfo {
 			props.addLiteralString(SCOREBOARD_THAW_TIME, Timestamp.format(thawTime.longValue()));
 
 		if (penalty != null) {
-			props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
+			if (ContestAPIHelper.is2023_06()) {
+				props.addInt(PENALTY_TIME, (int) (penalty.longValue() / (60 * 1000L)));
+			} else {
+				props.addLiteralString(PENALTY_TIME, RelativeTime.format(penalty));
+			}
 		}
 
 		if (!Double.isNaN(timeMultiplier))

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Version | Java Version | Contest API
 2.4 | Java 8 minimum | 2021-11
 2.5 | Java 11 minimum | 2022-07
 2.6 | Java 17 minimum | 2023-06 (+ draft support for 2026-01)
-2.7 | Java 17 minimum | 2026-01
+2.7 | Java 17 minimum | 2026-01 (2023-06 API available at /api/2023-06/)
 
 ## Contributing
 


### PR DESCRIPTION
Support multiple Contest API specs via separate endpoints:

/api - the default (currently 2026-01)
/api/2026-01 - Same content as /api
/api/2023-06 - The old spec, was removed by #1271 but I'm bringing it back. Now
  that we have different endpoints there's no harm in directly supporting it in
  case any clients still needed it.
/api/<?> - we'd put draft support for future spec here so that it doesn't affect
  any other endpoints/clients, and once it is ready change /api to it.

Fixes #1300.