### PR TITLE
Defer presentation server scheduler

### DIFF
--- a/CDS/src/org/icpc/tools/cds/presentations/PresentationServer.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PresentationServer.java
@@ -14,6 +14,7 @@ import java.util.prefs.Preferences;
 
 import org.icpc.tools.cds.CDSConfig;
 import org.icpc.tools.cds.CDSConfig.Domain;
+import org.icpc.tools.cds.service.ExecutorListener;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.feed.JSONParser;
@@ -52,6 +53,10 @@ public class PresentationServer {
 
 	private PresentationServer() {
 		super();
+
+		executor = ExecutorListener.getExecutor();
+
+		executor.scheduleWithFixedDelay(() -> forEachClient(clients, cl -> cl.writePing()), 30L, 45L, TimeUnit.SECONDS);
 	}
 
 	private static PresentationServer instance = new PresentationServer();
@@ -719,12 +724,6 @@ public class PresentationServer {
 	protected void handleCommand(JsonObject obj) {
 		int[] clientUIDs = readClients(obj);
 		sendCommand(clientUIDs, obj.getString("source"), obj.getString("action"));
-	}
-
-	public void setExecutor(ScheduledExecutorService executor) {
-		this.executor = executor;
-
-		executor.scheduleWithFixedDelay(() -> forEachClient(clients, cl -> cl.writePing()), 30L, 45L, TimeUnit.SECONDS);
 	}
 
 	public void scheduleCallback(IContest c, long contestTimeMs) {

--- a/CDS/src/org/icpc/tools/cds/service/ExecutorListener.java
+++ b/CDS/src/org/icpc/tools/cds/service/ExecutorListener.java
@@ -5,7 +5,6 @@ import java.util.concurrent.ThreadFactory;
 
 import org.icpc.tools.cds.CDSConfig;
 import org.icpc.tools.cds.ConfiguredContest;
-import org.icpc.tools.cds.presentations.PresentationServer;
 import org.icpc.tools.cds.video.ReactionVideoRecorder;
 import org.icpc.tools.cds.video.VideoAggregator;
 import org.icpc.tools.contest.Trace;
@@ -37,8 +36,6 @@ public class ExecutorListener implements ServletContextListener {
 		servletContextEvent.getServletContext().setAttribute("executor", executor);
 
 		new ContestFeedExecutor().start(executor);
-
-		PresentationServer.getInstance().setExecutor(executor);
 
 		ReactionVideoRecorder.getInstance().start(executor);
 	}


### PR DESCRIPTION
While working on streaming reactions I noticed that the presentation server is always triggered on CDS starting. This just defers it to not start scheduling jobs until something uses the presentation server the first time.