### PR TITLE
Contest time cleanup

### DIFF
--- a/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
+++ b/BalloonUtility/src/org/icpc/tools/balloon/BalloonUtility.java
@@ -1435,21 +1435,15 @@ public class BalloonUtility {
 		if (contest == null)
 			return "";
 
-		double timeMultiplier = contest.getTimeMultiplier();
-		Long startTime = contest.getStartStatus();
-		if (startTime == null)
-			return "";
-
-		if (startTime < 0)
-			return "Paused @ " + getTime(startTime * timeMultiplier, true);
+		Long clock = contest.getContestClock(getTimeMs());
+		if (contest.getCountdownPauseTime() != null)
+			return "Paused @ " + getTime(clock, true);
 
 		IState state = contest.getState();
-		if (state.getEnded() != null)
+		if (state != null && state.getEnded() != null)
 			return "Contest is over";
-		else if (state.getStarted() == null)
-			return getTime((getTimeMs() - contest.getStartTime()) * timeMultiplier, true);
 
-		return getTime((getTimeMs() - state.getStarted()) * timeMultiplier, true);
+		return getTime(clock, true);
 	}
 
 	private static String getTime(double ms, boolean floor) {

--- a/CDS/WebContent/WEB-INF/jsps/freeze.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/freeze.jsp
@@ -15,22 +15,22 @@
                     <table class="table table-sm table-hover table-striped">
                         <tr>
                             <th>Frozen:</th>
-                            <td><%= ContestUtil.formatStartTime(state.getFrozen()) %>
+                            <td><%= ContestUtil.formatTime(state.getFrozen()) %>
                             </td>
                         </tr>
                         <tr>
                             <th>Ended:</th>
-                            <td><%= ContestUtil.formatStartTime(state.getEnded()) %>
+                            <td><%= ContestUtil.formatTime(state.getEnded()) %>
                             </td>
                         </tr>
                         <tr>
                             <th>Finalized:</th>
-                            <td><%= ContestUtil.formatStartTime(state.getFinalized()) %>
+                            <td><%= ContestUtil.formatTime(state.getFinalized()) %>
                             </td>
                         </tr>
                         <tr>
                             <th>Thawed:</th>
-                            <td><%= ContestUtil.formatStartTime(state.getThawed()) %>
+                            <td><%= ContestUtil.formatTime(state.getThawed()) %>
                             </td>
                         </tr>
                     </table>
@@ -147,10 +147,10 @@
                             <tr>
                                 <td>Submission time of most recent judgement:</td>
                                 <td>
-                                    <%= s == null ? "no judgements" : ContestUtil.formatTime(s.getContestTime()) %>
+                                    <%= s == null ? "no judgements" : ContestUtil.formatRelTime(s.getContestTime()) %>
                                 </td>
                                 <td>
-                                    <%= s2 == null ? "no judgements" : ContestUtil.formatTime(s2.getContestTime()) %>
+                                    <%= s2 == null ? "no judgements" : ContestUtil.formatRelTime(s2.getContestTime()) %>
                                 </td>
                             </tr>
                         </tbody>

--- a/CDS/WebContent/WEB-INF/jsps/overview.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/overview.jsp
@@ -54,7 +54,7 @@
                                 <td><b>Current time:</b></td>
                                 <td><% if (state.getStarted() == null) { %>Not started
                                     <% } else if (state.getEnded() != null) { %>Finished
-                                    <% } else { %><%= ContestUtil.formatTime((long) ((System.currentTimeMillis() - state.getStarted()) * contest.getTimeMultiplier())) %><% } %>
+                                    <% } else { %><%= ContestUtil.formatRelTime(contest.getContestClock()) %><% } %>
                                 </td>
                                 <td><b>Freeze duration:</b></td>
                                 <td><%= ContestUtil.formatDuration(contest.getFreezeDuration()) %></td>
@@ -63,7 +63,7 @@
                                 <td><b>Validation:</b></td>
                                 <td><%= validation %></td>
                                 <td><b>Last event:</b></td>
-                                <td><%= ContestUtil.formatDuration(contest.getContestTimeOfLastEvent()) %></td>
+                                <td><%= ContestUtil.formatRelTime(contest.getContestTimeOfLastEvent()) %></td>
                             </tr>
                             <tr>
                                 <td><b>Connection state:</b></td>

--- a/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/teamSummary.jsp
@@ -224,7 +224,7 @@
                                     <% } %>
                                 </td>
                                 <td class="text-center">
-                                    <%= ContestUtil.formatTime(sub.getContestTime()) %>
+                                    <%= ContestUtil.formatRelTime(sub.getContestTime()) %>
                                 </td>
                                 <td>
                                     <%= probStr %>

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -194,7 +194,7 @@ public class ConfiguredContest {
 		@Override
 		public String toString() {
 			if (startTime > 0)
-				return "Playback at " + ContestUtil.formatStartTime(startTime) + " at " + getMultiplier() + "x speed";
+				return "Playback at " + ContestUtil.formatTime(startTime) + " at " + getMultiplier() + "x speed";
 			return "Playback in " + getCountdown() + "s at " + getMultiplier() + "x speed";
 		}
 	}

--- a/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestWebService.java
@@ -375,7 +375,7 @@ public class ContestWebService extends HttpServlet {
 								je.encode("mode", stream.getMode().name().toLowerCase());
 								je.encode("status", stream.getStatus().name().toLowerCase());
 								Stats stats = stream.getStats();
-								je.encode("time", ContestUtil.formatTime(stats.getTotalTime()));
+								je.encode("time", ContestUtil.formatRelTime(stats.getTotalTime()));
 								je.encode("current", stats.getCurrentListeners());
 								je.encode("total", stats.getTotalListeners());
 								time += stats.getTotalTime();
@@ -393,11 +393,11 @@ public class ContestWebService extends HttpServlet {
 							je.closeArray();
 							je.encode("current", current);
 							je.encode("total_listeners", listeners);
-							je.encode("total_time", ContestUtil.formatTime(time));
+							je.encode("total_time", ContestUtil.formatRelTime(time));
 							je.close();
 
 						}
-						je.encode("total_time", ContestUtil.formatTime(teamTime));
+						je.encode("total_time", ContestUtil.formatRelTime(teamTime));
 						je.close();
 					}
 
@@ -411,7 +411,7 @@ public class ContestWebService extends HttpServlet {
 						numStreams += vs.numStreams;
 						je.encode("current", vs.current);
 						je.encode("total_listeners", vs.total);
-						je.encode("total_time", ContestUtil.formatTime(vs.time));
+						je.encode("total_time", ContestUtil.formatRelTime(vs.time));
 						je.encode("mode", vs.mode);
 						je.close();
 					}
@@ -420,7 +420,7 @@ public class ContestWebService extends HttpServlet {
 					je.encode("current", va.getConcurrent());
 					je.encode("max_current", va.getMaxConcurrent());
 					je.encode("total_listeners", va.getTotal());
-					je.encode("total_time", ContestUtil.formatTime(va.getTotalTime()));
+					je.encode("total_time", ContestUtil.formatRelTime(va.getTotalTime()));
 					je.close();
 					return;
 				}

--- a/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
+++ b/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
@@ -35,6 +35,18 @@ public class StartTimeService {
 		return false;
 	}
 
+	private static Long getStartStatus(IContest contest) {
+		Long startTime = contest.getStartTime();
+		if (startTime != null)
+			return startTime;
+
+		Long pause = contest.getCountdownPauseTime();
+		if (pause == null)
+			return null;
+
+		return (long) -pause;
+	}
+
 	protected static void doPut(HttpServletResponse response, String command, ConfiguredContest cc) throws IOException {
 		// valid commands:
 		// pause - pause the countdown
@@ -45,7 +57,7 @@ public class StartTimeService {
 		// remove:0:00:00 - remove the given time from the countdown
 
 		IContest contest = cc.getContest();
-		Long startStatus = contest.getStartStatus();
+		Long startStatus = getStartStatus(contest);
 		long currentStart = 0;
 		if (startStatus != null)
 			currentStart = startStatus.longValue();
@@ -155,7 +167,7 @@ public class StartTimeService {
 			Trace.trace(Trace.INFO, "Setting start time to paused at: " + RelativeTime.format(-time.longValue()));
 		else
 			Trace.trace(Trace.INFO,
-					"Setting start time to: " + Timestamp.format(time) + " (" + ContestUtil.formatStartTime(time) + ")");
+					"Setting start time to: " + Timestamp.format(time) + " (" + ContestUtil.formatTime(time) + ")");
 
 		Contest contest = cc.getContest();
 		long now = System.currentTimeMillis();

--- a/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
+++ b/CDS/src/org/icpc/tools/cds/video/VideoServlet.java
@@ -233,7 +233,7 @@ public class VideoServlet extends HttpServlet {
 			je.encode("current", s.currentListeners);
 			je.encode("max_current", s.maxConcurrentListeners);
 			je.encode("total_listeners", s.totalListeners);
-			je.encode("total_time", ContestUtil.formatTime(s.totalTime));
+			je.encode("total_time", ContestUtil.formatRelTime(s.totalTime));
 			je.close();
 			c++;
 		}
@@ -242,7 +242,7 @@ public class VideoServlet extends HttpServlet {
 		je.encode("current", va.getConcurrent());
 		je.encode("max_current", va.getMaxConcurrent());
 		je.encode("total_listeners", va.getTotal());
-		je.encode("total_time", ContestUtil.formatTime(va.getTotalTime()));
+		je.encode("total_time", ContestUtil.formatRelTime(va.getTotalTime()));
 		je.close();
 	}
 }

--- a/ContestModel/src/org/icpc/tools/contest/model/ContestUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/ContestUtil.java
@@ -105,28 +105,22 @@ public class ContestUtil {
 	 * @return
 	 */
 	public static String formatStartTime(IContest contest) {
-		return formatStartTime(contest.getStartStatus());
+		IState state = contest.getState();
+		Long startTime = (state != null && state.getStarted() != null) ? state.getStarted() : contest.getStartTime();
+		return formatTime(startTime);
 	}
 
 	/**
-	 * Format contest start time as a string.
+	 * Format a wall clock time as a string.
 	 *
-	 * @param time contest start time, in seconds
+	 * @param time
 	 * @return
 	 */
-	public static String formatStartTime(Long startTime) {
-		if (startTime == null)
+	public static String formatTime(Long time) {
+		if (time == null)
 			return "undefined";
 
-		if (startTime < 0) {
-			long countdown = startTime / 1000L;
-			int hours = (int) Math.floor(-countdown / 3600);
-			int mins = (int) Math.floor(-countdown / 60) % 60;
-			int secs = (int) -countdown % 60;
-			return "Paused at " + hours + "h" + mins + "m" + secs + "s";
-		}
-
-		return SDF.format(new Date(startTime));
+		return SDF.format(new Date(time));
 	}
 
 	/**
@@ -142,7 +136,7 @@ public class ContestUtil {
 	}
 
 	/**
-	 * Format a contest duration (length) or relative time as a string.
+	 * Format a contest duration (length) as a string.
 	 *
 	 * @param duration a duration, in ms
 	 * @return
@@ -171,12 +165,12 @@ public class ContestUtil {
 	}
 
 	/**
-	 * Format a time (duration) or relative time as a string.
+	 * Format a relative time as a string.
 	 *
 	 * @param a time period, in ms
 	 * @return
 	 */
-	public static String formatTime(long time2) {
+	public static String formatRelTime(long time2) {
 		if (time2 >= 0 && time2 < 1000)
 			return "0s";
 

--- a/ContestModel/src/org/icpc/tools/contest/model/IContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IContest.java
@@ -224,13 +224,21 @@ public interface IContest {
 	IStartStatus getStartStatusById(String id);
 
 	/**
-	 * Returns a start status for the contest time. Null indicates the contest start is not set.
-	 * Negative numbers indicate a countdown pause, in ms. Positive numbers indicate contest time,
-	 * in ms. Long.MAX_VALUE indicates the contest is over.
+	 * Returns the current contest clock (including time multiplier, if there is one), or null if
+	 * the contest is neither scheduled nor paused.
 	 *
-	 * @return
+	 * @return the clock
 	 */
-	Long getStartStatus();
+	Long getContestClock();
+
+	/**
+	 * Returns the current contest clock (including time multiplier, if there is one), or null if
+	 * the contest is neither scheduled nor paused.
+	 *
+	 * @param timeMs the current time in ms
+	 * @return the clock
+	 */
+	Long getContestClock(long timeMs);
 
 	/**
 	 * Returns the pauses.

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -50,7 +50,7 @@ public class ContestAPIHelper {
 
 	private static String listContest(URL url, Info info) {
 		return url.toExternalForm() + " - " + info.getName() + " starting at "
-				+ ContestUtil.formatStartTime(info.getStartTime());
+				+ ContestUtil.formatTime(info.getStartTime());
 	}
 
 	private static URL getChildURL(URL url, String path) throws Exception {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RelativeTime.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RelativeTime.java
@@ -30,7 +30,10 @@ public class RelativeTime {
 		return contestTime;
 	}
 
-	public static long parse(String contestTime) throws ParseException {
+	public static Long parse(String contestTime) throws ParseException {
+		if (contestTime == null || contestTime.equals("null"))
+			return null;
+
 		Matcher match = TIME_PATTERN.matcher(contestTime);
 		if (!match.matches())
 			throw new ParseException("Invalid contest time string: " + contestTime, 0);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -724,16 +724,25 @@ public class Contest implements IContest {
 	}
 
 	@Override
-	public Long getStartStatus() {
-		Long startTime = info.getStartTime();
-		if (startTime != null)
-			return startTime;
+	public Long getContestClock() {
+		return getContestClock(System.currentTimeMillis());
+	}
 
-		Long pause = info.getCountdownPauseTime();
-		if (pause == null)
+	@Override
+	public Long getContestClock(long timeMs) {
+		double timeMultiplier = info.getTimeMultiplier();
+
+		Long pauseTime = info.getCountdownPauseTime();
+		if (pauseTime != null) {
+			return -Math.round(pauseTime * timeMultiplier);
+		}
+
+		Long startTime = (state != null && state.getStarted() != null) ? state.getStarted() : info.getStartTime();
+		if (startTime == null)
 			return null;
 
-		return (long) -pause;
+		long contestTimeMs = timeMs - startTime;
+		return Math.round(contestTimeMs * timeMultiplier);
 	}
 
 	public Info setStartStatus(Long start) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -173,8 +173,6 @@ public abstract class ContestObject implements IContestObject {
 	}
 
 	protected static Long parseRelativeTime(Object value) throws ParseException {
-		if (value == null || "null".equals(value))
-			return null;
 		return RelativeTime.parse((String) value);
 	}
 

--- a/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
+++ b/ContestUtil/src/org/icpc/tools/contest/util/EventFeedUtil.java
@@ -237,7 +237,7 @@ public class EventFeedUtil {
 		// IInfo info = contest.getInfo();
 		Trace.trace(Trace.USER, "");
 		Trace.trace(Trace.USER, "Name: " + contest.getName());
-		Trace.trace(Trace.USER, "Start time: " + ContestUtil.formatStartTime(contest.getStartTime()));
+		Trace.trace(Trace.USER, "Start time: " + ContestUtil.formatTime(contest.getStartTime()));
 		Trace.trace(Trace.USER, "Duration: " + ContestUtil.formatDuration(contest.getDuration()));
 		Trace.trace(Trace.USER, "Freeze duration: " + ContestUtil.formatDuration(contest.getFreezeDuration()));
 		Trace.trace(Trace.USER, "");

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/TeamDisplayPresentation.java
@@ -158,15 +158,7 @@ public class TeamDisplayPresentation extends AbstractICPCPresentation {
 		if (contest == null)
 			return null;
 
-		Long startTime = contest.getStartStatus();
-		if (startTime == null)
-			return null;
-
-		double timeMultiplier = contest.getTimeMultiplier();
-		if (startTime < 0)
-			return Math.round(startTime * timeMultiplier);
-
-		return Math.round((getTimeMs() - startTime) * timeMultiplier);
+		return contest.getContestClock(getTimeMs());
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/ClockPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/ClockPresentation.java
@@ -22,15 +22,7 @@ public class ClockPresentation extends AbstractICPCPresentation {
 		if (contest == null)
 			return null;
 
-		Long startTime = contest.getStartStatus();
-		if (startTime == null)
-			return null;
-
-		double timeMultiplier = contest.getTimeMultiplier();
-		if (startTime < 0)
-			return Math.round(startTime * timeMultiplier);
-
-		return Math.round((getTimeMs() - startTime) * timeMultiplier);
+		return contest.getContestClock(getTimeMs());
 	}
 
 	public Color getTextBackgroundColor() {

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/CountdownPresentation.java
@@ -50,11 +50,11 @@ public class CountdownPresentation extends ClockPresentation {
 	private void setClockTarget() {
 		IContest contest = getContest();
 		if (contest != null) {
-			Long startStatus = contest.getStartStatus();
-			if (startStatus == null)
+			Long contestClock = contest.getContestClock();
+			if (contestClock == null)
 				return;
 
-			if (startStatus < 0)
+			if (contest.getCountdownPauseTime() != null)
 				clock.setTarget(-getRemainingMillis(), 0);
 			else
 				clock.setTarget(-getRemainingMillis(), 1000.0 * contest.getTimeMultiplier());
@@ -82,13 +82,12 @@ public class CountdownPresentation extends ClockPresentation {
 		if (contest == null)
 			return 0;
 
-		Long startTime = contest.getStartStatus();
-		if (startTime == null)
+		Long contestClock = contest.getContestClock();
+		if (contestClock == null)
 			return 0;
 
-		double timeMultiplier = contest.getTimeMultiplier();
-		if (startTime < 0)
-			return -Math.round(startTime * timeMultiplier);
+		if (contestClock < 0)
+			return contestClock;
 
 		// where should we switch countdown between the start and end of a contest?
 		// switch at the contest freeze, or (if there is no freeze) 2/3 of the contest
@@ -99,13 +98,13 @@ public class CountdownPresentation extends ClockPresentation {
 		if (freezeDuration != null)
 			switchPoint = duration - freezeDuration;
 
-		if ((startTime - now) < -(switchPoint / timeMultiplier)) {
+		if ((contestClock - now) < -(switchPoint)) {
 			clockColor = EOC_COLOR;
-			return Math.round((startTime - now) * timeMultiplier + duration);
+			return duration - contestClock;
 		}
 
 		clockColor = isLightMode() ? Color.BLACK : Color.WHITE;
-		return Math.round((startTime - now) * timeMultiplier);
+		return contestClock;
 	}
 
 	@Override

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/StatusCountdownPresentation.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/presentations/clock/StatusCountdownPresentation.java
@@ -174,10 +174,10 @@ public class StatusCountdownPresentation extends CountdownPresentation {
 
 		IContest contest = getContest();
 		if (contest != null) {
-			Long contestStatus = contest.getStartStatus();
-			if (contestStatus == null)
+			Long contestClock = contest.getContestClock();
+			if (contestClock == null)
 				s = "Start time undefined";
-			else if (contestStatus < 0)
+			else if (contest.getCountdownPauseTime() != null)
 				s = "Status: Paused";
 
 			if (contest.getState() != null && contest.getState().isRunning())


### PR DESCRIPTION
When I went to start adding support for removed intervals I found a lot of cruft that needs to be cleaned up first:
- Many places that do their own calculation of contest time and pausing, as well as the time multiplier.
- Poorly named historical functions, e.g. formatStartTime() that formats wall clock time, and getTime() that only formats rel times.
- Odd IContest.getStartStatus() utility that returns a single value for paused (negative) vs contest start time (positive).

This adds a single utility IContest.getContestClock() to calculate the current contest time, either based on the current system clock or a given time (which allows you to predict the clock, but was added to allow exact timing in presentations). Clients are all updated to use getContestClock() instead of calculating it themselves.

ContestUtil functions renamed to formatTime() (wall clock), formatRelTime() (contest time) and formatDuration() (rel time, but slight difference in formatting)

getStartStatus() is removed. For StartTimeService I moved the getStartStatus() in as a private function to avoid further churn here.

First part of #1311.