### PR TITLE
Time-based replay support

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -8,13 +8,13 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
 import org.icpc.tools.cds.service.ExecutorListener;
+import org.icpc.tools.cds.util.CDSContest;
 import org.icpc.tools.cds.util.HttpHelper;
-import org.icpc.tools.cds.util.PlaybackContest;
+import org.icpc.tools.cds.util.ReplayContest;
 import org.icpc.tools.cds.video.VideoAggregator;
 import org.icpc.tools.cds.video.VideoAggregator.ConnectionMode;
 import org.icpc.tools.cds.video.VideoStream.StreamType;
@@ -34,7 +34,6 @@ import org.icpc.tools.contest.model.feed.Timestamp;
 import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.Info;
-import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.internal.YamlParser;
 import org.icpc.tools.contest.model.internal.account.AccountHelper;
 import org.w3c.dom.Element;
@@ -445,6 +444,14 @@ public class ConfiguredContest {
 		} catch (Exception e) {
 			Trace.trace(Trace.WARNING, "Could not close contest", e);
 		}
+		try {
+			if (contest != null && contest instanceof ReplayContest) {
+				ReplayContest rContest = (ReplayContest) contest;
+				rContest.stopReplay();
+			}
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Could not stop replay", e);
+		}
 	}
 
 	public String getPath() {
@@ -633,16 +640,13 @@ public class ConfiguredContest {
 
 		try {
 			ContestSource source = getContestSource();
-			PlaybackContest pc = new PlaybackContest(this);
-			pc.addModifier((cont, obj) -> {
-				if (obj instanceof Info) {
-					Info info2 = (Info) obj;
-					info2.setId(id);
-				}
-				return true;
-			});
-			if (isTesting())
-				pc.setTestMode();
+			Contest tempContest;
+			if (isTesting()) {
+				tempContest = new ReplayContest(this);
+			} else {
+				tempContest = new CDSContest(this);
+			}
+			final Contest cdsContest = tempContest;
 
 			source.addListener(new ContestSourceListener() {
 				@Override
@@ -654,12 +658,9 @@ public class ConfiguredContest {
 				}
 			});
 
-			contestSource.setInitialContest(pc);
+			contestSource.setInitialContest(cdsContest);
 			contest = contestSource.getContest();
 			contestSource.setExecutor(ExecutorListener.getExecutor());
-
-			if (isTesting())
-				contest.setHashCode(contest.hashCode() + (int) (Math.random() * 500.0));
 
 			// if you're an admin, staff, analyst, spectator, or balloon on the CDS, give equivalent
 			// access on all contests
@@ -672,31 +673,12 @@ public class ConfiguredContest {
 					contest.add(account);
 			}
 
-			State[] currentState = new State[1];
-			currentState[0] = new State();
 			contest.addListenerFromStart((contest2, obj, d) -> {
 				if (obj instanceof ITeam) {
 					ITeam team = (ITeam) obj;
 					if (videos != null && streamMap.get(team.getId()) == null && isTeamOrSpare(contest, team)) {
 						setupTeamStreams(team.getId());
 					}
-				}
-
-				if (obj instanceof State) {
-					State state2 = (State) obj;
-					if (!Objects.equals(currentState[0].getStarted(), state2.getStarted()))
-						Trace.trace(Trace.USER, "Contest started: " + id);
-					if (!Objects.equals(currentState[0].getFrozen(), state2.getFrozen()))
-						Trace.trace(Trace.USER, "Contest frozen: " + id);
-					if (!Objects.equals(currentState[0].getThawed(), state2.getThawed()))
-						Trace.trace(Trace.USER, "Contest thawed: " + id);
-					if (!Objects.equals(currentState[0].getEnded(), state2.getEnded()))
-						Trace.trace(Trace.USER, "Contest ended: " + id);
-					if (!Objects.equals(currentState[0].getFinalized(), state2.getFinalized()))
-						Trace.trace(Trace.USER, "Contest finalized: " + id);
-					if (!Objects.equals(currentState[0].getEndOfUpdates(), state2.getEndOfUpdates()))
-						Trace.trace(Trace.USER, "Contest end of updates: " + id);
-					currentState[0] = state2;
 				}
 			});
 
@@ -706,10 +688,7 @@ public class ConfiguredContest {
 				try {
 					RESTContestSource contestSource2 = new RESTContestSource(folder, apiSource.getURL(), apiSource.getUser(),
 							apiSource.getPassword(), name != null ? name + "-source" : "source");
-					Contest contest3 = contestSource2.getContest();
-					contest3.addListenerFromStart((contest2, obj, d) -> {
-						pc.add(obj);
-					});
+					contestSource2.setInitialContest(cdsContest);
 				} catch (Exception e) {
 					Trace.trace(Trace.ERROR, "Could not configure second contest source", e);
 				}

--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -561,11 +561,12 @@ public class ContestRESTService extends HttpServlet {
 				return;
 			}
 
-			Long newTime = null;
+			Long newStartTime = null;
+			Long newCountdownPauseTime = null;
 			if (time != null && !"null".equals(time))
 				try {
-					newTime = Timestamp.parse(time.toString());
-					Trace.trace(Trace.INFO, "Patch time: " + Timestamp.format(newTime));
+					newStartTime = Timestamp.parse(time.toString());
+					Trace.trace(Trace.INFO, "Patch time: " + Timestamp.format(newStartTime));
 				} catch (Exception e) {
 					Trace.trace(Trace.WARNING, "Invalid patch time: " + e.getMessage());
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
@@ -574,8 +575,9 @@ public class ContestRESTService extends HttpServlet {
 
 			if (countdownTime != null && !"null".equals(countdownTime))
 				try {
-					newTime = (long) -RelativeTime.parse(countdownTime.toString());
-					Trace.trace(Trace.INFO, "Patch countdown time: " + RelativeTime.format(newTime.longValue()));
+					newCountdownPauseTime = (long) RelativeTime.parse(countdownTime.toString());
+					Trace.trace(Trace.INFO,
+							"Patch countdown time: " + RelativeTime.format(newCountdownPauseTime.longValue()));
 				} catch (Exception e) {
 					Trace.trace(Trace.WARNING, "Invalid patch countdown time: " + e.getMessage());
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
@@ -583,8 +585,8 @@ public class ContestRESTService extends HttpServlet {
 				}
 
 			try {
-				Trace.trace(Trace.INFO, "Patching start time");
-				StartTimeService.setStartTime(ei.cc, newTime);
+				Trace.trace(Trace.INFO, "Patching contest start");
+				StartTimeService.setContestStart(ei.cc, newStartTime, newCountdownPauseTime);
 			} catch (Exception e) {
 				Trace.trace(Trace.ERROR, "Error setting start time", e);
 				response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, e.getMessage());

--- a/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
+++ b/CDS/src/org/icpc/tools/cds/service/StartTimeService.java
@@ -3,7 +3,7 @@ package org.icpc.tools.cds.service;
 import java.io.IOException;
 
 import org.icpc.tools.cds.ConfiguredContest;
-import org.icpc.tools.cds.util.PlaybackContest;
+import org.icpc.tools.cds.util.ReplayContest;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IContest;
@@ -28,23 +28,11 @@ public class StartTimeService {
 	}
 
 	private static boolean errorIfContestNotPaused(Long time, HttpServletResponse response) throws IOException {
-		if (time == null || time > 0) {
+		if (time == null || time < 0) {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Contest not paused");
 			return true;
 		}
 		return false;
-	}
-
-	private static Long getStartStatus(IContest contest) {
-		Long startTime = contest.getStartTime();
-		if (startTime != null)
-			return startTime;
-
-		Long pause = contest.getCountdownPauseTime();
-		if (pause == null)
-			return null;
-
-		return (long) -pause;
 	}
 
 	protected static void doPut(HttpServletResponse response, String command, ConfiguredContest cc) throws IOException {
@@ -57,27 +45,27 @@ public class StartTimeService {
 		// remove:0:00:00 - remove the given time from the countdown
 
 		IContest contest = cc.getContest();
-		Long startStatus = getStartStatus(contest);
-		long currentStart = 0;
-		if (startStatus != null)
-			currentStart = startStatus.longValue();
+		Long startTime = contest.getStartTime();
+		Long pauseTime = contest.getCountdownPauseTime();
 
 		long now = System.currentTimeMillis();
 
 		Trace.trace(Trace.USER, "Start time command: " + command);
 		try {
 			if (command.startsWith("set:")) {
-				if (errorIfContestNotPaused(currentStart, response))
+				if (startTime != null) {
+					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Contest currently in countdown");
 					return;
+				}
 
-				long time = -RelativeTime.parse(command.substring(4).trim());
-				if (time > -30000) {
+				long countdownPauseTime = RelativeTime.parse(command.substring(4).trim());
+				if (countdownPauseTime < 30000) {
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Can't set contest to less than 30s countdown");
 					return;
 				}
-				setStartTime(cc, time);
+				setContestStart(cc, null, countdownPauseTime);
 			} else if (command.startsWith("add:")) {
-				if (errorIfContestNotPaused(currentStart, response))
+				if (errorIfContestNotPaused(pauseTime, response))
 					return;
 
 				long time = RelativeTime.parse(command.substring(4).trim());
@@ -85,36 +73,42 @@ public class StartTimeService {
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid add time");
 					return;
 				}
-				setStartTime(cc, currentStart - time);
+				setContestStart(cc, null, pauseTime + time);
 			} else if (command.startsWith("remove:")) {
-				if (errorIfContestNotPaused(currentStart, response))
+				if (errorIfContestNotPaused(pauseTime, response))
 					return;
 
 				long time = RelativeTime.parse(command.substring(7).trim());
-				if (time <= 0 || time > -currentStart - 30000) {
+				if (pauseTime - time < 300000) {
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid remove time");
 					return;
 				}
-				setStartTime(cc, currentStart + time);
+				setContestStart(cc, null, pauseTime - time);
 			} else if (command.equals("pause")) {
-				if (errorIfContestNotCountingDown(currentStart, response))
+				if (errorIfContestNotCountingDown(startTime, response))
 					return;
 
-				if (currentStart - now < 30000) {
+				if (startTime - now < 30000) {
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Can't pause in the last 30s");
 					return;
 				}
-				setStartTimeInSeconds(cc, now - currentStart);
+
+				// pause at the next full second
+				long newPauseTime = (long) (Math.floor((startTime - now) / 1000.0)) * 1000;
+				setContestStart(cc, null, newPauseTime);
 			} else if (command.equals("resume")) {
-				if (errorIfContestNotPaused(currentStart, response))
+				if (errorIfContestNotPaused(pauseTime, response))
 					return;
-				setStartTimeInSeconds(cc, now - currentStart);
+
+				// resume at nearest full second
+				long newStartTime = ((now + pauseTime) / 1000) * 1000;
+				setContestStart(cc, newStartTime, null);
 			} else if (command.equals("clear")) {
 				if (contest.getState().isRunning()) {
 					response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Contest already running");
 					return;
 				}
-				setStartTime(cc, null);
+				setContestStart(cc, null, null);
 			}
 		} catch (IllegalArgumentException e) {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
@@ -130,27 +124,6 @@ public class StartTimeService {
 	}
 
 	/**
-	 * Sets the start time to null or a new date given in seconds.
-	 *
-	 * @param newTime
-	 * @throws Exception
-	 */
-	private static void setStartTimeInSeconds(ConfiguredContest cc, Long newTime) throws Exception {
-		if (newTime == null) {
-			setStartTime(cc, null);
-			return;
-		}
-
-		Long time = newTime;
-		if (time > 0) // resume at the closest second
-			time = (time / 1000) * 1000;
-		else // pause with the full current second
-			time = (long) (Math.floor(time / 1000.0)) * 1000;
-
-		setStartTime(cc, time);
-	}
-
-	/**
 	 * Sets the start time to null or a new date given in milliseconds.
 	 *
 	 * The request should fail with a 401 if the user does not have sufficient access rights, or a
@@ -160,14 +133,16 @@ public class StartTimeService {
 	 * @param newTime
 	 * @throws Exception
 	 */
-	protected static void setStartTime(ConfiguredContest cc, Long time) throws Exception {
-		if (time == null)
+	protected static void setContestStart(ConfiguredContest cc, Long startTime, Long countdownPauseTime)
+			throws Exception {
+		if (startTime == null && countdownPauseTime == null)
 			Trace.trace(Trace.INFO, "Setting start time to: null");
-		else if (time < 0)
-			Trace.trace(Trace.INFO, "Setting start time to paused at: " + RelativeTime.format(-time.longValue()));
-		else
+		else if (countdownPauseTime != null)
 			Trace.trace(Trace.INFO,
-					"Setting start time to: " + Timestamp.format(time) + " (" + ContestUtil.formatTime(time) + ")");
+					"Setting start time to paused at: " + RelativeTime.format(countdownPauseTime.longValue()));
+		else
+			Trace.trace(Trace.INFO, "Setting start time to: " + Timestamp.format(startTime) + " ("
+					+ ContestUtil.formatTime(startTime) + ")");
 
 		Contest contest = cc.getContest();
 		long now = System.currentTimeMillis();
@@ -176,24 +151,22 @@ public class StartTimeService {
 		if (currentStartTime != null && currentStartTime > 0 && currentStartTime < now)
 			throw new IllegalArgumentException("Contest has already started");
 
-		if (currentStartTime != null && currentStartTime < 0 && time != null && time < 0)
-			throw new IllegalArgumentException("Contest already paused");
-
-		if (time != null && time > 0 && time < now)
+		if (startTime != null && startTime < now)
 			throw new IllegalArgumentException("Can't start contest in the past");
 
-		if (contest instanceof PlaybackContest)
-			((PlaybackContest) contest).setStartTime(time);
-
-		IInfo newInfo = contest.setStartStatus(time);
-
-		if (!cc.isTesting() && cc.getCCS() != null) {
-			ContestSource source = cc.getContestSource();
-			if (source instanceof RESTContestSource) {
-				RESTContestSource restSource = (RESTContestSource) source;
-				restSource.cacheClientSideEvent(newInfo, Delta.UPDATE);
+		if (cc.isTesting()) {
+			if (contest instanceof ReplayContest)
+				((ReplayContest) contest).setContestStart(startTime, countdownPauseTime);
+		} else {
+			if (cc.getCCS() != null) {
+				ContestSource source = cc.getContestSource();
+				if (source instanceof RESTContestSource) {
+					RESTContestSource restSource = (RESTContestSource) source;
+					IInfo newInfo = contest.setContestStart(startTime, countdownPauseTime);
+					restSource.cacheClientSideEvent(newInfo, Delta.UPDATE);
+				}
+				source.setContestStart(startTime, countdownPauseTime);
 			}
-			source.setStartTime(time);
 		}
 	}
 }

--- a/CDS/src/org/icpc/tools/cds/util/CDSContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/CDSContest.java
@@ -3,10 +3,9 @@ package org.icpc.tools.cds.util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.locks.LockSupport;
+import java.util.Objects;
 
 import org.icpc.tools.cds.ConfiguredContest;
-import org.icpc.tools.cds.ConfiguredContest.Test;
 import org.icpc.tools.cds.ConfiguredContest.View;
 import org.icpc.tools.cds.video.ReactionVideoRecorder;
 import org.icpc.tools.cds.video.VideoAggregator;
@@ -21,7 +20,6 @@ import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
-import org.icpc.tools.contest.model.feed.Timestamp;
 import org.icpc.tools.contest.model.internal.Award;
 import org.icpc.tools.contest.model.internal.Clarification;
 import org.icpc.tools.contest.model.internal.Contest;
@@ -39,7 +37,20 @@ import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.internal.Submission;
 import org.icpc.tools.contest.model.internal.Team;
 
-public class PlaybackContest extends Contest {
+/**
+ * CDS Contest enables most of the CDS capabilities and behaviours on a contest:
+ * <ul>
+ * <li>Applies configuration defaults</li>
+ * <li>Adds video streams to teams, and cuts them off at contest freeze</li>
+ * <li>Downloads file references for contest objects</li>
+ * <li>Logs contest state change events (e.g. 'Contest started')</li>
+ * <li>Records reactions</li>
+ * <li>Does view filtering (contest subset)</li>
+ * <li>Enables countdown pause times (for CCSs that don't support it)</li>
+ * </ul>
+ *
+ */
+public class CDSContest extends Contest {
 	private static final String LOGO = "logo";
 	private static final String PHOTO = "photo";
 	private static final String VIDEO = "video";
@@ -55,93 +66,19 @@ public class PlaybackContest extends Contest {
 	private static final String KEY_LOG = "key_log";
 	private static final String TOOL_DATA = "tool_data";
 
-	protected ConfiguredContest cc;
-	protected String contestId;
-	protected boolean recordReactions;
-	protected boolean isTesting;
-	protected double timeMultiplier = Double.NaN;
-	protected Long startTime;
+	private ConfiguredContest cc;
+	private String contestId;
+	private boolean recordReactions;
 	private Contest defaultConfig = new Contest(false);
 
-	public PlaybackContest(ConfiguredContest cc) {
+	private State[] currentState = new State[1];
+
+	public CDSContest(ConfiguredContest cc) {
 		contestId = cc.getId();
 		recordReactions = cc.isRecordingReactions();
 		this.cc = cc;
-	}
 
-	public void setStartTime(Long startTime) {
-		this.startTime = startTime;
-	}
-
-	public void setTestMode() {
-		Test test = cc.getTest();
-		timeMultiplier = test.getMultiplier();
-		if (test.getStartTime() >= 0) {
-			startTime = test.getStartTime();
-			Trace.trace(Trace.USER, "Contest " + contestId + " starting at " + Timestamp.format(startTime));
-		} else if (test.getCountdown() >= 0) {
-			startTime = System.currentTimeMillis() + test.getCountdown() * 1000L;
-			Trace.trace(Trace.USER, "Contest " + contestId + " starting in " + test.getCountdown() + " seconds");
-		} else { // default to 30s countdown
-			startTime = System.currentTimeMillis() + 30L * 1000L;
-			Trace.trace(Trace.USER, "Contest " + contestId + " starting in 30s");
-		}
-
-		isTesting = true;
-	}
-
-	/**
-	 * Delay if we haven't reached the given contest time in ms based on the contest start time and
-	 * the time multiplier.
-	 *
-	 * @param info
-	 * @param time
-	 */
-	protected void waitForContestTime(long time) {
-		if (startTime == null || startTime < 0)
-			return;
-
-		double contestTime = System.currentTimeMillis() - startTime;
-		long dt = (long) (time / timeMultiplier - contestTime);
-
-		// no point waiting for less that 5ms
-		if (dt < 5)
-			return;
-
-		// let people know if we'll be waiting for a while
-		if (dt > 5000)
-			Trace.trace(Trace.USER, "Sleeping for " + (int) (dt / 100) / 10f + " seconds.");
-
-		try {
-			LockSupport.parkNanos(dt * 1_000_000);
-		} catch (Exception e) {
-			// ignore
-		}
-	}
-
-	private void fixInfoStartTime(Info info) {
-		if (info.getStartTime() == null)
-			return;
-
-		info.setStartStatus(startTime);
-	}
-
-	private void fixStateTimes(State state) {
-		if (startTime == null || startTime < 0)
-			return;
-
-		if (state.getStarted() != null)
-			state.setStarted(startTime);
-		if (state.getEnded() != null)
-			state.setEnded(startTime + getDuration());
-		if (state.getFrozen() != null)
-			state.setFrozen(startTime + getDuration() - getFreezeDuration());
-		if (state.getThawed() != null)
-			state.setThawed(startTime + getDuration());
-		if (state.getFinalized() != null)
-			state.setFinalized(startTime + getDuration());
-		if (state.getEndOfUpdates() != null)
-			state.setEndOfUpdates(startTime + getDuration());
+		currentState[0] = new State();
 	}
 
 	protected void downloadAndSync(RESTContestSource src, IContestObject obj) {
@@ -378,21 +315,40 @@ public class PlaybackContest extends Contest {
 			}
 		}
 
-		if (obj instanceof Submission) {
-			Submission sub = (Submission) obj;
+		// record reactions if not testing
+		if (recordReactions && !cc.isTesting()) {
+			if (obj instanceof Submission) {
+				Submission sub = (Submission) obj;
 
-			if (recordReactions && !isTesting)
 				ReactionVideoRecorder.getInstance().startRecording(cc, sub);
-		}
+			}
 
-		if (obj instanceof Judgement) {
-			Judgement j = (Judgement) obj;
-			if (recordReactions && !isTesting && j.getJudgementTypeId() != null)
-				ReactionVideoRecorder.getInstance().stopRecording(cc, j);
+			if (obj instanceof Judgement) {
+				Judgement j = (Judgement) obj;
+				if (j.getJudgementTypeId() != null)
+					ReactionVideoRecorder.getInstance().stopRecording(cc, j);
+			}
 		}
 
 		if (obj instanceof State) {
 			State state = (State) obj;
+
+			if (obj instanceof State) {
+				State state2 = (State) obj;
+				if (!Objects.equals(currentState[0].getStarted(), state2.getStarted()))
+					Trace.trace(Trace.USER, "Contest started: " + contestId);
+				if (!Objects.equals(currentState[0].getFrozen(), state2.getFrozen()))
+					Trace.trace(Trace.USER, "Contest frozen: " + contestId);
+				if (!Objects.equals(currentState[0].getThawed(), state2.getThawed()))
+					Trace.trace(Trace.USER, "Contest thawed: " + contestId);
+				if (!Objects.equals(currentState[0].getEnded(), state2.getEnded()))
+					Trace.trace(Trace.USER, "Contest ended: " + contestId);
+				if (!Objects.equals(currentState[0].getFinalized(), state2.getFinalized()))
+					Trace.trace(Trace.USER, "Contest finalized: " + contestId);
+				if (!Objects.equals(currentState[0].getEndOfUpdates(), state2.getEndOfUpdates()))
+					Trace.trace(Trace.USER, "Contest end of updates: " + contestId);
+				currentState[0] = state2;
+			}
 			if (state.isFrozen() && state.isRunning() && VideoAggregator.isRunning())
 				VideoAggregator.getInstance().dropUntrustedListeners();
 		}
@@ -411,84 +367,12 @@ public class PlaybackContest extends Contest {
 		// if the CCS says the contest is stopped but doesn't support pause time, fix it
 		if (obj instanceof Info) {
 			Info info = (Info) obj;
+			info.setId(cc.getId());
+
 			Info currentInfo = getInfo();
 			if (info.getStartTime() == null && info.getCountdownPauseTime() == null && !info.supportsCountdownPauseTime()
 					&& currentInfo != null)
 				info.setCountdownPauseTime(currentInfo.getCountdownPauseTime());
-		}
-
-		if (!isTesting) {
-			super.add(obj);
-			return;
-		}
-
-		if (obj instanceof Info) {
-			Info info = (Info) obj;
-			fixInfoStartTime(info);
-			if (!Double.isNaN(timeMultiplier))
-				info.setTimeMultiplier(timeMultiplier);
-		}
-
-		if (obj instanceof State) {
-			State state = (State) obj;
-			fixStateTimes(state);
-
-			// if we're testing and contest hasn't started yet, just loop for 5s in case something
-			// changes
-			if (getState().getStarted() == null) {
-				double dt = 5000;
-				if (startTime != null && startTime > 0)
-					dt = startTime - System.currentTimeMillis();
-				while (dt > 2500) {
-					// wait for 2s
-					try {
-						LockSupport.parkNanos(2000 * 1_000_000);
-					} catch (Exception e) {
-						// ignore
-					}
-
-					fixStateTimes(state);
-					dt = 5000;
-					if (startTime != null && startTime > 0)
-						dt = startTime - System.currentTimeMillis();
-				}
-			}
-
-			if (state.isRunning())
-				waitForContestTime(0);
-			if (state.isFrozen())
-				waitForContestTime(getDuration() - getFreezeDuration());
-			if ((!state.isRunning() && state.isFrozen()) || state.isFinal())
-				waitForContestTime(getDuration());
-		}
-
-		if (obj instanceof Submission) {
-			Submission s = (Submission) obj;
-			waitForContestTime(s.getContestTime());
-			s.add("time", Timestamp.now());
-		}
-
-		if (obj instanceof Judgement) {
-			Judgement j = (Judgement) obj;
-			if (j.getEndContestTime() != null) {
-				waitForContestTime(j.getEndContestTime());
-				j.add("end_time", Timestamp.now());
-			} else {
-				waitForContestTime(j.getStartContestTime());
-				j.add("start_time", Timestamp.now());
-			}
-		}
-
-		if (obj instanceof Run) {
-			Run r = (Run) obj;
-			waitForContestTime(r.getContestTime());
-			r.add("time", Timestamp.now());
-		}
-
-		if (obj instanceof Clarification) {
-			Clarification c = (Clarification) obj;
-			waitForContestTime(c.getContestTime());
-			c.add("time", Timestamp.now());
 		}
 
 		super.add(obj);

--- a/CDS/src/org/icpc/tools/cds/util/ReplayContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/ReplayContest.java
@@ -1,0 +1,222 @@
+package org.icpc.tools.cds.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.LockSupport;
+
+import org.icpc.tools.cds.ConfiguredContest;
+import org.icpc.tools.contest.Trace;
+import org.icpc.tools.contest.model.IContestObject;
+import org.icpc.tools.contest.model.IContestObject.ContestType;
+import org.icpc.tools.contest.model.feed.Timestamp;
+import org.icpc.tools.contest.model.internal.Info;
+import org.icpc.tools.contest.model.internal.Judgement;
+import org.icpc.tools.contest.model.internal.State;
+import org.icpc.tools.contest.model.internal.TimedEvent;
+
+/**
+ * A replay contest that withholds all time-based events until the contest starts, then replays
+ * them according to the correct contest time.
+ */
+public class ReplayContest extends CDSContest {
+	protected ConfiguredContest cc;
+	protected double timeMultiplier;
+	protected Long startTime;
+	protected boolean stopReplay = false;
+
+	protected Thread startThread;
+
+	protected List<IContestObject> timedObject = new ArrayList<IContestObject>();
+
+	public ReplayContest(ConfiguredContest cc) {
+		super(cc);
+		this.cc = cc;
+		setHashCode(hashCode() + (int) (Math.random() * 500.0));
+
+		if (cc.getTest().getStartTime() > 0) {
+			startTime = cc.getTest().getStartTime();
+		} else {
+			startTime = System.currentTimeMillis() + cc.getTest().getCountdown() * 1000;
+		}
+
+		timeMultiplier = cc.getTest().getMultiplier();
+
+		createReplayThread();
+	}
+
+	private void createReplayThread() {
+		startThread = new Thread("Contest replay") {
+			@Override
+			public void run() {
+				long timeUntilContest = startTime != null ? startTime - System.currentTimeMillis() : Long.MAX_VALUE;
+
+				// keep waiting for 5s until we're within 1s of the start time
+				while (timeUntilContest > 1000 && !stopReplay) {
+					try {
+						Thread.sleep(Math.min(timeUntilContest, 5000));
+					} catch (Exception e) {
+						// ignore
+					}
+					timeUntilContest = startTime != null ? startTime - System.currentTimeMillis() : Long.MAX_VALUE;
+				}
+
+				// release objects
+				releaseEvents();
+			}
+		};
+		startThread.setDaemon(true);
+		startThread.start();
+	}
+
+	public void stopReplay() {
+		stopReplay = true;
+
+		startThread.interrupt();
+	}
+
+	@Override
+	public Info setContestStart(Long startTime, Long countdownTime) {
+		this.startTime = startTime;
+		try {
+			startThread.interrupt();
+		} catch (Exception e) {
+			// ignore
+		}
+		return super.setContestStart(startTime, countdownTime);
+	}
+
+	/**
+	 * Delay if we haven't reached the given contest time in ms based on the contest start time and
+	 * the time multiplier.
+	 *
+	 * @param info
+	 * @param time
+	 */
+	protected void waitForContestTime(long time) {
+		if (startTime == null || startTime < 0)
+			return;
+
+		double contestTime = System.currentTimeMillis() - startTime;
+		long dt = (long) (time / timeMultiplier - contestTime);
+
+		// no point waiting for less that 5ms
+		if (dt < 5)
+			return;
+
+		// let people know if we'll be waiting for a while
+		if (dt > 5000)
+			Trace.trace(Trace.USER, "Sleeping for " + (int) (dt / 100) / 10f + " seconds.");
+
+		try {
+			LockSupport.parkNanos(dt * 1_000_000);
+		} catch (Exception e) {
+			// ignore
+		}
+	}
+
+	private static boolean isTimedEvent(IContestObject obj) {
+		ContestType type = obj.getType();
+		return (type == ContestType.STATE || type == ContestType.SUBMISSION || type == ContestType.JUDGEMENT
+				|| type == ContestType.CLARIFICATION || type == ContestType.COMMENTARY || type == ContestType.RUN);
+	}
+
+	private void releaseEvents() {
+		while (!timedObject.isEmpty() && !stopReplay) {
+			IContestObject nextObj = null;
+			long nextTime = Long.MAX_VALUE;
+			for (IContestObject obj : timedObject) {
+				long time = getReleaseTime(obj);
+				if (time < nextTime) {
+					nextObj = obj;
+					nextTime = time;
+				}
+			}
+
+			waitForContestTime(nextTime);
+
+			timedObject.remove(nextObj);
+			fixWallClockTime(nextObj);
+			super.add(nextObj);
+		}
+	}
+
+	private long getReleaseTime(IContestObject obj) {
+		if (obj instanceof Info) {
+			//
+		}
+		if (obj instanceof State) {
+			State state = (State) obj;
+			if (state.getEnded() != null) {
+				return getDuration();
+			}
+			if (state.getFrozen() != null) {
+				return getDuration() - getFreezeDuration();
+			}
+			if (state.getStarted() != null)
+				waitForContestTime(0);
+		}
+		if (obj instanceof TimedEvent) {
+			TimedEvent te = (TimedEvent) obj;
+			return te.getContestTime();
+		}
+		if (obj instanceof Judgement) {
+			Judgement j = (Judgement) obj;
+			if (j.getEndContestTime() != null)
+				return j.getEndContestTime();
+
+			return j.getStartContestTime();
+		}
+
+		return 0;
+	}
+
+	@Override
+	public void add(IContestObject obj) {
+		if (isTimedEvent(obj)) {
+			timedObject.add(obj);
+			return;
+		}
+
+		if (obj instanceof Info) {
+			Info info = (Info) obj;
+			info.setStartTime(startTime);
+			info.setTimeMultiplier(timeMultiplier);
+		}
+
+		super.add(obj);
+	}
+
+	public void fixWallClockTime(IContestObject obj) {
+		if (obj instanceof State) {
+			State state = (State) obj;
+
+			long duration = getDuration();
+			if (state.getStarted() != null)
+				state.setStarted(startTime);
+			if (state.getEnded() != null)
+				state.setEnded(startTime + duration);
+			if (state.getFrozen() != null)
+				state.setFrozen(startTime + duration - getFreezeDuration());
+			if (state.getThawed() != null)
+				state.setThawed(startTime + duration);
+			if (state.getFinalized() != null)
+				state.setFinalized(startTime + duration);
+			if (state.getEndOfUpdates() != null)
+				state.setEndOfUpdates(startTime + duration);
+		}
+
+		if (obj instanceof TimedEvent) {
+			TimedEvent te = (TimedEvent) obj;
+			te.add("time", Timestamp.now());
+		}
+
+		if (obj instanceof Judgement) {
+			Judgement j = (Judgement) obj;
+			if (j.getEndContestTime() != null) {
+				j.add("end_time", Timestamp.now());
+			} else {
+				j.add("start_time", Timestamp.now());
+			}
+		}
+	}
+}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -401,11 +401,11 @@ public abstract class ContestSource {
 	}
 
 	/**
-	 * Set the contest start time to null or a value in ms since the epoch.
+	 * Set the contest start or countdown pause times in ms since the epoch.
 	 *
 	 * @throws IOException
 	 */
-	public void setStartTime(Long time) throws IOException {
+	public void setContestStart(Long startTime, Long countdownPauseTime) throws IOException {
 		// ignore
 	}
 

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -763,7 +763,7 @@ public class RESTContestSource extends DiskContestSource {
 	 * @throws IOException
 	 */
 	@Override
-	public void setStartTime(Long time) throws IOException {
+	public void setContestStart(Long startTime, Long countdownPauseTime) throws IOException {
 		try {
 			Trace.trace(Trace.INFO, "Setting contest time at " + url);
 
@@ -776,14 +776,14 @@ public class RESTContestSource extends DiskContestSource {
 			BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream()));
 			bw.write("{ \"id\":\"" + contestId + "\", \"start_time\":");
 
-			if (time == null || time <= 0)
+			if (startTime == null || startTime <= 0)
 				bw.write("null");
 			else
-				bw.write("\"" + Timestamp.format(time.longValue()) + "\"");
+				bw.write("\"" + Timestamp.format(startTime.longValue()) + "\"");
 
-			if (time != null && time < 0) {
+			if (countdownPauseTime != null && countdownPauseTime > 0) {
 				bw.write(", \"countdown_pause_time\":");
-				bw.write("\"" + RelativeTime.format(-time.longValue()) + "\"");
+				bw.write("\"" + RelativeTime.format(countdownPauseTime.longValue()) + "\"");
 			}
 
 			bw.write(" }");

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -756,12 +756,13 @@ public class Contest implements IContest {
 		return Math.round(contestTimeMs * timeMultiplier);
 	}
 
-	public Info setStartStatus(Long start) {
+	public Info setContestStart(Long startTime, Long countdownPauseTime) {
 		if (info == null)
 			throw new IllegalArgumentException("Contest isn't initialized yet");
 
 		Info info2 = (Info) info.clone();
-		info2.setStartStatus(start);
+		info2.setStartTime(startTime);
+		info2.setCountdownPauseTime(countdownPauseTime);
 		add(info2);
 		return info2;
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Info.java
@@ -113,18 +113,8 @@ public class Info extends ContestObject implements IInfo {
 		return startTime;
 	}
 
-	public void setStartStatus(Long start) {
-		if (start == null) {
-			pauseTime = null;
-			startTime = null;
-		} else if (start.longValue() < 0) {
-			pauseTime = -start.longValue();
-			supportsPauseTime = true;
-			startTime = null;
-		} else {
-			pauseTime = null;
-			startTime = start;
-		}
+	public void setStartTime(Long time) {
+		startTime = time;
 	}
 
 	public boolean supportsCountdownPauseTime() {


### PR DESCRIPTION
The CDS playback mechanism has been based on replaying a feed - chronologically pausing on each new event. However, this meant it couldn't work on contests that didn't publish a feed, or where the feed uses arrays (i.e. all submissions in one array, then an array of judgements, etc) like the NAC26 challenge.

This change splits PlaybackContest into CDSContest (all the regular CDS behaviours) and ReplayContest (a contest that withholds any events that are time-based and replays them in time order). In regular use only CDSContest is used; when you add the <test> element to config it uses ReplayContest (which extends CDSContest).

I moved a little bit of the logic from ConfiguredContest into CDSContest, because that's where it should have been and cleans things up a little. When working on pausing/resuming I got confused a couple times with the 'start status' - a single value that represented either a positive contest start wall clock time or a negative countdown pause. It made this change even bigger, but startTime and countdownPauseTime are clearly separate values everywhere and setContestStart() whenever you are setting both at the same time.

I've tested pausing countdown and restarting, everything seems to work like before.

What this change still doesn't do is split up 'merged' events. e.g. if the contest data only has a final state event with all the times, the contest won't 'start' - you'll only get the state event at the end. Ditto with completed judgements not getting an event at the start of judging. Opened #1315 to track this.

Fixes #1295.