### PR TITLE
Presentation user role

### DIFF
--- a/CDS/src/org/icpc/tools/cds/CDSAuth.java
+++ b/CDS/src/org/icpc/tools/cds/CDSAuth.java
@@ -129,6 +129,14 @@ public class CDSAuth implements HttpAuthenticationMechanism {
 		return IAccount.PRES_ADMIN.equals(account.getAccountType()) || IAccount.ADMIN.equals(account.getAccountType());
 	}
 
+	public static boolean isPresUser(HttpServletRequest request) {
+		IAccount account = getAccount(request);
+		if (account == null)
+			return false;
+		return IAccount.PRES_USER.equals(account.getAccountType()) || IAccount.PRES_ADMIN.equals(account.getAccountType())
+				|| IAccount.ADMIN.equals(account.getAccountType());
+	}
+
 	public static boolean isStaff(HttpServletRequest request) {
 		IAccount account = getAccount(request);
 		if (account == null)

--- a/CDS/src/org/icpc/tools/cds/presentations/PropertyServlet.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PropertyServlet.java
@@ -25,7 +25,7 @@ public class PropertyServlet extends HttpServlet {
 
 	@Override
 	protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		if (!CDSAuth.isPresAdmin(request) && !CDSAuth.isAdmin(request)) {
+		if (!CDSAuth.isAdmin(request) && !CDSAuth.isPresAdmin(request) && !CDSAuth.isPresUser(request)) {
 			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 			return;
 		}
@@ -115,12 +115,18 @@ public class PropertyServlet extends HttpServlet {
 
 	@Override
 	protected void doPut(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-		if (!CDSAuth.isPresAdmin(request) && !CDSAuth.isAdmin(request)) {
+		if (!CDSAuth.isAdmin(request) && !CDSAuth.isPresAdmin(request) && !CDSAuth.isPresUser(request)) {
 			response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
 			return;
 		}
 		String path = request.getPathInfo();
 		if (path == null || path.length() < 2) {
+			response.sendError(HttpServletResponse.SC_BAD_REQUEST);
+			return;
+		}
+
+		// presentation users may only set properties
+		if (!path.startsWith("/property") && !CDSAuth.isAdmin(request) && !CDSAuth.isPresAdmin(request)) {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST);
 			return;
 		}

--- a/ContestModel/src/org/icpc/tools/contest/model/IAccount.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/IAccount.java
@@ -12,6 +12,7 @@ public interface IAccount extends IContestObject {
 	public String SPECTATOR = "spectator";
 	public String BALLOON = "balloon";
 	public String PRES_ADMIN = "presAdmin";
+	public String PRES_USER = "presUser";
 
 	/**
 	 * The name


### PR DESCRIPTION
Adds a presentation user role that can only set properties on presentations. The main purpose is the team intro presentation, where someone we don't trust as a presentation admin could still scan team badges to say who is entering the floor.

Roles with authority to change things:
Admin - can do anything
Pres admin - can only control presentations (what to show, properties, etc.) Pres admin with domains configured - same, but can only control a specific
  set of displays
Pres user - can only set properties on presentations

First part of #1282.