### PR TITLE
Team Intro page

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/countdown-control.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/countdown-control.jsp
@@ -102,32 +102,6 @@
             </tbody>
         </table>
     </div>
-    <div class="card-header">
-        <h3 class="card-title">Team Detail</h3>
-    </div>
-    <div class="card-body">
-    	<p>Set the team for the team detail presentation.</p>
-    	<form id="team-detail-form">
-        <div class="box-body">
-            <div class="form-group">
-                <label for="input-prefix" class="col-sm-4 control-label">Prefix (if multiple screens)</label>
-                <div class="col-sm-12">
-                    <input class="form-control" id="input-prefix" autocomplete="off" data-1p-ignore placeholder="e.g. 'left'">
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="input-team-id" class="col-sm-4 control-label">Team Id or Label</label>
-                <div class="col-sm-12">
-                    <input class="form-control" id="input-team-id" autocomplete="off" data-1p-ignore placeholder="e.g. '57'">
-                </div>
-            </div>
-        </div>
-        <div class="box-footer">
-          <button type="submit" class="btn btn-danger pull-right">Set</button>
-          <span id="detail-status">&nbsp;</span>
-        </div>
-        </form>
-    </div>
 </div>
 <script>
     var requestsDone = 0;
@@ -188,60 +162,6 @@
         sendCommandForContest(id, "<%= countdownContest.getId() %>", command);
         <% } %>
     }
-
-    $(function() {
-        $('#team-detail-form').on('submit', function() {
-            const $teamIdInput = $('#input-team-id')
-            let cmd = $teamIdInput.val();
-
-            const $prefixField = $('#input-prefix');
-            if ($prefixField.val()) {
-                cmd = $prefixField.val() + ':' + cmd;
-            }
-
-            console.log("Team detail: " + cmd);
-            var xmlhttp = new XMLHttpRequest();
-            xmlhttp.onreadystatechange = function () {
-                if (xmlhttp.readyState == 4) {
-                    if (xmlhttp.status == 200) {
-                        document.getElementById("detail-status").innerHTML = "Success";
-                    } else
-                        document.getElementById("detail-status").innerHTML = xmlhttp.responseText;
-                }
-            };
-            xmlhttp.open("PUT", "/presentation/admin/property/org.icpc.tools.presentation.contest.internal.presentations.TeamDetailPresentation=" + cmd, true);
-            xmlhttp.send();
-
-            // Clear the field again and set focus to keep going
-            $teamIdInput.val('');
-            $teamIdInput.focus();
-
-            return false;
-        });
-
-        if (typeof contest !== 'undefined') {
-            let teamMapping = [];
-            contest.loadTeams().then(function(data) {
-                for (let team of data) {
-                    teamMapping[team.id] = team.display_name;
-                }
-            });
-
-            $('#input-team-id').on('keyup', function (e) {
-                // Ignore enter
-                if (e.keyCode === 13) {
-                    return;
-                }
-                const teamId = $(this).val();
-                if (teamMapping[teamId]) {
-                    const team = teamMapping[teamId];
-                    $('#detail-status').text('Team: ' + team);
-                } else {
-                    $('#detail-status').text('Team not found');
-                }
-            })
-        }
-    });
 
     var contests = {
         <% for (IContest countdownContest : countdownContests) { %>

--- a/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/layout/head.jsp
@@ -185,6 +185,16 @@ function logout() {
             </li>
             <% } %>
             
+            <% if (CDSAuth.isPresUser(request)) { %>
+            <li class="nav-item">
+              <a href="${pageContext.request.contextPath}/presentation/admin/intro"
+                class="nav-link<% if (requestURI.contains("presentation/admin/intro")) { %> active<% } %>">
+                <i class="nav-icon fas fa-address-card"></i>
+                <p>Team Intro</p>
+              </a>
+            </li>
+            <% } %>
+            
             <% if (CDSAuth.isPresAdmin(request)) { %>
             <li class="nav-item">
               <a href="${pageContext.request.contextPath}/presentation/admin/web"

--- a/CDS/WebContent/WEB-INF/jsps/team-intro.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/team-intro.jsp
@@ -1,0 +1,92 @@
+<% request.setAttribute("title", "Team Intro"); %>
+<%@ include file="layout/head.jsp" %>
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-12">
+            <div class="card">
+                <div class="card-header">
+                    <h3 class="card-title">Team Intro</h3>
+                </div>
+   
+    <div class="card-body">
+    	<p>Set the team for the team detail presentation.</p>
+    	<form id="team-detail-form">
+        <div class="box-body">
+            <div class="form-group">
+                <label for="input-prefix" class="col-sm-4 control-label">Prefix (if multiple screens)</label>
+                <div class="col-sm-12">
+                    <input class="form-control" id="input-prefix" autocomplete="off" data-1p-ignore placeholder="e.g. 'left'">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="input-team-id" class="col-sm-4 control-label">Team Id or Label</label>
+                <div class="col-sm-12">
+                    <input class="form-control" id="input-team-id" autocomplete="off" data-1p-ignore placeholder="e.g. '57'">
+                </div>
+            </div>
+        </div>
+        <div class="box-footer">
+          <button type="submit" class="btn btn-danger pull-right">Set</button>
+          <span id="detail-status">&nbsp;</span>
+        </div>
+        </form>
+    </div>
+</div>
+</div>
+</div>
+</div>
+<script>
+    $(function() {
+        $('#team-detail-form').on('submit', function() {
+            const $teamIdInput = $('#input-team-id')
+            let cmd = $teamIdInput.val();
+
+            const $prefixField = $('#input-prefix');
+            if ($prefixField.val()) {
+                cmd = $prefixField.val() + ':' + cmd;
+            }
+
+            console.log("Team detail: " + cmd);
+            var xmlhttp = new XMLHttpRequest();
+            xmlhttp.onreadystatechange = function () {
+                if (xmlhttp.readyState == 4) {
+                    if (xmlhttp.status == 200) {
+                        document.getElementById("detail-status").innerHTML = "Success";
+                    } else
+                        document.getElementById("detail-status").innerHTML = xmlhttp.responseText;
+                }
+            };
+            xmlhttp.open("PUT", "/presentation/admin/property/org.icpc.tools.presentation.contest.internal.presentations.TeamDetailPresentation=" + cmd, true);
+            xmlhttp.send();
+
+            // Clear the field again and set focus to keep going
+            $teamIdInput.val('');
+            $teamIdInput.focus();
+
+            return false;
+        });
+
+        if (typeof contest !== 'undefined') {
+            let teamMapping = [];
+            contest.loadTeams().then(function(data) {
+                for (let team of data) {
+                    teamMapping[team.id] = team.display_name;
+                }
+            });
+
+            $('#input-team-id').on('keyup', function (e) {
+                // Ignore enter
+                if (e.keyCode === 13) {
+                    return;
+                }
+                const teamId = $(this).val();
+                if (teamMapping[teamId]) {
+                    const team = teamMapping[teamId];
+                    $('#detail-status').text('Team: ' + team);
+                } else {
+                    $('#detail-status').text('Team not found');
+                }
+            })
+        }
+    });
+</script>

--- a/CDS/src/org/icpc/tools/cds/presentations/PropertyServlet.java
+++ b/CDS/src/org/icpc/tools/cds/presentations/PropertyServlet.java
@@ -49,6 +49,9 @@ public class PropertyServlet extends HttpServlet {
 		} else if ("/web".equals(path)) {
 			request.getRequestDispatcher("/WEB-INF/jsps/present.jsp").forward(request, response);
 			return;
+		} else if ("/intro".equals(path)) {
+			request.getRequestDispatcher("/WEB-INF/jsps/team-intro.jsp").forward(request, response);
+			return;
 		} else {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST);
 			return;


### PR DESCRIPTION
Moves the team detail/intro control (where you can input which team has entered the team floor) from a section of the countdown control page onto its own page. This new page is accessible for pres users, pres admins, and admins. This cleanly separates the distinction between each role and what pages they have access to:
 - Pres user - can see this new page
 - Pres admin - can also see page to assign presentations
 - Admin - can also see countdown control

Fixes #1282.