### PR TITLE
Improved contest logo in team detail pres

### DIFF
--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDetailPresentation.java
@@ -165,8 +165,8 @@ public class TeamDetailPresentation extends AbstractICPCPresentation {
 	@Override
 	public void paint(Graphics2D g) {
 		if (contestImage == null)
-			contestImage = getContest().getLogoImage((int) (width * 0.7), (int) ((height - MARGIN * 2) * 0.7),
-					getModeTag(), true, true);
+			contestImage = getContest().getLogoImage((int) (width * 0.8), (int) ((height) * 0.8), getModeTag(), true,
+					true);
 
 		g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
 		g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);


### PR DESCRIPTION
Sam wanted a contest logo if there's no team selected, and a way to clear the team (but not via invalid team #, a specific option) to get back to the logo.

Both of these already work and were tested:
- contest logo is shown when there's no team selected
- invalid team numbers are ignored; empty string/content causes team to be deselected

The contest logo could be a little bigger - this fixes that.

Fixes #1305.