### PR TITLE
Resolving events for all account types

### DIFF
--- a/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
+++ b/CDS/src/org/icpc/tools/cds/ConfiguredContest.java
@@ -42,6 +42,7 @@ import org.icpc.tools.contest.model.internal.ResolveInfo;
 import org.icpc.tools.contest.model.internal.YamlParser;
 import org.icpc.tools.contest.model.internal.account.AccountHelper;
 import org.icpc.tools.contest.model.internal.account.PublicContest;
+import org.icpc.tools.contest.model.internal.account.StaffContest;
 import org.icpc.tools.contest.model.resolver.ResolutionControl;
 import org.icpc.tools.contest.model.resolver.ResolutionControl.IResolutionListener;
 import org.icpc.tools.contest.model.resolver.ResolutionUtil.AwardStep;
@@ -936,23 +937,29 @@ public class ConfiguredContest {
 
 	/**
 	 * Expose a contest object from during the freeze (typically judgements) to the publicly visible
-	 * contests (staff, balloon, and public roles).
+	 * contests (public, balloon, spectator, and team accounts).
 	 *
 	 * @param co
 	 */
 	public void exposeContestObject(IContestObject co) {
-		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
-		if (c instanceof PublicContest) {
-			PublicContest pc = (PublicContest) c;
-			pc.add(co);
+		PublicContest.getResolved().add(co);
+		synchronized (accountContests) {
+			for (Contest c : accountContests.values()) {
+				if (!(c instanceof StaffContest)) {
+					c.add(co);
+				}
+			}
 		}
 	}
 
 	public void unexposeContestObject(IContestObject co) {
-		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
-		if (c instanceof PublicContest) {
-			PublicContest pc = (PublicContest) c;
-			pc.add(new Deletion(co.getId(), co.getType()));
+		PublicContest.getResolved().remove(co);
+		synchronized (accountContests) {
+			for (Contest c : accountContests.values()) {
+				if (!(c instanceof StaffContest)) {
+					c.add(new Deletion(co.getId(), co.getType()));
+				}
+			}
 		}
 	}
 
@@ -969,13 +976,6 @@ public class ConfiguredContest {
 		if (awards == null || awards.length == 0) {
 			Trace.trace(Trace.USER, "Generating awards");
 			AwardUtil.createDefaultAwards(contest);
-		}
-
-		// let public contest know it's ok to start letting out judgements and awards
-		Contest c = getContestForAccount(PUBLIC_ACCOUNT);
-		if (c instanceof PublicContest) {
-			PublicContest pc = (PublicContest) c;
-			pc.setResolving(true);
 		}
 
 		// TODO - sync with ResolverLogic cleanOutlierSubmissions() and ResolverOptimizer

--- a/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
+++ b/ContestModel/src/org/icpc/tools/contest/model/internal/account/PublicContest.java
@@ -58,7 +58,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 	// objects seen during the freeze that should be sent on thaw
 	protected List<IContestObject> freeze = new ArrayList<>();
 
-	protected boolean resolving;
+	protected static List<IContestObject> resolved = new ArrayList<>();
 
 	public PublicContest() {
 		// do nothing
@@ -192,7 +192,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 					return;
 
 				// or during the freeze
-				if (getFreezeDuration() != null && !resolving && getState().getThawed() == null) {
+				if (getFreezeDuration() != null && !resolved.contains(j) && getState().getThawed() == null) {
 					long freezeTime = getDuration() - getFreezeDuration();
 					if (time >= freezeTime) {
 						freeze.add(j);
@@ -217,7 +217,7 @@ public class PublicContest extends Contest implements IFilteredContest {
 			}
 			case AWARD: {
 				IAward award = (IAward) obj;
-				if (!resolving) {
+				if (!resolved.contains(award)) {
 					if (award.getAwardType() != IAward.FIRST_TO_SOLVE)
 						return;
 
@@ -244,8 +244,12 @@ public class PublicContest extends Contest implements IFilteredContest {
 		freeze.clear();
 	}
 
-	public void setResolving(boolean resolving) {
-		this.resolving = resolving;
+	public static void setResolved(IContestObject obj) {
+		resolved.add(obj);
+	}
+
+	public static List<IContestObject> getResolved() {
+		return resolved;
 	}
 
 	/**


### PR DESCRIPTION
The resolver event feed was set to work on the public contest, but events weren't showing up on other account types (e.g. spectator or team). Also, we weren't keeping track of what has been resolved so if someone hadn't been logged in at all and then logs in part-way through the resolution they would have missed events.

Solved both issues by using a global resolved list to keep track of which objects have been allowed after the freeze.

There's probably some reverse-sharing that could be done with the frozen list, but that's a bigger job for later.