### PR TITLE
Draft spec versioning

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ContestRESTService.java
@@ -89,8 +89,8 @@ public class ContestRESTService extends HttpServlet {
 		if (path != null && path.startsWith("/2026-01")) {
 			ContestAPIHelper.setVersion(SpecVersion.v2026_01);
 			path = path.substring(8);
-		} else if (path != null && path.startsWith("/2026-draft")) {
-			ContestAPIHelper.setVersion(SpecVersion.v2026_draft);
+		} else if (path != null && path.startsWith("/2026-01-next")) {
+			ContestAPIHelper.setVersion(SpecVersion.v2026_01_next);
 			path = path.substring(11);
 		} else if (path != null && path.startsWith("/2023-06")) {
 			ContestAPIHelper.setVersion(SpecVersion.v2023_06);
@@ -301,14 +301,12 @@ public class ContestRESTService extends HttpServlet {
 		je.encode("name", "Contest Data Server");
 		je.encodePrimitive("logo", "[{\"href\":\"/cdsIcon.png\",\"filename\":\"logo.png\","
 				+ "\"mime\":\"image/png\",\"width\":512,\"height\":512}]");
-		if (ContestAPIHelper.is2026_draft()) {
-			je.encode("version", "2026-draft");
+		je.encode("version", ContestAPIHelper.getVersionString());
+		if (ContestAPIHelper.is2026_01_next()) {
 			je.encode("version_url", "https://ccs-specs.icpc.io/draft/contest_api");
 		} else if (ContestAPIHelper.is2023_06()) {
-			je.encode("version", "2023-06");
 			je.encode("version_url", "https://ccs-specs.icpc.io/2023-06/contest_api");
 		} else {
-			je.encode("version", "2026-01");
 			je.encode("version_url", "https://ccs-specs.icpc.io/2026-01/contest_api");
 		}
 		je.close();

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestAPIHelper.java
@@ -17,21 +17,42 @@ public class ContestAPIHelper {
 	protected static boolean isCDS;
 
 	public enum SpecVersion {
-		v2023_06, v2026_01, v2026_draft
+		v2023_06, v2026_01, v2026_01_next
 	}
 
 	private static final ThreadLocal<SpecVersion> local = new ThreadLocal<>();
 
 	public static SpecVersion parseVersion(String version) {
-		if ("2026-01".equals(version))
-			return SpecVersion.v2026_01;
-		else if ("2023-06".equals(version))
+		if ("2023-06".equals(version))
 			return SpecVersion.v2023_06;
-		else if ("2026-draft".equals(version))
-			return SpecVersion.v2026_draft;
+		else if ("2026-01".equals(version))
+			return SpecVersion.v2026_01;
+		else if ("2026-01-next".equals(version))
+			return SpecVersion.v2026_01_next;
 
 		// unknown or invalid version
 		return null;
+	}
+
+	public static String getVersionString() {
+		return getVersionString(local.get());
+	}
+
+	public static String getVersionString(SpecVersion version) {
+		switch (version) {
+			case v2023_06: {
+				return "2023-06";
+			}
+			case v2026_01: {
+				return "2026-01";
+			}
+			case v2026_01_next: {
+				return "2026-01-next";
+			}
+			default: {
+				return "draft";
+			}
+		}
 	}
 
 	public static void setVersion(SpecVersion v) {
@@ -39,10 +60,10 @@ public class ContestAPIHelper {
 	}
 
 	/**
-	 * Helper method to tell if we're using the 2026-draft spec version
+	 * Helper method to tell if we're using the 2026-01-next draft spec
 	 */
-	public static boolean is2026_draft() {
-		return local.get() == SpecVersion.v2026_draft;
+	public static boolean is2026_01_next() {
+		return local.get() == SpecVersion.v2026_01_next;
 	}
 
 	/**

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Clarification.java
@@ -79,7 +79,7 @@ public class Clarification extends TimedEvent implements IClarification {
 				toTeamIds = new String[] { (String) value };
 			return true;
 		} else if (TO_TEAM_IDS.equals(name)
-				&& (ContestAPIHelper.is2026_01() || ContestAPIHelper.is2026_draft() || ContestAPIHelper.isUnknownSpec())) {
+				&& (ContestAPIHelper.is2026_01() || ContestAPIHelper.is2026_01_next() || ContestAPIHelper.isUnknownSpec())) {
 			if (value == null || "null".equals(value))
 				toTeamIds = null;
 			else {


### PR DESCRIPTION
We initially said that draft specs would be named based on the year, e.g. `2026-draft`, but this doesn't say whether this is the draft before 2026-01 or after not account for multiple releases in a year.

After another discussion we changed this to be `2026-01-next` to clearly indicate 'work on the next release after 2026-01'. This moves the version strings into the helper and updates to this format.

https://github.com/icpc/ccs-specs/issues/302