### PR TITLE
Read local api.json for contest version

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/DiskContestSource.java
@@ -36,6 +36,7 @@ import org.icpc.tools.contest.model.IProblem;
 import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.TSVImporter;
+import org.icpc.tools.contest.model.feed.ContestAPIHelper.SpecVersion;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.ContestObject;
@@ -1284,9 +1285,43 @@ public class DiskContestSource extends ContestSource {
 		return new File(root, "config" + File.separator + file);
 	}
 
+	protected static SpecVersion parseAPIJsonForVersion(BufferedReader br) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		String s = br.readLine();
+		while (s != null) {
+			sb.append(s);
+			s = br.readLine();
+		}
+
+		JSONParser parser2 = new JSONParser(sb.toString());
+		JsonObject obj = parser2.readObject();
+
+		String version = obj.getString("version");
+		SpecVersion specVersion = ContestAPIHelper.parseVersion(version);
+
+		if (specVersion == null) {
+			Trace.trace(Trace.WARNING, "Unknown spec version: " + version);
+		}
+		return specVersion;
+	}
+
 	protected void loadConfigFiles() {
 		if (root == null) // this is a cache
 			return;
+
+		// spec version
+		try {
+			File f = new File(root, "api.json");
+			if (f.exists()) {
+				BufferedReader br = new BufferedReader(new FileReader(f));
+				SpecVersion specVersion = parseAPIJsonForVersion(br);
+				if (specVersion != null)
+					ContestAPIHelper.setVersion(specVersion);
+			}
+		} catch (Exception e) {
+			configValidation.err("Could not determine spec version: " + e.getMessage());
+			Trace.trace(Trace.WARNING, "Could not determine spec version", e);
+		}
 
 		// load yamls
 		configValidation = new Validation();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/RESTContestSource.java
@@ -593,29 +593,13 @@ public class RESTContestSource extends DiskContestSource {
 	 * Connect to the parent endpoint and cache the spec version.
 	 */
 	protected void cacheSpecVersion() {
-		if (specVersion != null) {
+		if (specVersion != null || url == null)
 			return;
-		}
 
 		try {
 			InputStream in = connect("../..");
 			BufferedReader br = new BufferedReader(new InputStreamReader(in, "UTF-8"));
-			StringBuilder sb = new StringBuilder();
-			String s = br.readLine();
-			while (s != null) {
-				sb.append(s);
-				s = br.readLine();
-			}
-
-			JSONParser parser2 = new JSONParser(sb.toString());
-			JsonObject obj = parser2.readObject();
-
-			String version = obj.getString("version");
-			specVersion = ContestAPIHelper.parseVersion(version);
-
-			if (specVersion == null) {
-				Trace.trace(Trace.WARNING, "Unknown spec version: " + version);
-			}
+			specVersion = parseAPIJsonForVersion(br);
 		} catch (Exception e) {
 			Trace.trace(Trace.WARNING, "Could not determine spec version", e);
 		}


### PR DESCRIPTION
#1326 added code to check the Contest API for spec version and respect it when reading from the REST endpoints. It didn't add support for a local api.json file, and unfortunately it output an error to the console if you tried running everything locally (e.g. resolver loading contest from disk).

This fixes both - contests read from disk will look for api.json and respect it if it's found when reading other files from the contest package, and the error is now gone. Common utility function for reading the API moved to DiskContestSource for sharing.

Fixes #1330.