### PR TITLE
Connect CDS resolving output to feed

### DIFF
--- a/CDS/WebContent/WEB-INF/jsps/admin.jsp
+++ b/CDS/WebContent/WEB-INF/jsps/admin.jsp
@@ -169,12 +169,9 @@
              <h3 class="card-title">Resolver Info (Beta)</h3>
            </div>
         <div class="card-body">
-          Initializing the resolver does three things:
-          <ul>
-            <li>Shows the status of the resolution</li>
-            <li>Allows you to control the resolution (for extreme circumstances)</li>
-            <li>Makes judgements public as they are resolved</li>
-          </ul>
+          <p>
+          Resolver status and control.
+          </p>
             <table id="resolver-table" class="table table-sm table-hover table-striped">
               <tbody>
                 <tr>

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -24,6 +24,8 @@ import org.icpc.tools.contest.model.IAccount;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IGroup;
+import org.icpc.tools.contest.model.IJudgement;
+import org.icpc.tools.contest.model.IJudgementType;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.ContestSource;
 import org.icpc.tools.contest.model.feed.ContestSource.ConnectionState;
@@ -34,8 +36,15 @@ import org.icpc.tools.contest.model.feed.Timestamp;
 import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.Info;
+import org.icpc.tools.contest.model.internal.ResolveInfo;
 import org.icpc.tools.contest.model.internal.YamlParser;
 import org.icpc.tools.contest.model.internal.account.AccountHelper;
+import org.icpc.tools.contest.model.internal.account.PublicContest;
+import org.icpc.tools.contest.model.resolver.ResolutionControl;
+import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
+import org.icpc.tools.contest.model.resolver.ResolverLogic;
 import org.w3c.dom.Element;
 
 import jakarta.servlet.AsyncContext;
@@ -79,6 +88,8 @@ public class ConfiguredContest {
 														// desktop, webcam, audio, total
 
 	private static Map<String, Map<StreamType, List<Integer>>> streamMap = new HashMap<>();
+
+	private ResolutionControl resolutionControl;
 
 	public static class Video {
 		private Element video;
@@ -925,10 +936,96 @@ public class ConfiguredContest {
 	 * @param co
 	 */
 	public void exposeContestObject(IContestObject co) {
-		synchronized (accountContests) {
-			for (Contest ac : accountContests.values())
-				ac.add(co);
+		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
+		if (c instanceof PublicContest) {
+			PublicContest pc = (PublicContest) c;
+			pc.add(co);
 		}
+	}
+
+	public void unexposeContestObject(IContestObject co) {
+		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
+		if (c instanceof PublicContest) {
+			PublicContest pc = (PublicContest) c;
+			pc.remove(co);
+		}
+	}
+
+	public ResolutionControl getResolutionControl() {
+		return resolutionControl;
+	}
+
+	public synchronized ResolutionControl initResolution(boolean startFromJudgeQueue) {
+		if (resolutionControl != null)
+			return resolutionControl;
+
+		// let public contest know it's ok to start letting out judgements
+		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
+		if (c instanceof PublicContest) {
+			PublicContest pc = (PublicContest) c;
+			pc.setResolving(true);
+		}
+
+		// TODO - sync with ResolverLogic cleanOutlierSubmissions() and ResolverOptimizer
+		// The resolver skips over non-solution/non-penalty judgements (e.g. compile error)
+		// since these typically 'disappear' from scoreboards during the regular contest.
+		// Resolve these first to avoid confusing the presenter
+		int count = 0;
+		for (IJudgement j : contest.getJudgements()) {
+			IJudgementType jt = contest.getJudgementTypeById(j.getJudgementTypeId());
+			if (!jt.isSolved() && !jt.isPenalty()) {
+				exposeContestObject(j);
+				count++;
+			}
+		}
+		Trace.trace(Trace.USER, "Auto-resolved " + count + " judgements");
+
+		ResolverLogic resolver = new ResolverLogic(contest, false);
+		List<ResolutionStep> steps = resolver.resolveFrom(startFromJudgeQueue);
+		resolutionControl = new ResolutionControl(steps);
+		resolutionControl.addListener(new IResolutionListener() {
+			@Override
+			public void step(ResolutionStep step, boolean forward) {
+				Trace.trace(Trace.INFO, "Resolver at step " + step);
+				if (step instanceof JudgementStep) {
+					JudgementStep jStep = (JudgementStep) step;
+					IJudgement[] judgements = jStep.judgements;
+					if (judgements == null)
+						return;
+
+					for (IJudgement j : judgements) {
+						if (forward) {
+							exposeContestObject(j);
+						} else {
+							unexposeContestObject(j);
+						}
+					}
+				}
+			}
+
+			@Override
+			public void atPause(int pause) {
+				Trace.trace(Trace.INFO, "Resolver at pause " + pause);
+			}
+
+			@Override
+			public void toPause(int pause, boolean includeDelays) {
+				Trace.trace(Trace.INFO, "Resolver going to pause " + pause);
+
+				ResolveInfo resolveInfo = (ResolveInfo) contest.getResolveInfo();
+				if (resolveInfo != null)
+					resolveInfo = ((ResolveInfo) resolveInfo.clone());
+				else
+					resolveInfo = new ResolveInfo();
+				if (!includeDelays)
+					resolveInfo.setClicks(pause + 1000);
+				else
+					resolveInfo.setClicks(pause);
+				contest.add(resolveInfo);
+			}
+		});
+
+		return resolutionControl;
 	}
 
 	@Override

--- a/CDS/src/org/icpc/tools/cds/service/ResolverService.java
+++ b/CDS/src/org/icpc/tools/cds/service/ResolverService.java
@@ -2,43 +2,30 @@ package org.icpc.tools.cds.service;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.ScheduledExecutorService;
 
 import org.icpc.tools.cds.ConfiguredContest;
 import org.icpc.tools.contest.Trace;
-import org.icpc.tools.contest.model.IContest;
-import org.icpc.tools.contest.model.IContestListener;
-import org.icpc.tools.contest.model.IContestObject;
-import org.icpc.tools.contest.model.IJudgement;
-import org.icpc.tools.contest.model.IJudgementType;
-import org.icpc.tools.contest.model.IResolveInfo;
 import org.icpc.tools.contest.model.feed.JSONParser.JsonObject;
 import org.icpc.tools.contest.model.feed.JSONWriter;
 import org.icpc.tools.contest.model.internal.Contest;
 import org.icpc.tools.contest.model.internal.ResolveInfo;
 import org.icpc.tools.contest.model.resolver.ResolutionControl;
-import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil;
-import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
-import org.icpc.tools.contest.model.resolver.ResolverLogic;
 
 import jakarta.servlet.http.HttpServletResponse;
 
 public class ResolverService {
-	protected static List<ResolutionStep> steps;
-	protected static ResolutionControl control;
-	protected static ScheduledExecutorService executor;
-	protected static boolean localControl;
-
 	protected static void doGet(HttpServletResponse response, ConfiguredContest cc) throws IOException {
 		response.setCharacterEncoding("UTF-8");
 		response.setHeader("Access-Control-Allow-Origin", "*");
 		response.setContentType("application/json");
 
 		JsonObject obj = new JsonObject();
+		ResolutionControl control = cc.getResolutionControl();
 		if (control != null) {
 			obj.put("pause", control.getCurrentPause());
+			List<ResolutionStep> steps = control.getSteps();
 			obj.put("total_pauses", ResolutionUtil.getTotalPauses(steps));
 			obj.put("total_time", ResolutionUtil.getTotalTime(steps));
 			obj.put("stepping", control.isStepping());
@@ -62,121 +49,20 @@ public class ResolverService {
 
 		Trace.trace(Trace.USER, "Resolver command: " + command);
 		try {
+			final ResolutionControl control = cc.getResolutionControl();
 			if ("reset".equals(command) && control == null) {
 				ResolveInfo resolveInfo = new ResolveInfo();
 				contest.add(resolveInfo);
 			} else if ("init".equals(command)) {
-				if (steps != null)
-					return;
-
-				if (executor == null)
-					executor = ExecutorListener.getExecutor();
-
-				// The resolver skips over non-solution/non-penalty judgements (e.g. compile error)
-				// since these typically 'disappear' from scoreboards during the regular contest.
-				// Resolve these first to avoid confusing the presenter
-				int count = 0;
-				for (IJudgement j : contest.getJudgements()) {
-					IJudgementType jt = contest.getJudgementTypeById(j.getJudgementTypeId());
-					if (!jt.isSolved() && !jt.isPenalty()) {
-						cc.exposeContestObject(j);
-						count++;
-					}
-				}
-				Trace.trace(Trace.USER, "Auto-resolved " + count + " judgements");
-
-				ResolverLogic resolver = new ResolverLogic(contest, false);
-				steps = resolver.resolveFrom(false);
-				control = new ResolutionControl(steps);
-				control.addListener(new IResolutionListener() {
-					@Override
-					public void step(ResolutionStep step, boolean forward) {
-						if (step instanceof JudgementStep) {
-							JudgementStep stateStep = (JudgementStep) step;
-							IJudgement[] judgements = stateStep.judgements;
-							if (judgements == null)
-								return;
-
-							for (IJudgement j : judgements) {
-								if (forward) {
-									contest.add(j);
-								} else {
-									contest.remove(j);
-								}
-							}
-						}
-					}
-
-					@Override
-					public void atPause(int pause) {
-						Trace.trace(Trace.INFO, "Resolver at pause " + pause);
-					}
-
-					@Override
-					public void toPause(int pause, boolean includeDelays) {
-						// send out changes coming from the local/CDS control
-						if (!localControl)
-							return;
-
-						localControl = false;
-
-						Trace.trace(Trace.INFO, "Resolver going to pause " + pause);
-
-						ResolveInfo resolveInfo = (ResolveInfo) contest.getResolveInfo();
-						if (resolveInfo != null)
-							resolveInfo = ((ResolveInfo) resolveInfo.clone());
-						else
-							resolveInfo = new ResolveInfo();
-						if (!includeDelays)
-							resolveInfo.setClicks(pause + 1000);
-						else
-							resolveInfo.setClicks(pause);
-						contest.add(resolveInfo);
-					}
-				});
-
-				contest.addListener(new IContestListener() {
-					@Override
-					public void contestChanged(IContest contest2, IContestObject obj, Delta delta) {
-						if (delta != Delta.DELETE && obj instanceof IResolveInfo) {
-							IResolveInfo resolveInfo = (IResolveInfo) obj;
-
-							if (resolveInfo.getSpeedFactor() != Double.NaN) {
-								control.setSpeedFactor(resolveInfo.getSpeedFactor());
-							}
-							if (resolveInfo.getScrollSpeedFactor() != Double.NaN) {
-								control.setScrollSpeedFactor(resolveInfo.getScrollSpeedFactor());
-							}
-							int pause = resolveInfo.getClicks();
-							if (pause >= 0 && resolveInfo.getClicks() != control.getCurrentPause()) {
-								boolean includeDelays = true;
-								if (pause > 999) {
-									pause -= 1000;
-									includeDelays = false;
-								} else if (Math.abs(pause - control.getCurrentPause()) > 1)
-									includeDelays = false;
-
-								final int pause2 = pause;
-								boolean includeDelays2 = includeDelays;
-								executor.submit(new Runnable() {
-									@Override
-									public void run() {
-										control.moveToPause(pause2, includeDelays2);
-									}
-								});
-							}
-						}
-					}
-				});
-
+				cc.initResolution(true);
 				return;
 			}
 
 			if (control == null || control.isStepping())
 				return;
 
-			localControl = true;
-			executor.submit(new Runnable() {
+			// TODO: output a ResolveInfo event instead?
+			ExecutorListener.getExecutor().submit(new Runnable() {
 				@Override
 				public void run() {
 					if ("fast-forward".equals(command))

--- a/CDS/src/org/icpc/tools/cds/util/CDSContest.java
+++ b/CDS/src/org/icpc/tools/cds/util/CDSContest.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 import org.icpc.tools.cds.ConfiguredContest;
 import org.icpc.tools.cds.ConfiguredContest.View;
+import org.icpc.tools.cds.service.ExecutorListener;
 import org.icpc.tools.cds.video.ReactionVideoRecorder;
 import org.icpc.tools.cds.video.VideoAggregator;
 import org.icpc.tools.cds.video.VideoAggregator.ConnectionMode;
@@ -18,6 +19,7 @@ import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IContestObject.ContestType;
 import org.icpc.tools.contest.model.IDelete;
 import org.icpc.tools.contest.model.IProblem;
+import org.icpc.tools.contest.model.IResolveInfo;
 import org.icpc.tools.contest.model.ITeam;
 import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.internal.Award;
@@ -36,6 +38,7 @@ import org.icpc.tools.contest.model.internal.Run;
 import org.icpc.tools.contest.model.internal.State;
 import org.icpc.tools.contest.model.internal.Submission;
 import org.icpc.tools.contest.model.internal.Team;
+import org.icpc.tools.contest.model.resolver.ResolutionControl;
 
 /**
  * CDS Contest enables most of the CDS capabilities and behaviours on a contest:
@@ -47,6 +50,7 @@ import org.icpc.tools.contest.model.internal.Team;
  * <li>Records reactions</li>
  * <li>Does view filtering (contest subset)</li>
  * <li>Enables countdown pause times (for CCSs that don't support it)</li>
+ * <li>Supports resolution control (resolver)</li>
  * </ul>
  *
  */
@@ -373,6 +377,42 @@ public class CDSContest extends Contest {
 			if (info.getStartTime() == null && info.getCountdownPauseTime() == null && !info.supportsCountdownPauseTime()
 					&& currentInfo != null)
 				info.setCountdownPauseTime(currentInfo.getCountdownPauseTime());
+		}
+
+		// resolution
+		if (obj instanceof IResolveInfo) {
+			// TODO: always start with judge queue for now, should allow either but not sent from the
+			// client
+			ResolutionControl control = cc.initResolution(true);
+
+			if (obj instanceof IResolveInfo) {
+				IResolveInfo resolveInfo = (IResolveInfo) obj;
+
+				if (!Double.isNaN(resolveInfo.getSpeedFactor())) {
+					control.setSpeedFactor(resolveInfo.getSpeedFactor());
+				}
+				if (!Double.isNaN(resolveInfo.getScrollSpeedFactor())) {
+					control.setScrollSpeedFactor(resolveInfo.getScrollSpeedFactor());
+				}
+				int pause = resolveInfo.getClicks();
+				if (pause >= 0 && resolveInfo.getClicks() != control.getCurrentPause()) {
+					boolean includeDelays = true;
+					if (pause > 999) {
+						pause -= 1000;
+						includeDelays = false;
+					} else if (Math.abs(pause - control.getCurrentPause()) > 1)
+						includeDelays = false;
+
+					final int pause2 = pause;
+					boolean includeDelays2 = includeDelays;
+					ExecutorListener.getExecutor().submit(new Runnable() {
+						@Override
+						public void run() {
+							control.moveToPause(pause2, includeDelays2);
+						}
+					});
+				}
+			}
 		}
 
 		super.add(obj);

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -58,6 +58,8 @@ public class PublicContest extends Contest implements IFilteredContest {
 	// objects seen during the freeze that should be sent on thaw
 	protected List<IContestObject> freeze = new ArrayList<>();
 
+	protected boolean resolving;
+
 	public PublicContest() {
 		// do nothing
 	}
@@ -190,9 +192,9 @@ public class PublicContest extends Contest implements IFilteredContest {
 					return;
 
 				// or during the freeze
-				if (getFreezeDuration() != null) {
+				if (getFreezeDuration() != null && !resolving && getState().getThawed() == null) {
 					long freezeTime = getDuration() - getFreezeDuration();
-					if (time >= freezeTime && getState().getThawed() == null) {
+					if (time >= freezeTime) {
 						freeze.add(j);
 						return;
 					}
@@ -238,6 +240,10 @@ public class PublicContest extends Contest implements IFilteredContest {
 			add(co);
 		}
 		freeze.clear();
+	}
+
+	public void setResolving(boolean resolving) {
+		this.resolving = resolving;
 	}
 
 	/**


### PR DESCRIPTION
The CDS had support for seeing the current state of the resolution process and controlling it, but it wasn't hooked up to the local contest - i.e. it would control the resolver presenter and client but not the CDS itself. This just connects it properly so that the CDS is in sync with the resolution and resolution events go out on the regular feeds. This change causes judgements to go out to the public feed as they resolve.

Mostly just moves the resolver logic from the resolver service (a REST endpoint) down into the CDS contest (so an incoming step from the presenter triggers the CDS) and ConfiguredContest (keep track of the resolution state).

The CDS PublicContest had a regression when we enforced the data access policy and implemented thawing: it wasn't letting resolver judgements out. Fixed that by having a declared resolving state.

Only judgements appear on the feed, no awards yet; undo (delete) also does not send out events.

Part of #1270.