### PR TITLE
Resolver contest state optimization

### DIFF
--- a/CDS/src/org/icpc/tools/cds/service/ResolverService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ResolverService.java
@@ -1,8 +1,6 @@
 package org.icpc.tools.cds.service;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -14,7 +12,6 @@ import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IJudgementType;
 import org.icpc.tools.contest.model.IResolveInfo;
-import org.icpc.tools.contest.model.ISubmission;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.feed.JSONWriter;
 import org.icpc.tools.contest.model.internal.Contest;
@@ -22,9 +19,8 @@ import org.icpc.tools.contest.model.internal.ResolveInfo;
 import org.icpc.tools.contest.model.resolver.ResolutionControl;
 import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil;
-import org.icpc.tools.contest.model.resolver.ResolutionUtil.ContestStateStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
-import org.icpc.tools.contest.model.resolver.ResolutionUtil.SubmissionSelectionStep;
 import org.icpc.tools.contest.model.resolver.ResolverLogic;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -58,7 +54,7 @@ public class ResolverService {
 	}
 
 	protected static void doPut(HttpServletResponse response, String command, ConfiguredContest cc) throws IOException {
-		IContest contest = cc.getContest();
+		Contest contest = cc.getContest();
 		if (contest.getState().isRunning()) {
 			response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Contest still running");
 			return;
@@ -66,10 +62,9 @@ public class ResolverService {
 
 		Trace.trace(Trace.USER, "Resolver command: " + command);
 		try {
-			Contest c = (Contest) contest;
 			if ("reset".equals(command) && control == null) {
 				ResolveInfo resolveInfo = new ResolveInfo();
-				c.add(resolveInfo);
+				contest.add(resolveInfo);
 			} else if ("init".equals(command)) {
 				if (steps != null)
 					return;
@@ -90,40 +85,25 @@ public class ResolverService {
 				}
 				Trace.trace(Trace.USER, "Auto-resolved " + count + " judgements");
 
-				ResolverLogic resolver = new ResolverLogic(c, false);
+				ResolverLogic resolver = new ResolverLogic(contest, false);
 				steps = resolver.resolveFrom(false);
 				control = new ResolutionControl(steps);
 				control.addListener(new IResolutionListener() {
-					protected List<IJudgement> judgements;
-
 					@Override
-					public void atStep(ResolutionStep step) {
-						if (step instanceof SubmissionSelectionStep) {
-							SubmissionSelectionStep step2 = (SubmissionSelectionStep) step;
-							if (step2.subInfo == null)
-								return;
-
-							String teamId = step2.subInfo.getTeam().getId();
-							int pInd = step2.subInfo.getProblemIndex();
-							String pId = contest.getProblems()[pInd].getId();
-							ISubmission[] subs = contest.getSubmissions();
-							judgements = new ArrayList<>();
-							for (ISubmission s : subs) {
-								if (s.getTeamId().equals(teamId) && s.getProblemId().equals(pId)) {
-									if (s.getContestTime() < contest.getDuration()) {
-										IJudgement[] j = contest.getJudgementsBySubmissionId(s.getId());
-										judgements.addAll(Arrays.asList(j));
-									}
-								}
-							}
-						} else if (step instanceof ContestStateStep) {
+					public void step(ResolutionStep step, boolean forward) {
+						if (step instanceof JudgementStep) {
+							JudgementStep stateStep = (JudgementStep) step;
+							IJudgement[] judgements = stateStep.judgements;
 							if (judgements == null)
 								return;
 
-							for (IJudgement j : judgements)
-								cc.exposeContestObject(j);
-
-							judgements = null;
+							for (IJudgement j : judgements) {
+								if (forward) {
+									contest.add(j);
+								} else {
+									contest.remove(j);
+								}
+							}
 						}
 					}
 
@@ -142,7 +122,7 @@ public class ResolverService {
 
 						Trace.trace(Trace.INFO, "Resolver going to pause " + pause);
 
-						ResolveInfo resolveInfo = (ResolveInfo) c.getResolveInfo();
+						ResolveInfo resolveInfo = (ResolveInfo) contest.getResolveInfo();
 						if (resolveInfo != null)
 							resolveInfo = ((ResolveInfo) resolveInfo.clone());
 						else
@@ -151,11 +131,11 @@ public class ResolverService {
 							resolveInfo.setClicks(pause + 1000);
 						else
 							resolveInfo.setClicks(pause);
-						c.add(resolveInfo);
+						contest.add(resolveInfo);
 					}
 				});
 
-				c.addListener(new IContestListener() {
+				contest.addListener(new IContestListener() {
 					@Override
 					public void contestChanged(IContest contest2, IContestObject obj, Delta delta) {
 						if (delta != Delta.DELETE && obj instanceof IResolveInfo) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -1330,20 +1330,6 @@ public class Contest implements IContest {
 		add(new Judgement(submission.getId(), submission, typeId));
 	}
 
-	/**
-	 * Updates the state of the submission to match the given submission.
-	 */
-	public void updateSubmissionTo(ISubmission submission, IContest contest) {
-		if (submission == null)
-			return;
-
-		IJudgement[] sjs = contest.getJudgementsBySubmissionId(submission.getId());
-		if (sjs != null) {
-			for (IJudgement sj : sjs)
-				add(sj);
-		}
-	}
-
 	@Override
 	public long getContestTimeOfLastEvent() {
 		return lastEventTime;

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionControl.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionControl.java
@@ -6,6 +6,7 @@ import java.util.concurrent.locks.LockSupport;
 
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.DelayStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.PauseStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
 
@@ -22,7 +23,7 @@ public class ResolutionControl {
 	public interface IResolutionListener {
 		void toPause(int pause, boolean includeDelays);
 
-		void atStep(ResolutionStep step);
+		void step(ResolutionStep step, boolean forward);
 
 		void atPause(int pause);
 	}
@@ -41,6 +42,10 @@ public class ResolutionControl {
 		synchronized (listeners) {
 			listeners.remove(listener);
 		}
+	}
+
+	public List<ResolutionStep> getSteps() {
+		return steps;
 	}
 
 	public int getCurrentPause() {
@@ -67,7 +72,7 @@ public class ResolutionControl {
 		scrollSpeedFactor = d;
 	}
 
-	private void notifyListenersAtStep(ResolutionStep step) {
+	private void notifyListenersAtStep(ResolutionStep step, boolean forward) {
 		IResolutionListener[] list = null;
 		synchronized (listeners) {
 			list = listeners.toArray(new IResolutionListener[0]);
@@ -75,7 +80,7 @@ public class ResolutionControl {
 
 		for (IResolutionListener listener : list) {
 			try {
-				listener.atStep(step);
+				listener.step(step, forward);
 			} catch (Throwable t) {
 				Trace.trace(Trace.ERROR, "Error notifying listener", t);
 			}
@@ -111,7 +116,7 @@ public class ResolutionControl {
 			if (!forward)
 				step = findPrevious(step);
 			Trace.trace(Trace.INFO, "Step " + currentStep + " <  " + step);
-			notifyListenersAtStep(step);
+			notifyListenersAtStep(step, forward);
 		}
 		return false;
 	}
@@ -201,6 +206,9 @@ public class ResolutionControl {
 	}
 
 	private ResolutionStep findPrevious(ResolutionStep step) {
+		if (step instanceof JudgementStep)
+			return step;
+
 		Class<? extends ResolutionStep> cl = step.getClass();
 		int num = currentStep;
 		while (num > 0) {

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolutionUtil.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.icpc.tools.contest.model.IAward;
+import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.internal.Contest;
 
@@ -90,6 +91,19 @@ public class ResolutionUtil {
 		@Override
 		public String toString() {
 			return "Change contest state";
+		}
+	}
+
+	public static class JudgementStep implements ResolutionStep {
+		public IJudgement[] judgements;
+
+		public JudgementStep(IJudgement[] judgements) {
+			this.judgements = judgements;
+		}
+
+		@Override
+		public String toString() {
+			return "Judgement step";
 		}
 	}
 
@@ -315,4 +329,3 @@ public class ResolutionUtil {
 		}
 	}
 }
-

--- a/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/resolver/ResolverLogic.java
@@ -26,6 +26,7 @@ import org.icpc.tools.contest.model.resolver.ResolutionUtil.AwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ContestStateStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.DelayStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.DelayType;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ListAwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.MessageStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.PauseStep;
@@ -165,6 +166,7 @@ public class ResolverLogic {
 	 */
 	public List<ResolutionStep> resolveFrom(boolean startWithJudgeQueue) {
 		Trace.trace(Trace.INFO, "Resolving...");
+		long time = System.currentTimeMillis();
 
 		// cache all the awards by team id
 		IAward[] contestAwards = finalContest.getAwards();
@@ -229,6 +231,9 @@ public class ResolverLogic {
 		Trace.trace(Trace.USER, "Resolving " + countUnjudgedSubmissions(contest) + " pending submissions out of the "
 				+ contest.getNumSubmissions() + " total submissions in the contest... ");
 
+		// take our 'moving copy' to make changes without touching the initial contest
+		contest = contest.clone(false);
+
 		// first click - show the scoreboard
 		steps.add(new ScrollStep(0));
 		steps.add(new PresentationStep(PresentationStep.Presentations.SCOREBOARD));
@@ -245,7 +250,7 @@ public class ResolverLogic {
 
 		ResolutionUtil.numberThePauses(steps);
 
-		Trace.trace(Trace.USER, "Done resolving");
+		Trace.trace(Trace.USER, "Done resolving in " + (System.currentTimeMillis() - time) + " ms");
 
 		return steps;
 	}
@@ -256,6 +261,20 @@ public class ResolverLogic {
 			return AwardUtil.getPlaceString(n);
 		} catch (Exception e) {
 			return place;
+		}
+	}
+
+	/**
+	 * Updates the state of the submission to match the given submission.
+	 */
+	public static void updateSubmissionJudgements(ISubmission submission, Contest fromContest, Contest toContest) {
+		if (submission == null)
+			return;
+
+		IJudgement[] sjs = fromContest.getJudgementsBySubmissionId(submission.getId());
+		if (sjs != null) {
+			for (IJudgement sj : sjs)
+				toContest.add(sj);
 		}
 	}
 
@@ -271,7 +290,7 @@ public class ResolverLogic {
 				IResult result = contest.getResult(team, probIndex);
 
 				if (result.getStatus() != Status.SUBMITTED) {
-					contest.updateSubmissionTo(submission, finalContest);
+					updateSubmissionJudgements(submission, finalContest, contest);
 				}
 			}
 		}
@@ -328,10 +347,14 @@ public class ResolverLogic {
 			if (!contest.isJudged(submission) && submission.getTeamId().equals(team.getId())
 					&& submission.getProblemId().equals(contest.getProblems()[problemIndex].getId())) {
 				// we found it; update its status to match the correct (final contest) status
-				contest = contest.clone(false);
-				contest.updateSubmissionTo(submission, finalContest);
+				IJudgement[] sjs = finalContest.getJudgementsBySubmissionId(submission.getId());
+				if (sjs != null) {
+					for (IJudgement sj : sjs)
+						contest.add(sj);
+				}
 
-				steps.add(new ContestStateStep(contest));
+				steps.add(new JudgementStep(sjs));
+
 				steps.add(new SubmissionSelectionStep2(submission.getId()));
 				timing.onStep(steps, State.SELECT_SUBMISSION);
 

--- a/Resolver/src/org/icpc/tools/resolver/ResolverOptimizer.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverOptimizer.java
@@ -164,7 +164,7 @@ public class ResolverOptimizer {
 				IResult result = contest.getResult(team, probIndex);
 
 				if (result.getStatus() != Status.SUBMITTED) {
-					contest.updateSubmissionTo(submission, finalContest);
+					ResolverLogic.updateSubmissionJudgements(submission, finalContest, contest);
 				}
 			}
 		}
@@ -231,7 +231,7 @@ public class ResolverOptimizer {
 		for (ISubmission submission : submissions) {
 			if (!contest.isJudged(submission) && submission.getTeamId().equals(resolve.teamId)
 					&& submission.getProblemId().equals(resolve.problemId)) {
-				contest.updateSubmissionTo(submission, finalContest);
+				ResolverLogic.updateSubmissionJudgements(submission, finalContest, contest);
 			}
 		}
 

--- a/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
+++ b/Resolver/src/org/icpc/tools/resolver/ResolverUI.java
@@ -16,12 +16,14 @@ import java.util.List;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IContest;
+import org.icpc.tools.contest.model.IJudgement;
 import org.icpc.tools.contest.model.IResolveInfo;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.resolver.ResolutionControl;
 import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.AwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ContestStateStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ListAwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.MessageStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.PauseStep;
@@ -158,8 +160,8 @@ public class ResolverUI {
 			}
 
 			@Override
-			public void atStep(ResolutionStep step) {
-				processStep(step);
+			public void step(ResolutionStep step, boolean forward) {
+				processStep(step, forward);
 			}
 
 			@Override
@@ -218,7 +220,8 @@ public class ResolverUI {
 				if (teamListPresentation == null || !isPresenter || !active)
 					return;
 
-				if ('r' == e.getKeyChar() || 'R' == e.getKeyChar() || 'b' == e.getKeyChar() || 'B' == e.getKeyChar() || KeyEvent.VK_PAGE_UP == e.getKeyCode())
+				if ('r' == e.getKeyChar() || 'R' == e.getKeyChar() || 'b' == e.getKeyChar() || 'B' == e.getKeyChar()
+						|| KeyEvent.VK_PAGE_UP == e.getKeyCode())
 					processAction(Action.REVERSE);
 				else if ('1' == e.getKeyChar())
 					processAction(Action.FAST_REVERSE);
@@ -243,7 +246,8 @@ public class ResolverUI {
 					setScrollPauseImpl(!pauseScroll);
 				} else if ('i' == e.getKeyChar())
 					scoreboardPresentation.setShowSubmissionInfo(!scoreboardPresentation.getShowSubmissionInfo());
-				else if (' ' == e.getKeyChar() || 'f' == e.getKeyChar() || 'F' == e.getKeyChar() || KeyEvent.VK_PAGE_DOWN == e.getKeyCode())
+				else if (' ' == e.getKeyChar() || 'f' == e.getKeyChar() || 'F' == e.getKeyChar()
+						|| KeyEvent.VK_PAGE_DOWN == e.getKeyCode())
 					processAction(Action.FORWARD);
 				else if ('s' == e.getKeyChar() && listener != null)
 					listener.swap();
@@ -501,19 +505,23 @@ public class ResolverUI {
 		return null;
 	}
 
-	private int processStep(ResolutionStep step) {
+	private int processStep(ResolutionStep step, boolean forward) {
 		if (step instanceof ContestStateStep) {
-			ContestStateStep state = (ContestStateStep) step;
-			splashPresentation.setContest(state.contest);
-			scoreboardPresentation.setContest(state.contest);
-			teamListPresentation.setContest(state.contest);
-			teamListPhotoPresentation.setContest(state.contest);
-			judgePresentation.setContest(state.contest);
-			awardPresentation.setContest(state.contest);
-			if (teamLogoPresentation != null)
-				teamLogoPresentation.setContest(state.contest);
-			if (orgPresentation != null)
-				orgPresentation.setContest(state.contest);
+			// do nothing
+		} else if (step instanceof JudgementStep) {
+			JudgementStep jStep = (JudgementStep) step;
+			Contest contest = getFirstContest();
+
+			IJudgement[] judgements = jStep.judgements;
+			if (judgements != null) {
+				for (IJudgement j : judgements) {
+					if (forward) {
+						contest.add(j);
+					} else {
+						contest.remove(j);
+					}
+				}
+			}
 		} else if (step instanceof TeamSelectionStep) {
 			TeamSelectionStep sel = (TeamSelectionStep) step;
 			scoreboardPresentation.setSelectedTeams(sel.teams, sel.type);


### PR DESCRIPTION
I think I intuitively knew this should be possible now, but kicking myself that I never tried it until now...

The original resolver worked by creating a copy of the contest at freeze time, making a change, saving the complete contest state, making another copy, and repeating. So resolution steps are like:
- full initial contest state
- select a submission
- clone the contest, judge it and store full contest state 1
- select a different submission
- clone the contest, judge it and store full contest state 2

As we moved to the Contest API this got a _lot_ cheaper because the contest is just a huge array with very little change in objects each loop - you store a massive array for each loop but otherwise no new objects in memory.

The change is to avoid cloning entirely and only store the changed judgements on each loop instead of the full contest state, i.e.:

- full initial contest state
- select a submission
- judge it and store the affected judgements
- select a different submission
- judge it and store the affected judgements

Instead of stepping through the states, the resolver just adds the judgements to the current contest, or removes them to go in reverse.

I used the Luxor WF to test the resolution stage on my MacBook. No change in external behaviour, but the perf results speak for themselves:
 - Old: 1500ms, 1.4Gb peak
 - New: 250ms, 950Mb peak

A few other notes:
1. In the past going in reverse meant finding the prior state at each step, e.g. undoing a row selection meant finding the prior row selection. findPrevious() just skips this for undoable steps like JudgementStep.
2. The updateSubmissionTo() util didn't belong in the Contest object, so I moved it to the resolution logic.