### PR TITLE
Handle null judgement score without logging

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/ContestObject.java
@@ -107,7 +107,19 @@ public abstract class ContestObject implements IContestObject {
 		}
 	}
 
+	protected static Boolean parseBooleanObj(Object value) {
+		if (value == null || "null".equals(value))
+			return null;
+
+		if (value instanceof Boolean)
+			return (Boolean) value;
+		return Boolean.parseBoolean((String) value);
+	}
+
 	protected static boolean parseBoolean(Object value) {
+		if (value == null || "null".equals(value))
+			return false;
+
 		if (value instanceof Boolean)
 			return (Boolean) value;
 		return Boolean.parseBoolean((String) value);
@@ -125,7 +137,19 @@ public abstract class ContestObject implements IContestObject {
 		return Long.parseLong((String) value);
 	}
 
+	protected static Double parseDoubleObj(Object value) throws NumberFormatException {
+		if (value == null || "null".equals(value))
+			return null;
+
+		if (value instanceof Double)
+			return (Double) value;
+		return Double.parseDouble((String) value);
+	}
+
 	protected static double parseDouble(Object value) throws NumberFormatException {
+		if (value == null || "null".equals(value))
+			return Double.NaN;
+
 		if (value instanceof Double)
 			return (Double) value;
 		return Double.parseDouble((String) value);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Judgement.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Judgement.java
@@ -129,10 +129,10 @@ public class Judgement extends ContestObject implements IJudgement {
 			endTime = parseTimestamp(value);
 			return true;
 		} else if (SCORE.equals(name)) {
-			score = Double.parseDouble((String) value);
+			score = parseDoubleObj(value);
 			return true;
 		} else if (CURRENT.equals(name)) {
-			current = Boolean.parseBoolean((String) value);
+			current = parseBooleanObj(value);
 			return true;
 		}
 		return super.addImpl(name, value);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Problem.java
@@ -259,7 +259,7 @@ public class Problem extends ContestObject implements IProblem {
 				return true;
 			}
 			case MAX_SCORE: {
-				maxScore = parseDouble(value);
+				maxScore = parseDoubleObj(value);
 				return true;
 			}
 			case LOCATION: {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/TestData.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/TestData.java
@@ -43,7 +43,7 @@ public class TestData extends ContestObject implements ITestData {
 			ordinal = parseInt(value);
 			return true;
 		} else if (SAMPLE.equals(name)) {
-			isSample = parseBoolean(value);
+			isSample = parseBooleanObj(value);
 			return true;
 		}
 


### PR DESCRIPTION
I noticed at NAC there were judgements with '"score":null'. This was a little odd since it wasn't a scoring contest, but totally valid from a spec perspective. This caused the CDS to output a parsing error - with no impact, but could have caused someone to take time to confirm that.

This just changes it to handle null properly and avoid the log message. I handled the same thing in other Double and Boolean while I was at it, also added "null" as a string, since I've seen that accidentally in a feed before and it's handled elsewhere.