### PR TITLE
Resolver feed undo and award support

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -21,6 +21,7 @@ import org.icpc.tools.cds.video.VideoStream.StreamType;
 import org.icpc.tools.contest.Trace;
 import org.icpc.tools.contest.model.ContestUtil;
 import org.icpc.tools.contest.model.IAccount;
+import org.icpc.tools.contest.model.IAward;
 import org.icpc.tools.contest.model.IContest;
 import org.icpc.tools.contest.model.IContestObject;
 import org.icpc.tools.contest.model.IGroup;
@@ -35,6 +36,7 @@ import org.icpc.tools.contest.model.feed.RESTContestSource;
 import org.icpc.tools.contest.model.feed.Timestamp;
 import org.icpc.tools.contest.model.internal.Account;
 import org.icpc.tools.contest.model.internal.Contest;
+import org.icpc.tools.contest.model.internal.Deletion;
 import org.icpc.tools.contest.model.internal.Info;
 import org.icpc.tools.contest.model.internal.ResolveInfo;
 import org.icpc.tools.contest.model.internal.YamlParser;
@@ -42,9 +44,12 @@ import org.icpc.tools.contest.model.internal.account.AccountHelper;
 import org.icpc.tools.contest.model.internal.account.PublicContest;
 import org.icpc.tools.contest.model.resolver.ResolutionControl;
 import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.AwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.JudgementStep;
+import org.icpc.tools.contest.model.resolver.ResolutionUtil.ListAwardStep;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.ResolutionStep;
 import org.icpc.tools.contest.model.resolver.ResolverLogic;
+import org.icpc.tools.contest.model.util.AwardUtil;
 import org.w3c.dom.Element;
 
 import jakarta.servlet.AsyncContext;
@@ -947,7 +952,7 @@ public class ConfiguredContest {
 		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
 		if (c instanceof PublicContest) {
 			PublicContest pc = (PublicContest) c;
-			pc.remove(co);
+			pc.add(new Deletion(co.getId(), co.getType()));
 		}
 	}
 
@@ -959,7 +964,14 @@ public class ConfiguredContest {
 		if (resolutionControl != null)
 			return resolutionControl;
 
-		// let public contest know it's ok to start letting out judgements
+		// awards
+		IAward[] awards = contest.getAwards();
+		if (awards == null || awards.length == 0) {
+			Trace.trace(Trace.USER, "Generating awards");
+			AwardUtil.createDefaultAwards(contest);
+		}
+
+		// let public contest know it's ok to start letting out judgements and awards
 		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
 		if (c instanceof PublicContest) {
 			PublicContest pc = (PublicContest) c;
@@ -983,6 +995,7 @@ public class ConfiguredContest {
 		ResolverLogic resolver = new ResolverLogic(contest, false);
 		List<ResolutionStep> steps = resolver.resolveFrom(startFromJudgeQueue);
 		resolutionControl = new ResolutionControl(steps);
+		resolutionControl.setSpeedFactor(0.2);
 		resolutionControl.addListener(new IResolutionListener() {
 			@Override
 			public void step(ResolutionStep step, boolean forward) {
@@ -999,6 +1012,22 @@ public class ConfiguredContest {
 						} else {
 							unexposeContestObject(j);
 						}
+					}
+				} else if (step instanceof AwardStep) {
+					AwardStep aStep = (AwardStep) step;
+					for (IAward a : aStep.awards) {
+						if (forward) {
+							exposeContestObject(a);
+						} else {
+							unexposeContestObject(a);
+						}
+					}
+				} else if (step instanceof ListAwardStep) {
+					ListAwardStep aStep = (ListAwardStep) step;
+					if (forward) {
+						exposeContestObject(aStep.award);
+					} else {
+						unexposeContestObject(aStep.award);
 					}
 				}
 			}

--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -995,7 +995,6 @@ public class ConfiguredContest {
 		ResolverLogic resolver = new ResolverLogic(contest, false);
 		List<ResolutionStep> steps = resolver.resolveFrom(startFromJudgeQueue);
 		resolutionControl = new ResolutionControl(steps);
-		resolutionControl.setSpeedFactor(0.2);
 		resolutionControl.addListener(new IResolutionListener() {
 			@Override
 			public void step(ResolutionStep step, boolean forward) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -217,12 +217,14 @@ public class PublicContest extends Contest implements IFilteredContest {
 			}
 			case AWARD: {
 				IAward award = (IAward) obj;
-				if (award.getAwardType() != IAward.FIRST_TO_SOLVE)
-					return;
+				if (!resolving) {
+					if (award.getAwardType() != IAward.FIRST_TO_SOLVE)
+						return;
 
-				IState state = getState();
-				if (state.isFrozen())
-					return;
+					IState state = getState();
+					if (state.isFrozen())
+						return;
+				}
 
 				super.add(obj);
 				return;


### PR DESCRIPTION
Changes three things:
1. Undo (removing judgements) wasn't working because to delete something from a contest, you don't remove it - 'you add a deletion event'. Fixed.

2. If you start the resolution process from the CDS admin and there are no awards, it will create default ones (same behaviour as the regular resolver).

3. Added awards to the feed (also with working undo), just like judgements.

Part of #1270.