### PR TITLE
Fix access endpoint and add default properties

### DIFF
--- a/CDS/src/org/icpc/tools/cds/AccessService.java
+++ b/CDS/src/org/icpc/tools/cds/AccessService.java
@@ -65,7 +65,7 @@ public class AccessService {
 		Set<String>[] allKnownProperties = cc.getContestByRole(request).getKnownProperties();
 		for (IContestObject.ContestType ct : IContestObject.ContestType.values()) {
 			Set<String> properties = allKnownProperties[ct.ordinal()];
-			if (properties != null) {
+			if (properties != null && !properties.isEmpty()) {
 				je.writeSeparator();
 				je.open();
 				if (ct == IContestObject.ContestType.CONTEST)

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -96,6 +96,27 @@ public class Contest implements IContest {
 	public Contest(boolean keepHistory) {
 		data = new ContestData(keepHistory);
 		data.add(state);
+
+		addDefaultKnownProperties();
+	}
+
+	protected void addDefaultKnownProperties() {
+		addKnownProperties(IContestObject.ContestType.STATE, "started", "ended", "end_of_updates");
+
+		addKnownProperties(IContestObject.ContestType.PROBLEM, "id", "label", "name", "ordinal");
+
+		addKnownProperties(IContestObject.ContestType.SUBMISSION, "id", "language_id", "problem_id", "team_id");
+
+		addKnownProperties(IContestObject.ContestType.JUDGEMENT, "id", "submission_id", "start_time", "end_time");
+	}
+
+	protected void addKnownProperties(ContestType type, String... props) {
+		Set<String> knownProps = new SimpleSet();
+		allKnownProperties[type.ordinal()] = knownProps;
+
+		for (String s : props) {
+			knownProps.add(s);
+		}
 	}
 
 	@Override

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/SimpleSet.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/SimpleSet.java
@@ -70,7 +70,7 @@ public class SimpleSet implements Set<String> {
 
 			@Override
 			public boolean hasNext() {
-				return count < size - 1;
+				return count < size;
 			}
 
 			@Override


### PR DESCRIPTION
I was looking at the access endpoint and noticed a few issues:
1. some properties were missing due to a bug in SimpleSet
2. if there are no visible properties on an object it includes a property ""
3. if objects don't exist yet (e.g. submissions before a contest) then there's no access listed

1 & 2 are simple bug fixes, 3 needs more explanation.

The CDS should probably check the /access endpoint of any CCS providing data, but that isn't done today for a few reasons [1]. Instead, initial data is loaded for each role and then /access is directly based on the properties that the role has access to. This works well for all 'static' data (i.e. once the CDS is configured you know for sure whether there are logos or not and who can access them), but not for things like state and submissions that don't exist yet.

This change just adds some default properties that will exist for sure once you receive a state, problem, submission, or judgement. They are not 100% complete (i.e. access to additional props may be added during the contest, and pass-fail or scoring will add different properties), but at least the initial object and core properties are there.

[1] First, it's complicated: CCS may tell you about 3 properties and you need to filter out non-spec properties and role-access to determine which one(s) to include in /access. Second, if the CCS endpoint is invalid or under-commits we're the same as today, and if it over-commits we're actually worse. Third: need a separate solution when loading from disk / replaying a contest.