### PR TITLE
Strict spec versioning

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -30,6 +30,7 @@ import org.icpc.tools.contest.model.ILanguage;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.Scoreboard;
 import org.icpc.tools.contest.model.feed.ContestAPIHelper;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper.SpecVersion;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.DiskContestSource;
 import org.icpc.tools.contest.model.feed.JSONArrayWriter;
@@ -86,13 +87,16 @@ public class ContestRESTService extends HttpServlet {
 		}
 
 		if (path != null && path.startsWith("/2026-01")) {
-			ContestAPIHelper.set2026_01();
+			ContestAPIHelper.setVersion(SpecVersion.v2026_01);
 			path = path.substring(8);
+		} else if (path != null && path.startsWith("/2026-draft")) {
+			ContestAPIHelper.setVersion(SpecVersion.v2026_draft);
+			path = path.substring(11);
 		} else if (path != null && path.startsWith("/2023-06")) {
-			ContestAPIHelper.set2023_06();
+			ContestAPIHelper.setVersion(SpecVersion.v2023_06);
 			path = path.substring(8);
 		} else {
-			ContestAPIHelper.set2026_01();
+			ContestAPIHelper.setVersion(SpecVersion.v2026_01);
 		}
 		if (path == null || path.equals("") || path.equals("/")) {
 			sendAPIInfo(response);
@@ -297,15 +301,15 @@ public class ContestRESTService extends HttpServlet {
 		je.encode("name", "Contest Data Server");
 		je.encodePrimitive("logo", "[{\"href\":\"/cdsIcon.png\",\"filename\":\"logo.png\","
 				+ "\"mime\":\"image/png\",\"width\":512,\"height\":512}]");
-		if (ContestAPIHelper.is2026_01()) {
-			je.encode("version", "2026-01");
-			je.encode("version_url", "https://ccs-specs.icpc.io/2026-01/contest_api");
+		if (ContestAPIHelper.is2026_draft()) {
+			je.encode("version", "2026-draft");
+			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
 		} else if (ContestAPIHelper.is2023_06()) {
 			je.encode("version", "2023-06");
 			je.encode("version_url", "https://ccs-specs.icpc.io/2023-06/contest_api");
 		} else {
-			je.encode("version", "draft");
-			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
+			je.encode("version", "2026-01");
+			je.encode("version_url", "https://ccs-specs.icpc.io/2026-01/contest_api");
 		}
 		je.close();
 	}

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -16,26 +16,54 @@ import org.icpc.tools.contest.model.internal.Info;
 public class ContestAPIHelper {
 	protected static boolean isCDS;
 
-	private enum Version {
-		v2023_06, v2026_01
+	public enum SpecVersion {
+		v2023_06, v2026_01, v2026_draft
 	}
 
-	private static final ThreadLocal<Version> local = new ThreadLocal<>();
+	private static final ThreadLocal<SpecVersion> local = new ThreadLocal<>();
 
-	public static void set2026_01() {
-		local.set(Version.v2026_01);
+	public static SpecVersion parseVersion(String version) {
+		if ("2026-01".equals(version))
+			return SpecVersion.v2026_01;
+		else if ("2023-06".equals(version))
+			return SpecVersion.v2023_06;
+		else if ("2026-draft".equals(version))
+			return SpecVersion.v2026_draft;
+
+		// unknown or invalid version
+		return null;
 	}
 
-	public static void set2023_06() {
-		local.set(Version.v2023_06);
+	public static void setVersion(SpecVersion v) {
+		local.set(v);
 	}
 
+	/**
+	 * Helper method to tell if we're using the 2026-draft spec version
+	 */
+	public static boolean is2026_draft() {
+		return local.get() == SpecVersion.v2026_draft;
+	}
+
+	/**
+	 * Helper method to tell if we're using the 2026-01 spec version
+	 */
 	public static boolean is2026_01() {
-		return local.get() == Version.v2026_01;
+		return local.get() == SpecVersion.v2026_01;
 	}
 
+	/**
+	 * Helper method to tell if we're using the 2023-06 spec version
+	 */
 	public static boolean is2023_06() {
-		return local.get() == Version.v2023_06;
+		return local.get() == SpecVersion.v2023_06;
+	}
+
+	/**
+	 * Helper method to tell if we're using the 2023-06 spec version
+	 */
+	public static boolean isUnknownSpec() {
+		return local.get() == null;
 	}
 
 	static class Result {

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -43,6 +43,7 @@ import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IContestObject.ContestType;
 import org.icpc.tools.contest.model.IOrganization;
 import org.icpc.tools.contest.model.ITeam;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper.SpecVersion;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.ContestObject;
 import org.icpc.tools.contest.model.internal.FileReference;
@@ -75,6 +76,7 @@ public class RESTContestSource extends DiskContestSource {
 	private boolean firstConnection = true;
 	private int contestSizeBeforeFeed;
 	private boolean isCDS;
+	private SpecVersion specVersion;
 
 	/**
 	 * Creates a REST contest source with local (temp) caching.
@@ -141,6 +143,8 @@ public class RESTContestSource extends DiskContestSource {
 				feedCacheFile.delete();
 			}
 		}
+
+		cacheSpecVersion();
 	}
 
 	private void setup() {
@@ -214,6 +218,14 @@ public class RESTContestSource extends DiskContestSource {
 
 	private URL getChildURL(String path) throws Exception {
 		String u = url.toExternalForm();
+		if ("../..".equals(path)) {
+			// special case the API endpoint so we get a clean url
+			int ind = u.lastIndexOf("/", u.length() - 1);
+			u = u.substring(0, ind);
+			ind = u.lastIndexOf("/", u.length() - 1);
+			return new URI(u.substring(0, ind)).toURL();
+		}
+
 		if (u.endsWith("/"))
 			return new URI(u + path).toURL();
 
@@ -577,6 +589,38 @@ public class RESTContestSource extends DiskContestSource {
 		}
 	}
 
+	/**
+	 * Connect to the parent endpoint and cache the spec version.
+	 */
+	protected void cacheSpecVersion() {
+		if (specVersion != null) {
+			return;
+		}
+
+		try {
+			InputStream in = connect("../..");
+			BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+			StringBuilder sb = new StringBuilder();
+			String s = br.readLine();
+			while (s != null) {
+				sb.append(s);
+				s = br.readLine();
+			}
+
+			JSONParser parser2 = new JSONParser(sb.toString());
+			JsonObject obj = parser2.readObject();
+
+			String version = obj.getString("version");
+			specVersion = ContestAPIHelper.parseVersion(version);
+
+			if (specVersion == null) {
+				Trace.trace(Trace.WARNING, "Unknown spec version: " + version);
+			}
+		} catch (Exception e) {
+			Trace.trace(Trace.WARNING, "Could not determine spec version", e);
+		}
+	}
+
 	@Override
 	protected void loadContestImpl() throws Exception {
 		if (url == null || feedFile != null)
@@ -617,6 +661,10 @@ public class RESTContestSource extends DiskContestSource {
 				} catch (Exception ex) {
 					Trace.trace(Trace.WARNING, "Could not write message to feed cache", ex);
 				}
+			}
+
+			if (specVersion != null) {
+				ContestAPIHelper.setVersion(specVersion);
 			}
 
 			in = new BackupInputStream(connect(path), feedCacheOut);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -72,13 +72,14 @@ public class Clarification extends TimedEvent implements IClarification {
 		} else if (FROM_TEAM_ID.equals(name)) {
 			fromTeamId = (String) value;
 			return true;
-		} else if (TO_TEAM_ID.equals(name)) {
+		} else if (TO_TEAM_ID.equals(name) && (ContestAPIHelper.is2023_06() || ContestAPIHelper.isUnknownSpec())) {
 			if (value == null || "null".equals(value))
 				toTeamIds = null;
 			else
 				toTeamIds = new String[] { (String) value };
 			return true;
-		} else if (TO_TEAM_IDS.equals(name)) {
+		} else if (TO_TEAM_IDS.equals(name)
+				&& (ContestAPIHelper.is2026_01() || ContestAPIHelper.is2026_draft() || ContestAPIHelper.isUnknownSpec())) {
 			if (value == null || "null".equals(value))
 				toTeamIds = null;
 			else {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -85,6 +85,12 @@ public class Contest implements IContest {
 	private int lastTimedEventIndex;
 	private boolean isConfigLoaded;
 
+	public enum SpecVersion {
+		UNKNOWN, v2026_01, v2023_06
+	}
+
+	private SpecVersion specVersion = SpecVersion.UNKNOWN;
+
 	// map of known properties for each contest type
 	@SuppressWarnings("unchecked")
 	protected Set<String>[] allKnownProperties = new Set[ContestType.values().length];
@@ -154,6 +160,14 @@ public class Contest implements IContest {
 		synchronized (modifiers) {
 			modifiers.remove(modifier);
 		}
+	}
+
+	public void setSpecVersion(SpecVersion version) {
+		this.specVersion = version;
+	}
+
+	public SpecVersion getSpecVersion() {
+		return specVersion;
 	}
 
 	public void add(IContestObject obj) {


### PR DESCRIPTION
Adds strict spec version parsing where individual properties can be read or ignored based on the version returned by the REST contest's API endpoint, starting with clarifications.

Changes the spec version on ContestAPIHelper to be public and cleans up the API a little.

Caches the spec version when you connect to a REST contest API, and logs if the spec version is unknown. When it is known it's set on the parser so that any contest object can check which version we expect we're reading from.

For now, only Clarifications are updated to switch which version of the to_team_ids property is parsed. We could be super-strict on other properties too (e.g. only parse the expected integer or RELTIME for penalty time) but that's a lot of change for no direct benefit, so this provides the mechanism we could do that but no other changes.

Fixes #1130.