### PR TITLE
Avoid loading runs in the resolver

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -639,6 +639,7 @@ public class ConfiguredContest {
 					Info info2 = (Info) obj;
 					info2.setId(id);
 				}
+				return true;
 			});
 			if (isTesting())
 				pc.setTestMode();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -15,6 +15,7 @@ import org.icpc.tools.contest.model.IContestListener;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.FileReference;
+import org.icpc.tools.contest.model.internal.IContestModifier;
 
 /**
  * A generic interface for sources of contest data, either file, URL, or other.
@@ -130,9 +131,15 @@ public abstract class ContestSource {
 	}
 
 	public Contest loadContest(IContestListener listener) {
+		return loadContest(listener, null);
+	}
+
+	public Contest loadContest(IContestListener listener, IContestModifier modifier) {
 		if (contest != null) {
 			if (listener != null)
 				contest.addListener(listener);
+			if (modifier != null)
+				contest.addModifier(modifier);
 			return contest;
 		}
 
@@ -140,6 +147,8 @@ public abstract class ContestSource {
 			if (contest != null) {
 				if (listener != null)
 					contest.addListener(listener);
+				if (modifier != null)
+					contest.addModifier(modifier);
 				return contest;
 			}
 
@@ -150,6 +159,8 @@ public abstract class ContestSource {
 
 			if (listener != null)
 				contest.addListener(listener);
+			if (modifier != null)
+				contest.addModifier(modifier);
 
 			loadContestInBackground();
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -750,8 +750,12 @@ public class DiskContestSource extends ContestSource {
 				Info info2 = (Info) obj;
 				info2.setId(contestId);
 			}
+			return true;
 		});
-		IContestModifier mod = (contest2, obj) -> attachLocalResources(obj);
+		IContestModifier mod = (contest2, obj) -> {
+			attachLocalResources(obj);
+			return true;
+		};
 		contest.addModifier(mod);
 
 		loadConfigFiles();

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -121,8 +121,11 @@ public class Contest implements IContest {
 		// make sure to modify all existing data
 		synchronized (data) {
 			if (data.size() > 0) {
-				for (IContestObject obj : data)
-					modifier.notify(this, obj);
+				for (IContestObject obj : data) {
+					if (!modifier.notify(this, obj)) {
+						Trace.trace(Trace.WARNING, "Modifier wanted to remove object that was already added to contest");
+					}
+				}
 			}
 		}
 	}
@@ -141,7 +144,8 @@ public class Contest implements IContest {
 		if (obj == null)
 			return;
 
-		notifyModifiers(obj);
+		if (!notifyModifiers(obj))
+			return;
 
 		Delta delta = null;
 		synchronized (data) {
@@ -468,19 +472,22 @@ public class Contest implements IContest {
 		}
 	}
 
-	private void notifyModifiers(IContestObject co) {
+	private boolean notifyModifiers(IContestObject co) {
 		IContestModifier[] list = null;
 		synchronized (modifiers) {
 			list = modifiers.toArray(new IContestModifier[0]);
 		}
 
+		IContestObject co2 = co;
 		for (IContestModifier modifier : list) {
 			try {
-				modifier.notify(this, co);
+				if (!modifier.notify(this, co2))
+					return false;
 			} catch (Throwable t) {
 				Trace.trace(Trace.ERROR, "Error notifying modifier", t);
 			}
 		}
+		return true;
 	}
 
 	public IContestObject[] getObjects() {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/IContestModifier.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/IContestModifier.java
@@ -4,5 +4,5 @@ import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
 
 public interface IContestModifier {
-	public void notify(IContest contest, IContestObject obj);
+	public boolean notify(IContest contest, IContestObject obj);
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/util/TeamDisplay.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/util/TeamDisplay.java
@@ -17,6 +17,7 @@ public class TeamDisplay {
 				String name = getTeamName(c, team, template);
 				team.setDisplayName(name);
 			}
+			return true;
 		});
 	}
 

--- a/Resolver/src/org/icpc/tools/resolver/Resolver.java
+++ b/Resolver/src/org/icpc/tools/resolver/Resolver.java
@@ -18,19 +18,23 @@ import javax.imageio.ImageIO;
 import org.icpc.tools.client.core.IConnectionListener;
 import org.icpc.tools.client.core.IPropertyListener;
 import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IAward;
+import org.icpc.tools.contest.model.IClarification;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestListener;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IGroup;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.IResolveInfo;
+import org.icpc.tools.contest.model.IRun;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.Scoreboard;
 import org.icpc.tools.contest.model.TimeFilter;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.internal.Contest;
+import org.icpc.tools.contest.model.internal.IContestModifier;
 import org.icpc.tools.contest.model.internal.ResolveInfo;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
@@ -455,6 +459,13 @@ public class Resolver {
 		try {
 			contestSources[con].outputValidation();
 
+			IContestModifier mod = (contest2, obj) -> {
+				if (obj instanceof IRun || obj instanceof IAccount || obj instanceof IClarification) {
+					return false;
+				}
+				return true;
+			};
+
 			finalContest[con] = contestSources[con].loadContest(new IContestListener() {
 				@Override
 				public void contestChanged(IContest contest, IContestObject obj, Delta delta) {
@@ -472,7 +483,7 @@ public class Resolver {
 						}
 					}
 				}
-			});
+			}, mod);
 			if (displayName != null)
 				TeamDisplay.overrideDisplayName(finalContest[con], displayName);
 


### PR DESCRIPTION
The resolver doesn't use some contest objects, most significantly runs since there are typically a ton of them. Having them in the contest or not doesn't matter, but since resolving involves creating a lot of copies (states) of the contest, less objects is faster.

The ResolverLogic currently discards any unnecessary objects as the first step, since it could be called on any contest source. The standalone resolver can do one e step better though: use a contest modifier to immediately throw out runs as we parse the JSON. This saves processing time putting them into the model, only to take them out again later.

On one reasonably sized contest (144 teams, 15,000 objects, 4.4Mb event feed) this drops the contest reading time on my M4 from ~900 ms to under 650ms. (Time saved not removing runs later is only an additional ~3ms)

Part of #1129.