### PR TITLE
Fix missing judgement events in replay

### DIFF
--- a/CDS/src/org/icpc/tools/cds/util/ReplayContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/ReplayContest.java
@@ -131,17 +131,20 @@ public class ReplayContest extends CDSContest {
 		while (!timedObject.isEmpty() && !stopReplay) {
 			IContestObject nextObj = null;
 			long nextTime = Long.MAX_VALUE;
-			for (IContestObject obj : timedObject) {
+			int nextIndex = -1;
+			for (int i = 0; i < timedObject.size(); i++) {
+				IContestObject obj = timedObject.get(i);
 				long time = getReleaseTime(obj);
 				if (time < nextTime) {
 					nextObj = obj;
 					nextTime = time;
+					nextIndex = i;
 				}
 			}
 
 			waitForContestTime(nextTime);
 
-			timedObject.remove(nextObj);
+			timedObject.remove(nextIndex);
 			fixWallClockTime(nextObj);
 			super.add(nextObj);
 		}
@@ -153,7 +156,7 @@ public class ReplayContest extends CDSContest {
 			if (state.getEnded() != null) {
 				return getDuration();
 			}
-			if (state.getFrozen() != null) {
+			if (state.getFrozen() != null && getFreezeDuration() != null) {
 				return getDuration() - getFreezeDuration();
 			}
 			if (state.getStarted() != null)
@@ -199,7 +202,7 @@ public class ReplayContest extends CDSContest {
 				state.setStarted(startTime);
 			if (state.getEnded() != null)
 				state.setEnded(startTime + duration);
-			if (state.getFrozen() != null)
+			if (state.getFrozen() != null && getFreezeDuration() != null)
 				state.setFrozen(startTime + duration - getFreezeDuration());
 			if (state.getThawed() != null)
 				state.setThawed(startTime + duration);


### PR DESCRIPTION
This fixes two issues related to the new CDS contest replay:

1. When replaying a past contest, the next event is found by scanning objects in a list, an event is fired, and then the object is removed from the list. However, because they're removed from the list by object (id) it can remove the wrong instance of an object if anything was out of time order. e.g. if a final judgement was in the list before the start of judgement, it can fire the start judgement, remove the end judgement, and then fire the start again: no final judgement is ever sent. This fixes it to remove from the list based on the index.

2. A contest I tested had an invalid contest freeze time, which caused exceptions when the contest state froze later on. This just adds guards to avoid NPEs.