### PR TITLE
Fix access endpoint for public account

### DIFF
--- a/CDS/config/wlp/cds/config/accounts.yaml
+++ b/CDS/config/wlp/cds/config/accounts.yaml
@@ -13,12 +13,12 @@
 - username: presentation
   password: presentat1on
   type: public
-- username: myicpc
-  password: my1cpc
+- username: analyst
+  password: ana1yst
   type: analyst
 - username: live
   password: l1ve
-  type: analyst
+  type: spectator
 - username: team1
   password: t3am
   type: team

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/Contest.java
@@ -105,7 +105,7 @@ public class Contest implements IContest {
 
 		addKnownProperties(IContestObject.ContestType.PROBLEM, "id", "label", "name", "ordinal");
 
-		addKnownProperties(IContestObject.ContestType.SUBMISSION, "id", "language_id", "problem_id", "team_id");
+		addKnownProperties(IContestObject.ContestType.SUBMISSION, "id", "problem_id", "team_id", "time", "contest_time");
 
 		addKnownProperties(IContestObject.ContestType.JUDGEMENT, "id", "submission_id", "start_time", "end_time");
 	}
@@ -211,6 +211,21 @@ public class Contest implements IContest {
 		for (String name : props.keySet())
 			if (!knownProps.contains(name))
 				knownProps.add(name);
+	}
+
+	public void addKnownProperty(IContestObject.ContestType type, String name) {
+		if (type == null || name == null)
+			return;
+
+		int ord = type.ordinal();
+		Set<String> knownProps = allKnownProperties[ord];
+		if (knownProps == null) {
+			knownProps = new SimpleSet();
+			allKnownProperties[ord] = knownProps;
+		}
+
+		if (!knownProps.contains(name))
+			knownProps.add(name);
 	}
 
 	private void updateTime(long time) {

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/SpectatorContest.java
@@ -28,6 +28,15 @@ public class SpectatorContest extends PublicContest {
 	}
 
 	@Override
+	protected void addDefaultKnownProperties() {
+		super.addDefaultKnownProperties();
+
+		addKnownProperties(IContestObject.ContestType.PROBLEM, "test_data_count");
+
+		addKnownProperty(IContestObject.ContestType.SUBMISSION, "language_id");
+	}
+
+	@Override
 	public void add(IContestObject obj) {
 		IContestObject.ContestType cType = obj.getType();
 		if (obj instanceof IDelete) {


### PR DESCRIPTION
While debugging the team view I noticed that the public account (no login / lowest common denominator) /access endpoint incorrectly says it has access to the submissions language id. This change removes it, and adds it back to the spectator (and analyst) accounts. I also reviewed all the differences between accounts and policy and added problem test_data_count as the only other omission I could find.

The default accounts.yaml is also a little out of date: I made live a spectator account since that's what we use at finals, and renamed myicpc to analyst (since that's the type of account it is).