### PR TITLE
Add timeout in waitForContestLoad()

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -713,7 +713,7 @@ public class ConfiguredContest {
 
 			// wait up to 2s to connect
 			if (contestSource instanceof RESTContestSource)
-				contestSource.waitForContestLoad();
+				contestSource.waitForContestLoad(2000);
 		} catch (Exception e) {
 			Trace.trace(Trace.ERROR, "Error reading event feed: " + e.getMessage());
 		}

--- a/CoachView/src/org/icpc/tools/coachview/CoachView.java
+++ b/CoachView/src/org/icpc/tools/coachview/CoachView.java
@@ -601,7 +601,7 @@ public class CoachView extends Panel {
 			if (contest.getNumTeams() > 0)
 				loadTeamList();
 
-			contestSource.waitForContestLoad();
+			contestSource.waitForContestLoad(5000);
 
 			if (contestSource.isCDS()) {
 				BasicClient client = new BasicClient(contestSource, "Coach");

--- a/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/feed/ContestSource.java
@@ -273,18 +273,19 @@ public abstract class ContestSource {
 	}
 
 	/**
-	 * Wait for the contest to be loading.
+	 * Wait for the contest to be loading with the given timeout in ms.
 	 *
+	 * @param timeout a timeout in ms
 	 * @return <code>true</code> if the contest is or was successfully loaded, and
 	 *         <code>false</code> otherwise
 	 */
-	public boolean waitForContestLoad() {
+	public boolean waitForContestLoad(int timeout) {
 		return waitForContest(new Ready() {
 			@Override
 			public boolean isReady(ConnectionState state) {
 				return state == ConnectionState.CONNECTED || state == ConnectionState.READING;
 			}
-		}, 2000);
+		}, timeout);
 	}
 
 	/**
@@ -298,7 +299,7 @@ public abstract class ContestSource {
 	 */
 	public boolean waitForContest(int timeout) {
 		long endTime = System.currentTimeMillis() + timeout;
-		boolean b = waitForContestLoad();
+		boolean b = waitForContestLoad(timeout);
 		if (!b)
 			return false;
 

--- a/PresContest/src/org/icpc/tools/presentation/contest/internal/ContestData.java
+++ b/PresContest/src/org/icpc/tools/presentation/contest/internal/ContestData.java
@@ -24,7 +24,7 @@ public class ContestData {
 		BufferedContest bufferedContest = new BufferedContest();
 		source.setInitialContest(bufferedContest);
 		Contest tempContest = source.getContest();
-		source.waitForContestLoad();
+		source.waitForContestLoad(5000);
 		int count = 0;
 		while (count < 6 && bufferedContest.isBuffering()) {
 			count++;


### PR DESCRIPTION
A recent resolver log showed "Could not load complete contest" even though the contest was being loaded correctly. The cause is the waitForContestLoad() that doesn't take a timeout - if the initial load was a little too slow it would return and then waitForContest() would exit early without waiting the full timeout.

Changed it to require a specific timeout, and updated waitForContest() to use it's own timeout.

Fixes #1336.