### PR TITLE
Remove unused contest spec versioning

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -85,12 +85,6 @@ public class Contest implements IContest {
 	private int lastTimedEventIndex;
 	private boolean isConfigLoaded;
 
-	public enum SpecVersion {
-		UNKNOWN, v2026_01, v2023_06
-	}
-
-	private SpecVersion specVersion = SpecVersion.UNKNOWN;
-
 	// map of known properties for each contest type
 	@SuppressWarnings("unchecked")
 	protected Set<String>[] allKnownProperties = new Set[ContestType.values().length];
@@ -160,14 +154,6 @@ public class Contest implements IContest {
 		synchronized (modifiers) {
 			modifiers.remove(modifier);
 		}
-	}
-
-	public void setSpecVersion(SpecVersion version) {
-		this.specVersion = version;
-	}
-
-	public SpecVersion getSpecVersion() {
-		return specVersion;
 	}
 
 	public void add(IContestObject obj) {


### PR DESCRIPTION
Remove unused code from the contest that was never used. Initially I thought every contest would be at a specific spec version, but in reality you could have config files on disk and CCS at different spec levels, and multiple clients each also requiring different versions.

The support that we eventually settled on accounts for this, allowing disk, REST, and multiple clients to all be on different versions (except that we only have three supported versions of the spec at the moment, but you get the idea).