### PR TITLE
Avoid team detail audio playing twice

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
@@ -46,6 +46,7 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 	private ITeam team;
 	private TeamInfo info;
 	private boolean voice;
+	private long lastAudio;
 
 	@Override
 	public void setSize(Dimension d) {
@@ -93,9 +94,14 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 		}
 
 		// if there is an audio recording for this university, play it
+		if (lastAudio > System.currentTimeMillis() - 2000) {
+			// do not play audio if we started one within the last 2s
+			return;
+		}
 		if (org != null && org.getAudio() != null && !org.getAudio().isEmpty()) {
 			File f = org.getAudio(voice ? FileReference.TAG_MALE : FileReference.TAG_FEMALE, true);
 			voice = !voice;
+			lastAudio = System.currentTimeMillis();
 			if (f != null) {
 				Trace.trace(Trace.INFO, "Playing audio for org " + org.getId() + " " + f.getName());
 				if (f.getName().endsWith(".wav"))


### PR DESCRIPTION
At NAC apparently the QR codes were accidentally scanned more than once, causing the audio to play twice over top of itself. I can think of situations where we might want to play it again on purpose (e.g. team got delayed walking onto the floor) and don't want to make any delay dependent on the length of audio (and not clear we could safely anyway) so just don't play an audio file if we've set the team within the last 2s.

Fixes #1288.