### PR TITLE
Update to WF50 information access policy

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
@@ -40,7 +40,7 @@ public class SpectatorContest extends PublicContest {
 				addIt(obj);
 				return;
 			}
-			case RUN: { // TODO - access block for live
+			case RUN: {
 				IRun run = (IRun) obj;
 
 				IJudgement j = getJudgementById(run.getJudgementId());


### PR DESCRIPTION
Implements the changes in this year's contest data information access policy:
1. “Submissions > Language”, changed the access for role “Spectator” from “S” to “Y”.
2. “Judgements”, added a new row for “Judgement type”, with access by role as: Spectator : F,& ; Teams : N,* ; Analyst : F,& ; Staff : Y.
3. “Runs”, changed Spectator access from “N” to “F”. (#1121)

1. Was a misnomer, spectators don't have access to submissions before the contest so this was just making the policy text consistent.
2. The change is that teams shouldn't see other team's specific judgement type, which isn't implementable (nor exposed) at the CDS level until we get to the 2026_01 spec.
3. Was already implemented in May 2025: #1121. Just removing the TODO.

Fixes #1286.