### PR TITLE
Don't output empty award parameters

### DIFF
--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Award.java
@@ -220,7 +220,8 @@ public class Award extends ContestObject implements IAward {
 		props.addString(CITATION, citation);
 		if (mode != null && mode != DisplayMode.DETAIL)
 			props.addLiteralString(DISPLAY_MODE, mode.name().toLowerCase());
-		props.add(PARAMETERS, getEncodedParameters());
+		if (!parameters.isEmpty())
+			props.add(PARAMETERS, getEncodedParameters());
 	}
 
 	private String getEncodedParameters() {


### PR DESCRIPTION
I noticed awards always output the `parameters` property, even when it's empty, e.g.:
`{"id":"first-to-solve-idontmisspennies","team_ids":["17"],"citation":"First to solve problem I","parameters":{}}`

This fixes it to only output when there is a parameter:
`{"id":"first-to-solve-idontmisspennies","team_ids":["17"],"citation":"First to solve problem I"}`